### PR TITLE
fix: issue with p tag in xml

### DIFF
--- a/lib/lutaml/model/xml_adapter/nokogiri_adapter.rb
+++ b/lib/lutaml/model/xml_adapter/nokogiri_adapter.rb
@@ -52,7 +52,7 @@ module Lutaml
                            xml
                          end
 
-          prefixed_xml.send(xml_mapping.root_element, attributes) do
+          prefixed_xml.public_send(xml_mapping.root_element, attributes) do
             xml_mapping.elements.each do |element_rule|
               if element_rule.delegate
                 attribute_def =
@@ -84,13 +84,13 @@ module Lutaml
                 if v && (attribute_def&.type&.<= Lutaml::Model::Serialize)
                   handle_nested_elements(xml, element_rule, v)
                 else
-                  nsp_xml.send(element_rule.name) do
+                  nsp_xml.public_send(element_rule.name) do
                     if !v.nil?
                       serialized_value = attribute_def.type.serialize(v)
 
                       if attribute_def.type == Lutaml::Model::Type::Hash
                         serialized_value.each do |key, val|
-                          xml.send(key) { xml.text val }
+                          xml.public_send(key) { xml.text val }
                         end
                       else
                         xml.text(serialized_value)

--- a/spec/lutaml/model/xml_mapping_spec.rb
+++ b/spec/lutaml/model/xml_mapping_spec.rb
@@ -13,6 +13,17 @@ class Italic < Lutaml::Model::Serializable
   end
 end
 
+# Define a sample class for testing p tag
+class Paragraph < Lutaml::Model::Serializable
+  attribute :text, Lutaml::Model::Type::String
+
+  xml do
+    root "p"
+
+    map_content to: :text
+  end
+end
+
 RSpec.describe Lutaml::Model::XmlMapping do
   let(:mapping) { described_class.new }
 
@@ -108,6 +119,26 @@ RSpec.describe Lutaml::Model::XmlMapping do
 
     it "parses the textual content of an XML element" do
       expect(italic.text).to eq(["my text ", " is in italics"])
+    end
+  end
+
+  context "with p object" do
+    describe "convert from xml containing p tag" do
+      let(:xml_data) { "<p>my text for paragraph</p>" }
+      let(:paragraph) { Paragraph.from_xml(xml_data) }
+
+      it "parses the textual content of an XML element" do
+        expect(paragraph.text).to eq("my text for paragraph")
+      end
+    end
+
+    describe "generate xml with p tag" do
+      let(:paragraph) { Paragraph.new(text: "my text for paragraph") }
+      let(:expected_xml) { "<p>my text for paragraph</p>" }
+
+      it "converts to xml correctly" do
+        expect(paragraph.to_xml).to eq(expected_xml)
+      end
     end
   end
 end


### PR DESCRIPTION
`p` is a private method in `Object` class, it was getting used when using `send` in [nokogiri_adaptar.rb:55](https://github.com/lutaml/lutaml-model/blob/main/lib/lutaml/model/xml_adapter/nokogiri_adapter.rb#L55) and instead of adding a `p` tag to `output xml` it was just printing the parameters.
Converted that to `public_send` and added a test case for that.