### PR TITLE
feat: using model instead of hash in conversion

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1338,11 +1338,11 @@ class CustomCeramic < Lutaml::Model::Serializable
   end
 
   def name_to_json(model, value)
-    "Masterpiece: #{value}"
+    doc["name"] = "Masterpiece: #{value}"
   end
 
   def name_from_json(model, doc)
-    doc['name'].sub(/^Masterpiece: /, '')
+    model.name = value.sub(/^JSON Masterpiece: /, '')
   end
 end
 ----
@@ -1972,52 +1972,56 @@ class Example < Lutaml::Model::Serializable
                         from: :description_from_xml }
   end
 
-  def name_to_json(_model, value)
-    "JSON Masterpiece: #{value}"
+  def name_to_json(model, doc)
+    doc["name"] = "JSON Masterpiece: #{model.name}"
   end
 
-  def name_from_json(_model, doc)
-    doc["name"].sub(/^JSON Masterpiece: /, "")
+  def name_from_json(model, value)
+    model.name = value.sub(/^JSON Masterpiece: /, "")
   end
 
-  def color_to_json(_model, value)
-    value.upcase
+  def color_to_json(model, doc)
+    doc["color"] = model.color.upcase
   end
 
-  def color_from_json(_model, doc)
-    doc["color"].downcase
+  def color_from_json(model, value)
+    model.color = value.downcase
   end
 
-  def description_to_json(_model, value)
-    "JSON Description: #{value}"
+  def description_to_json(model, doc)
+    doc["description"] = "JSON Description: #{model.description}"
   end
 
-  def description_from_json(_model, doc)
-    doc["description"].sub(/^JSON Description: /, "")
+  def description_from_json(model, value)
+    model.description = value.sub(/^JSON Description: /, "")
   end
 
-  def name_to_xml(_model, value)
-    "XML Masterpiece: #{value}"
+  def name_to_xml(model, parent, doc)
+    el = doc.create_element("Name")
+    doc.add_text(el, "XML Masterpiece: #{model.name}")
+    doc.add_element(parent, el)
   end
 
-  def name_from_xml(_model, value)
-    value.sub(/^XML Masterpiece: /, "")
+  def name_from_xml(model, value)
+    model.name = value.sub(/^XML Masterpiece: /, "")
   end
 
-  def color_to_xml(_model, value)
-    value.upcase
+  def color_to_xml(model, parent, doc)
+    color_element = doc.create_element("Color")
+    doc.add_text(color_element, model.color.upcase)
+    doc.add_element(parent, color_element)
   end
 
-  def color_from_xml(_model, value)
-    value.downcase
+  def color_from_xml(model, value)
+    model.color = value.downcase
   end
 
-  def description_to_xml(_model, value)
-    "XML Description: #{value}"
+  def description_to_xml(model, parent, doc)
+    doc.add_text(parent, "XML Description: #{model.description}")
   end
 
-  def description_from_xml(_model, value)
-    value.sub(/^XML Description: /, "")
+  def description_from_xml(model, value)
+    model.description = value.join.strip.sub(/^XML Description: /, "")
   end
 end
 ----

--- a/lib/lutaml/model/attribute.rb
+++ b/lib/lutaml/model/attribute.rb
@@ -40,6 +40,35 @@ module Lutaml
       def render_nil?
         options.fetch(:render_nil, false)
       end
+
+      def serialize(value, format, options = {})
+        if value.is_a?(Array)
+          value.map do |v|
+            serialize(v, format, options)
+          end
+        elsif type <= Serialize
+          type.hash_representation(value, format, options)
+        else
+          type.serialize(value)
+        end
+      end
+
+      def cast(value, format, options = {})
+        value ||= [] if collection?
+        instance = options[:instance]
+
+        if value.is_a?(Array)
+          value.map do |v|
+            cast(v, format, instance: instance)
+          end
+        elsif type <= Serialize
+          instance ||= type.model.new
+          type.apply_mappings(value, format, instance, options)
+          instance
+        else
+          Lutaml::Model::Type.cast(value, type)
+        end
+      end
     end
   end
 end

--- a/lib/lutaml/model/attribute.rb
+++ b/lib/lutaml/model/attribute.rb
@@ -62,9 +62,7 @@ module Lutaml
             cast(v, format, instance: instance)
           end
         elsif type <= Serialize
-          instance ||= type.model.new
-          type.apply_mappings(value, format, instance, options)
-          instance
+          type.apply_mappings(value, format, options)
         else
           Lutaml::Model::Type.cast(value, type)
         end

--- a/lib/lutaml/model/serialize.rb
+++ b/lib/lutaml/model/serialize.rb
@@ -126,7 +126,6 @@ module Lutaml
 
             attribute = attributes[name]
 
-            # require "pry"; binding.pry
             hash[rule.from] = if rule.child_mappings
                                 generate_hash_from_child_mappings(value, rule.child_mappings)
                               else

--- a/lib/lutaml/model/serialize.rb
+++ b/lib/lutaml/model/serialize.rb
@@ -88,11 +88,8 @@ module Lutaml
 
             instance = model.new
 
-            # mapped_attrs = apply_mappings(doc.to_h, format, instance)
             apply_mappings(doc.to_h, format, instance)
 
-            # apply_content_mapping(doc, mapped_attrs) if format == :xml
-            # generate_model_object(self, mapped_attrs)
             instance
           end
 
@@ -124,83 +121,39 @@ module Lutaml
             name = rule.to
             next if except&.include?(name) || (only && !only.include?(name))
 
-            next handle_delegate(instance, rule, hash) if rule.delegate
+            next handle_delegate(instance, rule, hash, format) if rule.delegate
+            next instance.send(rule.custom_methods[:to], instance, hash) if rule.custom_methods[:to]
 
-            value = if rule.custom_methods[:to]
-                      instance.send(rule.custom_methods[:to], instance, hash)
-                      next
-                    else
-                      instance.send(name)
-                    end
+            value = instance.send(name)
 
             next if value.nil? && !rule.render_nil
 
             attribute = attributes[name]
 
+            # require "pry"; binding.pry
             hash[rule.from] = if rule.child_mappings
                                 generate_hash_from_child_mappings(value, rule.child_mappings)
-                              elsif value.is_a?(Array)
-                                value.map do |v|
-                                  if attribute.type <= Serialize
-                                    attribute.type.hash_representation(v, format, options)
-                                  else
-                                    attribute.type.serialize(v)
-                                  end
-                                end
-                              elsif attribute.type <= Serialize
-                                attribute.type.hash_representation(value, format, options)
                               else
-                                attribute.type.serialize(value)
+                                attribute.serialize(value, format, options)
                               end
           end
         end
 
-        def handle_delegate(instance, rule, hash)
+        def handle_delegate(instance, rule, hash, format)
           name = rule.to
           value = instance.send(rule.delegate).send(name)
           return if value.nil? && !rule.render_nil
 
           attribute = instance.send(rule.delegate).class.attributes[name]
-          hash[rule.from] = case value
-                            when Array
-                              value.map do |v|
-                                if v.is_a?(Serialize)
-                                  hash_representation(v, format, options)
-                                else
-                                  attribute.type.serialize(v)
-                                end
-                              end
-                            else
-                              if value.is_a?(Serialize)
-                                hash_representation(value, format, options)
-                              else
-                                attribute.type.serialize(value)
-                              end
-                            end
+          hash[rule.from] = attribute.serialize(value, format)
         end
 
         def mappings_for(format)
           mappings[format] || default_mappings(format)
         end
 
-        def generate_model_object(type, mapped_attrs)
-          return type.model.new(mapped_attrs) if self == model
-
-          instance = type.model.new
-
-          type.attributes.each do |name, attr|
-            value = attr_value(mapped_attrs, name, attr)
-
-            instance.send(:"#{name}=", ensure_utf8(value))
-          end
-
-          instance
-        end
-
         def attr_value(attrs, name, attr_rule)
-          value = if attrs.key?(name)
-                    attrs[name]
-                  elsif attrs.key?(name.to_sym)
+          value = if attrs.key?(name.to_sym)
                     attrs[name.to_sym]
                   elsif attrs.key?(name.to_s)
                     attrs[name.to_s]
@@ -218,8 +171,6 @@ module Lutaml
                 Lutaml::Model::Type.cast(v, attr_rule.type)
               end
             end
-          elsif value.is_a?(Hash) && attr_rule.type != Lutaml::Model::Type::Hash
-            generate_model_object(attr_rule.type, value)
           else
             # TODO: This code is problematic because Type.cast does not know
             # about all the types.
@@ -286,11 +237,11 @@ module Lutaml
           hash
         end
 
-        def apply_mappings(doc, format, instance)
-          return apply_xml_mapping(doc, instance) if format == :xml
+        def apply_mappings(doc, format, instance, options = {})
+          return apply_xml_mapping(doc, instance, options) if format == :xml
 
           mappings = mappings_for(format).mappings
-          mappings.each_with_object(Lutaml::Model::MappingHash.new) do |rule, hash|
+          mappings.each do |rule|
             attr = if rule.delegate
                      attributes[rule.delegate].type.attributes[rule.to]
                    else
@@ -311,37 +262,20 @@ module Lutaml
             end
 
             value = apply_child_mappings(value, rule.child_mappings)
-
-            if attr.collection?
-              value = (value || []).map do |v|
-                child_instance = attr.type.model.new
-                attr.type <= Serialize ? attr.type.apply_mappings(v, format, child_instance) : Lutaml::Model::Type.cast(v, attr.type)
-                child_instance
-              end
-            elsif value.is_a?(Hash) && attr.type != Lutaml::Model::Type::Hash
-              child_instance = attr.type.model.new
-              attr.type.apply_mappings(value, format, child_instance)
-              value = child_instance
-            else
-              value = Lutaml::Model::Type.cast(value, attr.type)
-            end
+            value = attr.cast(value, format)
 
             if rule.delegate
-              hash[rule.delegate] ||= {}
-              hash[rule.delegate][rule.to] = value
-
               if instance.public_send(rule.delegate).nil?
                 instance.public_send(:"#{rule.delegate}=", attributes[rule.delegate].type.new)
               end
               instance.public_send(rule.delegate).public_send("#{rule.to}=", value)
             else
-              hash[rule.to] = value
               instance.public_send("#{rule.to}=", value)
             end
           end
         end
 
-        def apply_xml_mapping(doc, instance, caller_class: nil, mixed_content: false)
+        def apply_xml_mapping(doc, instance, options = {})
           return unless doc
 
           mappings = mappings_for(:xml).mappings
@@ -351,18 +285,15 @@ module Lutaml
                   "missing for #{self} in #{caller_class}"
           end
 
-          mapping_hash = Lutaml::Model::MappingHash.new
-          mapping_hash.item_order = doc.item_order
-          mapping_hash.ordered = mappings_for(:xml).mixed_content? || mixed_content
+          caller_class = options[:caller_class]
+          mixed_content = options[:mixed_content]
 
           if instance.respond_to?(:ordered=)
-            instance.ordered = mapping_hash.ordered
-            instance.element_order = mapping_hash.item_order
+            instance.element_order = doc.item_order
+            instance.ordered = mappings_for(:xml).mixed_content? || mixed_content
           end
 
-          mapping_from = []
-
-          mappings.each_with_object(mapping_hash) do |rule, hash|
+          mappings.each do |rule|
             attr = attributes[rule.to]
             raise "Attribute '#{rule.to}' not found in #{self}" unless attr
 
@@ -373,52 +304,33 @@ module Lutaml
                       doc[rule.name.to_s] || doc[rule.name.to_sym]
                     end
 
-            if attr.collection?
-              if value && !value.is_a?(Array)
-                value = [value]
-              end
-
-              value = (value || []).map do |v|
-                if attr.type <= Serialize
-                  child_instance = attr.type.model.new
-                  attr.type.apply_xml_mapping(v, child_instance, caller_class: self, mixed_content: rule.mixed_content)
-                  child_instance
-                elsif v.is_a?(Hash)
-                  Lutaml::Model::Type.cast(v["text"], attr.type)
+            if value.is_a?(Array)
+              value = value.map do |v|
+                if v.is_a?(Hash) && !(attr.type <= Serialize)
+                  v["text"]
                 else
-                  Lutaml::Model::Type.cast(v, attr.type)
+                  v
                 end
               end
-            elsif attr.type <= Serialize
-              child_instance = attr.type.model.new
-              attr.type.apply_xml_mapping(value, child_instance, caller_class: self, mixed_content: rule.mixed_content)
-              value = child_instance
-            else
-              if value.is_a?(Hash) && attr.type != Lutaml::Model::Type::Hash
-                value = value["text"]
-              end
-
-              value = attr.type.cast(value) unless is_content_mapping
+            elsif !(attr.type <= Serialize) && value.is_a?(Hash) && attr.type != Lutaml::Model::Type::Hash
+              value = value["text"]
             end
 
-            mapping_from << rule if rule.custom_methods[:from]
+            unless is_content_mapping
+              value = attr.cast(
+                value,
+                :xml,
+                caller_class: self,
+                mixed_content: rule.mixed_content,
+              )
+            end
 
-            instance.public_send("#{rule.to}=", value)
-            hash[rule.to] = value
+            if rule.custom_methods[:from]
+              new.send(rule.custom_methods[:from], instance, value)
+            else
+              instance.public_send("#{rule.to}=", value)
+            end
           end
-
-          mapping_from.each do |rule|
-            value = if rule.name.nil?
-                      mapping_hash[rule.to].join("\n").strip
-                    else
-                      mapping_hash[rule.to]
-                    end
-
-            new.send(rule.custom_methods[:from], instance, value)
-            mapping_hash[rule.to] = value
-          end
-
-          mapping_hash
         end
 
         def ensure_utf8(value)

--- a/lib/lutaml/model/xml_adapter/builder/nokogiri.rb
+++ b/lib/lutaml/model/xml_adapter/builder/nokogiri.rb
@@ -1,0 +1,73 @@
+module Lutaml
+  module Model
+    module XmlAdapter
+      module Builder
+        class Nokogiri
+          def self.build(options = {})
+            if block_given?
+              ::Nokogiri::XML::Builder.new(options) do |xml|
+                yield(new(xml))
+              end
+            else
+              new(::Nokogiri::XML::Builder.new(options))
+            end
+          end
+
+          attr_reader :xml
+
+          def initialize(xml)
+            @xml = xml
+          end
+
+          def create_element(name, attributes = {})
+            xml.doc.create_element(name, attributes)
+          end
+
+          def add_element(element, child)
+            element.add_child(child)
+          end
+
+          def create_and_add_element(element_name, prefix: nil, attributes: {})
+            add_namespace_prefix(prefix) if prefix
+
+            if block_given?
+              public_send(element_name, attributes) do
+                yield(self)
+              end
+            else
+              public_send(element_name, attributes)
+            end
+          end
+
+          def add_text(element, text)
+            if element.is_a?(self.class)
+              element = element.xml.parent
+            end
+
+            add_element(element, ::Nokogiri::XML::Text.new(text.to_s, xml.doc))
+          end
+
+          def add_namespace_prefix(prefix)
+            xml[prefix] if prefix
+
+            self
+          end
+
+          def method_missing(method_name, *args)
+            if block_given?
+              xml.public_send(method_name, *args) do
+                yield(xml)
+              end
+            else
+              xml.public_send(method_name, *args)
+            end
+          end
+
+          def respond_to_missing?(method_name, include_private = false)
+            xml.respond_to?(method_name) || super
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/lutaml/model/xml_adapter/builder/ox.rb
+++ b/lib/lutaml/model/xml_adapter/builder/ox.rb
@@ -1,0 +1,89 @@
+module Lutaml
+  module Model
+    module XmlAdapter
+      module Builder
+        class Ox
+          def self.build(options = {})
+            if block_given?
+              ::Ox::Builder.new(options) do |xml|
+                yield(new(xml))
+              end
+            else
+              new(::Ox::Builder.new(options))
+            end
+          end
+
+          attr_reader :xml
+
+          def initialize(xml)
+            @xml = xml
+          end
+
+          def create_element(name, attributes = {})
+            if block_given?
+              xml.element(name, attributes) do |element|
+                yield(self.class.new(element))
+              end
+            else
+              xml.element(name, attributes)
+            end
+          end
+
+          def add_element(element, child)
+            element << child
+          end
+
+          def create_and_add_element(element_name, prefix: nil, attributes: {})
+            prefixed_name = if prefix
+                              "#{prefix}:#{element_name}"
+                            else
+                              element_name
+                            end
+
+            if block_given?
+              xml.element(prefixed_name, attributes) do |element|
+                yield(self.class.new(element))
+              end
+            else
+              xml.element(prefixed_name, attributes)
+            end
+          end
+
+          def <<(text)
+            xml.text(text)
+          end
+
+          def add_text(element, text)
+            element << text
+          end
+
+          # Add XML namespace to document
+          #
+          # Ox doesn't support XML namespaces so this method does nothing.
+          def add_namespace_prefix(_prefix)
+            # :noop:
+            self
+          end
+
+          def parent
+            xml
+          end
+
+          def method_missing(method_name, *args)
+            if block_given?
+              xml.public_send(method_name, *args) do
+                yield(xml)
+              end
+            else
+              xml.public_send(method_name, *args)
+            end
+          end
+
+          def respond_to_missing?(method_name, include_private = false)
+            xml.respond_to?(method_name) || super
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/lutaml/model/xml_adapter/nokogiri_adapter.rb
+++ b/lib/lutaml/model/xml_adapter/nokogiri_adapter.rb
@@ -129,7 +129,6 @@ module Lutaml
 
               attribute_def = attribute_definition_for(element, element_rule, mapper_class: mapper_class)
               value = attribute_value_for(element, element_rule)
-              nsp_xml = element_rule.prefix ? xml[element_rule.prefix] : xml
 
               if element_rule == xml_mapping.content_mapping
                 text = element.send(xml_mapping.content_mapping.to)
@@ -137,44 +136,15 @@ module Lutaml
 
                 prefixed_xml.text text
               elsif attribute_def.collection?
-                add_to_xml_old(
-                  nsp_xml,
+                add_to_xml(
+                  xml,
+                  element_rule.prefix,
                   value[curr_index],
                   attribute_def,
                   element_rule,
                 )
               elsif !value.nil? || element_rule.render_nil?
-                add_to_xml_old(nsp_xml, value, attribute_def, element_rule)
-              end
-            end
-          end
-        end
-
-        def add_to_xml_old(xml, value, attribute, rule)
-          if rule.custom_methods[:to]
-            @root.send(rule.custom_methods[:to], @root, xml.parent, xml)
-            return
-          end
-
-          if value && (attribute&.type&.<= Lutaml::Model::Serialize)
-            handle_nested_elements(
-              xml,
-              value,
-              rule: rule,
-              attribute: attribute,
-            )
-          else
-            xml.public_send(rule.name) do
-              if !value.nil?
-                serialized_value = attribute.type.serialize(value)
-
-                if attribute.type == Lutaml::Model::Type::Hash
-                  serialized_value.each do |key, val|
-                    xml.public_send(key) { xml.text val }
-                  end
-                else
-                  xml.text(serialized_value)
-                end
+                add_to_xml(xml, element_rule.prefix, value, attribute_def, element_rule)
               end
             end
           end

--- a/lib/lutaml/model/xml_adapter/nokogiri_adapter.rb
+++ b/lib/lutaml/model/xml_adapter/nokogiri_adapter.rb
@@ -64,6 +64,10 @@ module Lutaml
             xml.public_send(method_name, *args)
           end
         end
+
+        def respond_to_missing?(method_name, include_private = false)
+          xml.respond_to?(method_name) || super
+        end
       end
 
       class NokogiriAdapter < XmlDocument
@@ -133,8 +137,12 @@ module Lutaml
 
                 prefixed_xml.text text
               elsif attribute_def.collection?
-                add_to_xml_old(nsp_xml, value[curr_index], attribute_def,
-                           element_rule)
+                add_to_xml_old(
+                  nsp_xml,
+                  value[curr_index],
+                  attribute_def,
+                  element_rule,
+                )
               elsif !value.nil? || element_rule.render_nil?
                 add_to_xml_old(nsp_xml, value, attribute_def, element_rule)
               end

--- a/lib/lutaml/model/xml_adapter/ox_adapter.rb
+++ b/lib/lutaml/model/xml_adapter/ox_adapter.rb
@@ -136,38 +136,9 @@ module Lutaml
 
                 el.add_text(el, text)
               elsif attribute_def.collection?
-                add_to_xml_old(el, value[curr_index], attribute_def, element_rule)
+                add_to_xml(el, nil, value[curr_index], attribute_def, element_rule)
               elsif !value.nil? || element_rule.render_nil?
-                add_to_xml_old(el, value, attribute_def, element_rule)
-              end
-            end
-          end
-        end
-
-        def add_to_xml_old(xml, value, attribute, rule)
-          if rule.custom_methods[:to]
-            value = @root.send(rule.custom_methods[:to], @root, value)
-          end
-
-          if value && (attribute&.type&.<= Lutaml::Model::Serialize)
-            handle_nested_elements(
-              xml,
-              value,
-              rule: rule,
-              attribute: attribute,
-            )
-          else
-            xml.create_element(rule.name) do |el|
-              if !value.nil?
-                serialized_value = attribute.type.serialize(value)
-
-                if attribute.type == Lutaml::Model::Type::Hash
-                  serialized_value.each do |key, val|
-                    el.element(key) { |child_el| child_el.text val }
-                  end
-                else
-                  el.add_text(el, serialized_value)
-                end
+                add_to_xml(el, nil, value, attribute_def, element_rule)
               end
             end
           end

--- a/lib/lutaml/model/xml_adapter/ox_adapter.rb
+++ b/lib/lutaml/model/xml_adapter/ox_adapter.rb
@@ -62,7 +62,7 @@ module Lutaml
         # Add XML namespace to document
         #
         # Ox doesn't support XML namespaces so this method does nothing.
-        def add_namespace_prefix(prefix)
+        def add_namespace_prefix(_prefix)
           # :noop:
           self
         end
@@ -79,6 +79,10 @@ module Lutaml
           else
             xml.public_send(method_name, *args)
           end
+        end
+
+        def respond_to_missing?(method_name, include_private = false)
+          xml.respond_to?(method_name) || super
         end
       end
 
@@ -153,7 +157,7 @@ module Lutaml
               attribute: attribute,
             )
           else
-            element = xml.create_element(rule.name) do |el|
+            xml.create_element(rule.name) do |el|
               if !value.nil?
                 serialized_value = attribute.type.serialize(value)
 

--- a/lib/lutaml/model/xml_adapter/ox_adapter.rb
+++ b/lib/lutaml/model/xml_adapter/ox_adapter.rb
@@ -71,15 +71,15 @@ module Lutaml
           xml
         end
 
-        # def method_missing(method_name, *args)
-        #   if block_given?
-        #     xml.public_send(method_name, *args) do
-        #       yield(xml)
-        #     end
-        #   else
-        #     xml.public_send(method_name, *args)
-        #   end
-        # end
+        def method_missing(method_name, *args)
+          if block_given?
+            xml.public_send(method_name, *args) do
+              yield(xml)
+            end
+          else
+            xml.public_send(method_name, *args)
+          end
+        end
       end
 
       class OxAdapter < XmlDocument

--- a/lib/lutaml/model/xml_adapter/ox_adapter.rb
+++ b/lib/lutaml/model/xml_adapter/ox_adapter.rb
@@ -4,6 +4,84 @@ require_relative "xml_document"
 module Lutaml
   module Model
     module XmlAdapter
+      class OxXmlBuilder
+        def self.build(options = {})
+          if block_given?
+            Ox::Builder.new(options) do |xml|
+              yield(new(xml))
+            end
+          else
+            new(Ox::Builder.new(options))
+          end
+        end
+
+        attr_reader :xml
+
+        def initialize(xml)
+          @xml = xml
+        end
+
+        def create_element(name, attributes = {})
+          if block_given?
+            xml.element(name, attributes) do |element|
+              yield(OxXmlBuilder.new(element))
+            end
+          else
+            xml.element(name, attributes)
+          end
+        end
+
+        def add_element(element, child)
+          element << child
+        end
+
+        def create_and_add_element(element_name, prefix: nil, attributes: {})
+          prefixed_name = if prefix
+                            "#{prefix}:#{element_name}"
+                          else
+                            element_name
+                          end
+
+          if block_given?
+            xml.element(prefixed_name, attributes) do |element|
+              yield(OxXmlBuilder.new(element))
+            end
+          else
+            xml.element(prefixed_name, attributes)
+          end
+        end
+
+        def <<(text)
+          xml.text(text)
+        end
+
+        def add_text(element, text)
+          element << text
+        end
+
+        # Add XML namespace to document
+        #
+        # Ox doesn't support XML namespaces so this method does nothing.
+        def add_namespace_prefix(prefix)
+          # :noop:
+          self
+        end
+
+        def parent
+          xml
+        end
+
+        # def method_missing(method_name, *args)
+        #   if block_given?
+        #     xml.public_send(method_name, *args) do
+        #       yield(xml)
+        #     end
+        #   else
+        #     xml.public_send(method_name, *args)
+        #   end
+        # end
+      end
+
       class OxAdapter < XmlDocument
         def self.parse(xml)
           parsed = Ox.parse(xml)
@@ -12,7 +90,7 @@ module Lutaml
         end
 
         def to_xml(options = {})
-          builder = Ox::Builder.new
+          builder = OxXmlBuilder.build
 
           if @root.is_a?(Lutaml::Model::XmlAdapter::OxElement)
             @root.to_xml(builder)
@@ -22,65 +100,11 @@ module Lutaml
             build_element(builder, @root, options)
           end
 
-          # xml_data = Ox.dump(builder)
-          xml_data = builder.to_s
+          xml_data = builder.xml.to_s
           options[:declaration] ? declaration(options) + xml_data : xml_data
         end
 
         private
-
-        def build_unordered_element(builder, element, options = {})
-          mapper_class = options[:mapper_class] || element.class
-          xml_mapping = mapper_class.mappings_for(:xml)
-          return xml unless xml_mapping
-
-          attributes = build_attributes(element, xml_mapping).compact
-
-          tag_name = options[:tag_name] || xml_mapping.root_element
-          prefixed_name = if options.key?(:namespace_prefix)
-                            [options[:namespace_prefix], tag_name].compact.join(":")
-                          elsif xml_mapping.namespace_prefix
-                            "#{xml_mapping.namespace_prefix}:#{tag_name}"
-                          else
-                            tag_name
-                          end
-
-          builder.element(prefixed_name, attributes) do |el|
-            xml_mapping.elements.each do |element_rule|
-              attribute_def = attribute_definition_for(element, element_rule, mapper_class: mapper_class)
-              value = attribute_value_for(element, element_rule)
-
-              val = if attribute_def.collection?
-                      value
-                    elsif value || element_rule.render_nil?
-                      [value]
-                    else
-                      []
-                    end
-
-              val.each do |v|
-                if attribute_def&.type&.<= Lutaml::Model::Serialize
-                  handle_nested_elements(el, v, rule: element_rule, attribute: attribute_def)
-                else
-                  builder.element(element_rule.prefixed_name) do |el|
-                    el.text(attribute_def.type.serialize(v)) if v
-                  end
-                end
-              end
-            end
-
-            if (content_rule = xml_mapping.content_mapping)
-              text = element.send(xml_mapping.content_mapping.to)
-              text = text.join if text.is_a?(Array)
-
-              if content_rule.custom_methods[:to]
-                text = @root.send(content_rule.custom_methods[:to], @root, text)
-              end
-
-              el.text text
-            end
-          end
-        end
 
         def build_ordered_element(builder, element, options = {})
           mapper_class = options[:mapper_class] || element.class
@@ -90,7 +114,7 @@ module Lutaml
           attributes = build_attributes(element, xml_mapping).compact
 
           tag_name = options[:tag_name] || xml_mapping.root_element
-          builder.element(tag_name, attributes) do |el|
+          builder.create_and_add_element(tag_name, attributes: attributes) do |el|
             index_hash = {}
 
             element.element_order.each do |name|
@@ -106,17 +130,17 @@ module Lutaml
                 text = element.send(xml_mapping.content_mapping.to)
                 text = text[curr_index] if text.is_a?(Array)
 
-                el.text text
+                el.add_text(el, text)
               elsif attribute_def.collection?
-                add_to_xml(el, value[curr_index], attribute_def, element_rule)
+                add_to_xml_old(el, value[curr_index], attribute_def, element_rule)
               elsif !value.nil? || element_rule.render_nil?
-                add_to_xml(el, value, attribute_def, element_rule)
+                add_to_xml_old(el, value, attribute_def, element_rule)
               end
             end
           end
         end
 
-        def add_to_xml(xml, value, attribute, rule)
+        def add_to_xml_old(xml, value, attribute, rule)
           if rule.custom_methods[:to]
             value = @root.send(rule.custom_methods[:to], @root, value)
           end
@@ -129,7 +153,7 @@ module Lutaml
               attribute: attribute,
             )
           else
-            xml.element(rule.name) do |el|
+            element = xml.create_element(rule.name) do |el|
               if !value.nil?
                 serialized_value = attribute.type.serialize(value)
 
@@ -138,7 +162,7 @@ module Lutaml
                     el.element(key) { |child_el| child_el.text val }
                   end
                 else
-                  el.text(serialized_value)
+                  el.add_text(el, serialized_value)
                 end
               end
             end
@@ -188,13 +212,13 @@ module Lutaml
         end
 
         def to_xml(builder = nil)
-          builder ||= Ox::Builder.new
+          builder ||= OxXmlBuilder.build
           attrs = build_attributes(self)
 
           if text?
-            builder.text(text)
+            builder.add_text(builder, text)
           else
-            builder.element(name, attrs) do |el|
+            builder.create_and_add_element(name, attributes: attrs) do |el|
               children.each { |child| child.to_xml(el) }
             end
           end

--- a/lib/lutaml/model/xml_adapter/ox_adapter.rb
+++ b/lib/lutaml/model/xml_adapter/ox_adapter.rb
@@ -1,91 +1,10 @@
 require "ox"
 require_relative "xml_document"
+require_relative "builder/ox"
 
 module Lutaml
   module Model
     module XmlAdapter
-      class OxXmlBuilder
-        def self.build(options = {})
-          if block_given?
-            Ox::Builder.new(options) do |xml|
-              yield(new(xml))
-            end
-          else
-            new(Ox::Builder.new(options))
-          end
-        end
-
-        attr_reader :xml
-
-        def initialize(xml)
-          @xml = xml
-        end
-
-        def create_element(name, attributes = {})
-          if block_given?
-            xml.element(name, attributes) do |element|
-              yield(OxXmlBuilder.new(element))
-            end
-          else
-            xml.element(name, attributes)
-          end
-        end
-
-        def add_element(element, child)
-          element << child
-        end
-
-        def create_and_add_element(element_name, prefix: nil, attributes: {})
-          prefixed_name = if prefix
-                            "#{prefix}:#{element_name}"
-                          else
-                            element_name
-                          end
-
-          if block_given?
-            xml.element(prefixed_name, attributes) do |element|
-              yield(OxXmlBuilder.new(element))
-            end
-          else
-            xml.element(prefixed_name, attributes)
-          end
-        end
-
-        def <<(text)
-          xml.text(text)
-        end
-
-        def add_text(element, text)
-          element << text
-        end
-
-        # Add XML namespace to document
-        #
-        # Ox doesn't support XML namespaces so this method does nothing.
-        def add_namespace_prefix(_prefix)
-          # :noop:
-          self
-        end
-
-        def parent
-          xml
-        end
-
-        def method_missing(method_name, *args)
-          if block_given?
-            xml.public_send(method_name, *args) do
-              yield(xml)
-            end
-          else
-            xml.public_send(method_name, *args)
-          end
-        end
-
-        def respond_to_missing?(method_name, include_private = false)
-          xml.respond_to?(method_name) || super
-        end
-      end
-
       class OxAdapter < XmlDocument
         def self.parse(xml)
           parsed = Ox.parse(xml)
@@ -94,7 +13,7 @@ module Lutaml
         end
 
         def to_xml(options = {})
-          builder = OxXmlBuilder.build
+          builder = Builder::Ox.build
 
           if @root.is_a?(Lutaml::Model::XmlAdapter::OxElement)
             @root.to_xml(builder)
@@ -187,7 +106,7 @@ module Lutaml
         end
 
         def to_xml(builder = nil)
-          builder ||= OxXmlBuilder.build
+          builder ||= Builder::Ox.build
           attrs = build_attributes(self)
 
           if text?

--- a/lib/lutaml/model/xml_adapter/xml_document.rb
+++ b/lib/lutaml/model/xml_adapter/xml_document.rb
@@ -157,6 +157,8 @@ module Lutaml
               next if value.nil? && !element_rule.render_nil?
 
               if attribute_def.collection?
+                value = [value] unless value.is_a?(Array)
+
                 value.each do |v|
                   add_to_xml(xml, element_rule.prefix, v, attribute_def, element_rule)
                 end

--- a/lib/lutaml/model/yaml_adapter/standard_yaml_adapter.rb
+++ b/lib/lutaml/model/yaml_adapter/standard_yaml_adapter.rb
@@ -16,18 +16,6 @@ module Lutaml
         def to_yaml(options = {})
           YAML.dump(@attributes, options)
         end
-
-        # TODO: Is this really needed?
-        def self.to_yaml(attributes, *args)
-          new(attributes).to_yaml(*args)
-        end
-
-        # TODO: Is this really needed?
-        def self.from_yaml(yaml, klass)
-          data = parse(yaml)
-          mapped_attrs = klass.send(:apply_mappings, data, :yaml)
-          klass.new(mapped_attrs)
-        end
       end
     end
   end

--- a/spec/fixtures/person.rb
+++ b/spec/fixtures/person.rb
@@ -64,11 +64,11 @@ class Person < Lutaml::Model::Serializable
     map "active", to: :active
   end
 
-  def yaml_from_last_name(_model, value)
-    value
+  def yaml_from_last_name(model, doc)
+    doc["lastName"] = model.last_name
   end
 
-  def yaml_to_last_name(_model, doc)
-    doc["lastName"]
+  def yaml_to_last_name(model, value)
+    model.last_name = value
   end
 end

--- a/spec/lutaml/model/custom_serialization_spec.rb
+++ b/spec/lutaml/model/custom_serialization_spec.rb
@@ -28,52 +28,60 @@ class CustomSerialization < Lutaml::Model::Serializable
                         from: :description_from_xml }
   end
 
-  def name_to_json(_model, value)
-    "JSON Masterpiece: #{value}"
+  def name_to_json(model, doc)
+    doc["name"] = "JSON Masterpiece: #{model.name}"
   end
 
-  def name_from_json(_model, doc)
-    doc["name"].sub(/^JSON Masterpiece: /, "")
+  def name_from_json(model, value)
+    model.name = value.sub(/^JSON Masterpiece: /, "")
   end
 
-  def color_to_json(_model, value)
-    value.upcase
+  def color_to_json(model, doc)
+    doc["color"] = model.color.upcase
   end
 
-  def color_from_json(_model, doc)
-    doc["color"].downcase
+  def color_from_json(model, value)
+    model.color = value.downcase
   end
 
-  def description_to_json(_model, value)
-    "JSON Description: #{value}"
+  def description_to_json(model, doc)
+    doc["description"] = "JSON Description: #{model.description}"
   end
 
-  def description_from_json(_model, doc)
-    doc["description"].sub(/^JSON Description: /, "")
+  def description_from_json(model, value)
+    # model.description = doc["description"].sub(/^JSON Description: /, "")
+    model.description = value.sub(/^JSON Description: /, "")
   end
 
-  def name_to_xml(_model, value)
-    "XML Masterpiece: #{value}"
+  def name_to_xml(model, parent, doc)
+    # doc["name"] = "XML Masterpiece: #{model.name}"
+
+    el = doc.create_element('Name')
+    doc.add_text(el, "XML Masterpiece: #{model.name}")
+    doc.add_element(parent, el)
   end
 
-  def name_from_xml(_model, value)
-    value.sub(/^XML Masterpiece: /, "")
+  def name_from_xml(model, value)
+    # value.sub(/^XML Masterpiece: /, "")
+    model.name = value.sub(/^XML Masterpiece: /, "")
   end
 
-  def color_to_xml(_model, value)
-    value.upcase
+  def color_to_xml(model, parent, doc)
+    color_element = doc.create_element("Color")
+    doc.add_text(color_element, model.color.upcase)
+    doc.add_element(parent, color_element)
   end
 
-  def color_from_xml(_model, value)
-    value.downcase
+  def color_from_xml(model, value)
+    model.color = value.downcase
   end
 
-  def description_to_xml(_model, value)
-    "XML Description: #{value}"
+  def description_to_xml(model, parent, doc)
+    doc.add_text(parent, "XML Description: #{model.description}")
   end
 
-  def description_from_xml(_model, value)
-    value.sub(/^XML Description: /, "")
+  def description_from_xml(model, value)
+    model.description = value.sub(/^XML Description: /, "")
   end
 end
 

--- a/spec/lutaml/model/custom_serialization_spec.rb
+++ b/spec/lutaml/model/custom_serialization_spec.rb
@@ -81,7 +81,7 @@ class CustomSerialization < Lutaml::Model::Serializable
   end
 
   def description_from_xml(model, value)
-    model.description = value.sub(/^XML Description: /, "")
+    model.description = value.join.strip.sub(/^XML Description: /, "")
   end
 end
 

--- a/spec/lutaml/model/custom_serialization_spec.rb
+++ b/spec/lutaml/model/custom_serialization_spec.rb
@@ -49,7 +49,6 @@ class CustomSerialization < Lutaml::Model::Serializable
   end
 
   def description_from_json(model, value)
-    # model.description = doc["description"].sub(/^JSON Description: /, "")
     model.description = value.sub(/^JSON Description: /, "")
   end
 

--- a/spec/lutaml/model/custom_serialization_spec.rb
+++ b/spec/lutaml/model/custom_serialization_spec.rb
@@ -56,7 +56,7 @@ class CustomSerialization < Lutaml::Model::Serializable
   def name_to_xml(model, parent, doc)
     # doc["name"] = "XML Masterpiece: #{model.name}"
 
-    el = doc.create_element('Name')
+    el = doc.create_element("Name")
     doc.add_text(el, "XML Masterpiece: #{model.name}")
     doc.add_element(parent, el)
   end

--- a/spec/lutaml/model/custom_serialization_spec.rb
+++ b/spec/lutaml/model/custom_serialization_spec.rb
@@ -54,15 +54,12 @@ class CustomSerialization < Lutaml::Model::Serializable
   end
 
   def name_to_xml(model, parent, doc)
-    # doc["name"] = "XML Masterpiece: #{model.name}"
-
     el = doc.create_element("Name")
     doc.add_text(el, "XML Masterpiece: #{model.name}")
     doc.add_element(parent, el)
   end
 
   def name_from_xml(model, value)
-    # value.sub(/^XML Masterpiece: /, "")
     model.name = value.sub(/^XML Masterpiece: /, "")
   end
 

--- a/spec/lutaml/model/yaml_adapter_spec.rb
+++ b/spec/lutaml/model/yaml_adapter_spec.rb
@@ -13,17 +13,15 @@ RSpec.shared_examples "a YAML adapter" do |adapter_class|
   end
 
   it "serializes to YAML" do
-    yaml = described_class.to_yaml(
-      model.class.hash_representation(model, :yaml),
-    )
+    yaml = adapter_class.new(attributes).to_yaml
 
     expect(yaml).to eq(expected_yaml)
   end
 
   it "deserializes from YAML" do
-    new_model = described_class.from_yaml(expected_yaml, SampleModel)
-    expect(new_model.name).to eq("John Doe")
-    expect(new_model.age).to eq(30)
+    new_model = adapter_class.parse(expected_yaml)
+    expect(new_model["name"]).to eq("John Doe")
+    expect(new_model["age"]).to eq(30)
   end
 end
 


### PR DESCRIPTION
Now we are using models in between conversions instead of the intermediary hash.

For #51