### PR TITLE
do not override parent mapping when inheriting

### DIFF
--- a/lib/lutaml/model/serialize.rb
+++ b/lib/lutaml/model/serialize.rb
@@ -85,7 +85,7 @@ module Lutaml
         Lutaml::Model::Config::AVAILABLE_FORMATS.each do |format|
           define_method(format) do |&block|
             klass = format == :xml ? XmlMapping : KeyValueMapping
-            mappings[format] = klass.new
+            mappings[format] ||= klass.new
             mappings[format].instance_eval(&block)
 
             if format == :xml && !mappings[format].root_element

--- a/spec/lutaml/model/delegation_spec.rb
+++ b/spec/lutaml/model/delegation_spec.rb
@@ -145,55 +145,6 @@ RSpec.describe Delegation do
     expect(xml_data).to include('<?xml version="1.0" encoding="ASCII"?>')
   end
 
-  it "sets the default namespace of <delegation>" do
-    Delegation::Ceramic.class_eval do
-      xml do
-        root "delegation"
-        namespace "https://example.com/delegation/1.2"
-        map_element "type", to: :type
-        map_element "color", to: :color, delegate: :glaze
-        map_element "finish", to: :finish, delegate: :glaze
-      end
-    end
-
-    delegation_class = Delegation::Ceramic
-    delegation = delegation_class.from_yaml(yaml_data)
-    xml_data = delegation.to_xml(
-      pretty: true,
-      declaration: true,
-      encoding: "UTF-8",
-    )
-    expect(xml_data).to(
-      include('<delegation xmlns="https://example.com/delegation/1.2">'),
-    )
-  end
-
-  it "sets the namespace of <delegation> with a prefix" do
-    Delegation::Ceramic.class_eval do
-      xml do
-        root "delegation"
-        namespace "https://example.com/delegation/1.2", "del"
-        map_element "type", to: :type
-        map_element "color", to: :color, delegate: :glaze
-        map_element "finish", to: :finish, delegate: :glaze
-      end
-    end
-
-    delegation_class = Delegation::Ceramic
-    delegation = delegation_class.from_yaml(yaml_data)
-    xml_data = delegation.to_xml(
-      pretty: true,
-      declaration: true,
-      encoding: "UTF-8",
-    )
-
-    expect(xml_data).to(
-      include(
-        '<del:delegation xmlns:del="https://example.com/delegation/1.2">',
-      ),
-    )
-  end
-
   it "sets the namespace of a particular element inside Ceramic" do
     Delegation::Ceramic.class_eval do
       xml do
@@ -217,32 +168,6 @@ RSpec.describe Delegation do
     )
     expect(xml_data).to include('<delegation xmlns:type="https://example.com/type/1.2">')
     expect(xml_data).to include("<type:type>Vase</type:type>")
-  end
-
-  it "sets the namespace of <delegation> and also" \
-     "a particular element inside using :inherit" do
-    Delegation::Ceramic.class_eval do
-      xml do
-        root "delegation"
-        namespace "https://example.com/delegation/1.2", "del"
-        map_element "type", to: :type # , namespace: :inherit
-        map_element "color", to: :color, delegate: :glaze
-        map_element "finish", to: :finish, delegate: :glaze
-      end
-    end
-
-    delegation_class = Delegation::Ceramic
-    delegation = delegation_class.from_yaml(yaml_data)
-    xml_data = delegation.to_xml(
-      pretty: true,
-      declaration: true,
-      encoding: "UTF-8",
-    )
-
-    delegation_attribute = 'xmlns:del="https://example.com/delegation/1.2">'
-
-    expect(xml_data).to include("<del:delegation #{delegation_attribute}")
-    expect(xml_data).to include("<del:type>Vase</del:type>")
   end
 
   it "sets the namespace of a particular attribute inside <delegation>" do
@@ -283,6 +208,81 @@ RSpec.describe Delegation do
     ]
 
     expect(xml_data).to include("<delegation #{delegation_attributes.join(' ')}>")
+  end
+
+  it "sets the default namespace of <delegation>" do
+    Delegation::Ceramic.class_eval do
+      xml do
+        root "delegation"
+        namespace "https://example.com/delegation/1.2"
+        map_element "type", to: :type
+        map_element "color", to: :color, delegate: :glaze
+        map_element "finish", to: :finish, delegate: :glaze
+      end
+    end
+
+    delegation_class = Delegation::Ceramic
+    delegation = delegation_class.from_yaml(yaml_data)
+    xml_data = delegation.to_xml(
+      pretty: true,
+      declaration: true,
+      encoding: "UTF-8",
+    )
+    expect(xml_data).to(
+      include('<delegation xmlns="https://example.com/delegation/1.2" xmlns:del="https://example.com/delegation/1.2">'),
+    )
+  end
+
+  it "sets the namespace of <delegation> with a prefix" do
+    Delegation::Ceramic.class_eval do
+      xml do
+        root "delegation"
+        namespace "https://example.com/delegation/1.2", "del"
+        map_element "type", to: :type
+        map_element "color", to: :color, delegate: :glaze
+        map_element "finish", to: :finish, delegate: :glaze
+      end
+    end
+
+    delegation_class = Delegation::Ceramic
+    delegation = delegation_class.from_yaml(yaml_data)
+    xml_data = delegation.to_xml(
+      pretty: true,
+      declaration: true,
+      encoding: "UTF-8",
+    )
+
+    expect(xml_data).to(
+      include(
+        '<del:delegation xmlns:del="https://example.com/delegation/1.2">',
+      ),
+    )
+  end
+
+  it "sets the namespace of <delegation> and also" \
+     "a particular element inside using :inherit" do
+    Delegation::Ceramic.class_eval do
+      xml do
+        root "delegation"
+        namespace "https://example.com/delegation/1.2", "del"
+        map_element "type", to: :type # , namespace: :inherit
+        map_element "color", to: :color, delegate: :glaze
+        map_element "finish", to: :finish, delegate: :glaze
+      end
+    end
+
+    delegation_class = Delegation::Ceramic
+    delegation = delegation_class.from_yaml(yaml_data)
+    xml_data = delegation.to_xml(
+      pretty: true,
+      declaration: true,
+      encoding: "UTF-8",
+    )
+
+    delegation_attribute = 'xmlns:del="https://example.com/delegation/1.2">'
+
+    expect(xml_data).to include("<del:delegation #{delegation_attribute}")
+    expect(xml_data).to include("<del:type>Vase</del:type>")
   end
 
   it "sets the namespace of <delegation> and also" \

--- a/spec/lutaml/model/inheritance_spec.rb
+++ b/spec/lutaml/model/inheritance_spec.rb
@@ -1,30 +1,34 @@
 require "spec_helper"
 require "lutaml/model"
 
-class Parent < Lutaml::Model::Serializable
-  attribute :text, Lutaml::Model::Type::String
-  attribute :id, Lutaml::Model::Type::String
-  attribute :name, Lutaml::Model::Type::String
-end
+module InheritanceSpec
+  class Parent < Lutaml::Model::Serializable
+    attribute :text, Lutaml::Model::Type::String
+    attribute :id, Lutaml::Model::Type::String
+    attribute :name, Lutaml::Model::Type::String
 
-class Child < Parent
-  attribute :age, Lutaml::Model::Type::Integer
+    xml do
+      map_content to: :text
 
-  xml do
-    root "child"
+      map_attribute "id", to: :id
+      map_element "name", to: :name
+    end
+  end
 
-    map_content to: :text
+  class Child < Parent
+    attribute :age, Lutaml::Model::Type::Integer
 
-    map_attribute "id", to: :id
+    xml do
+      root "child"
 
-    map_element "age", to: :age
-    map_element "name", to: :name
+      map_element "age", to: :age
+    end
   end
 end
 
 RSpec.describe "Inheritance" do
   subject(:child_object) do
-    Child.new(
+    InheritanceSpec::Child.new(
       {
         text: "Some text",
         name: "John Doe",
@@ -35,7 +39,7 @@ RSpec.describe "Inheritance" do
   end
 
   let(:expected_xml) do
-    '<child id="foobar"><age>30</age><name>John Doe</name>Some text</child>'
+    '<child id="foobar"><name>John Doe</name><age>30</age>Some text</child>'
   end
 
   it "uses parent attributes" do

--- a/spec/lutaml/model/serializable_spec.rb
+++ b/spec/lutaml/model/serializable_spec.rb
@@ -1,76 +1,78 @@
-class TestModel
-  attr_accessor :name, :age
+module SerializeableSpec
+  class TestModel
+    attr_accessor :name, :age
 
-  def initialize(name: nil, age: nil)
-    @name = name
-    @age = age
+    def initialize(name: nil, age: nil)
+      @name = name
+      @age = age
+    end
   end
-end
 
-class TestModelMapper < Lutaml::Model::Serializable
-  model TestModel
+  class TestModelMapper < Lutaml::Model::Serializable
+    model TestModel
 
-  attribute :name, Lutaml::Model::Type::String
-  attribute :age, Lutaml::Model::Type::String
-end
-
-class TestMapper < Lutaml::Model::Serializable
-  attribute :name, Lutaml::Model::Type::String
-  attribute :age, Lutaml::Model::Type::String
-
-  yaml do
-    map :na, to: :name
-    map :ag, to: :age
+    attribute :name, Lutaml::Model::Type::String
+    attribute :age, Lutaml::Model::Type::String
   end
-end
 
-### XML root mapping
+  class TestMapper < Lutaml::Model::Serializable
+    attribute :name, Lutaml::Model::Type::String
+    attribute :age, Lutaml::Model::Type::String
 
-class RecordDate < Lutaml::Model::Serializable
-  attribute :content, :string
-
-  xml do
-    root "recordDate"
-    map_content to: :content
+    yaml do
+      map :na, to: :name
+      map :ag, to: :age
+    end
   end
-end
 
-class OriginInfo < Lutaml::Model::Serializable
-  attribute :date_issued, RecordDate, collection: true
+  ### XML root mapping
 
-  xml do
-    root "originInfo"
-    map_element "dateIssued", to: :date_issued
+  class RecordDate < Lutaml::Model::Serializable
+    attribute :content, :string
+
+    xml do
+      root "recordDate"
+      map_content to: :content
+    end
   end
-end
 
-### Enumeration
+  class OriginInfo < Lutaml::Model::Serializable
+    attribute :date_issued, RecordDate, collection: true
 
-class Ceramic < Lutaml::Model::Serializable
-  attribute :type, :string
-  attribute :firing_temperature, :integer
-end
+    xml do
+      root "originInfo"
+      map_element "dateIssued", to: :date_issued
+    end
+  end
 
-class CeramicCollection < Lutaml::Model::Serializable
-  attribute :featured_piece,
-            Ceramic,
-            values: [
-              Ceramic.new(type: "Porcelain", firing_temperature: 1300),
-              Ceramic.new(type: "Stoneware", firing_temperature: 1200),
-              Ceramic.new(type: "Earthenware", firing_temperature: 1000),
-            ]
-end
+  ### Enumeration
 
-class GlazeTechnique < Lutaml::Model::Serializable
-  attribute :name, :string, values: ["Celadon", "Raku", "Majolica"]
+  class Ceramic < Lutaml::Model::Serializable
+    attribute :type, :string
+    attribute :firing_temperature, :integer
+  end
+
+  class CeramicCollection < Lutaml::Model::Serializable
+    attribute :featured_piece,
+              Ceramic,
+              values: [
+                Ceramic.new(type: "Porcelain", firing_temperature: 1300),
+                Ceramic.new(type: "Stoneware", firing_temperature: 1200),
+                Ceramic.new(type: "Earthenware", firing_temperature: 1000),
+              ]
+  end
+
+  class GlazeTechnique < Lutaml::Model::Serializable
+    attribute :name, :string, values: ["Celadon", "Raku", "Majolica"]
+  end
 end
 
 RSpec.describe Lutaml::Model::Serializable do
   describe ".model" do
     it "sets the model for the class" do
-      expect { described_class.model(TestModel) }.to change(described_class, :model)
+      expect { described_class.model(SerializeableSpec::TestModel) }.to change(described_class, :model)
         .from(nil)
-        .to(TestModel)
+        .to(SerializeableSpec::TestModel)
     end
   end
 
@@ -78,22 +80,17 @@ RSpec.describe Lutaml::Model::Serializable do
     subject(:mapper) { described_class.new }
 
     it "adds the attribute and getter setter for that attribute" do
-      expect do
-        described_class.attribute("foo", Lutaml::Model::Type::String)
-      end.to change {
-               described_class.attributes.keys
-             }.from([]).to(["foo"]).and change {
-                                          mapper.respond_to?(:foo)
-                                        }.from(false).to(true).and change {
-                                                                     mapper.respond_to?(:foo=)
-                                                                   }.from(false).to(true)
+      expect { described_class.attribute("foo", Lutaml::Model::Type::String) }
+        .to change { described_class.attributes.keys }.from([]).to(["foo"])
+        .and change { mapper.respond_to?(:foo) }.from(false).to(true)
+        .and change { mapper.respond_to?(:foo=) }.from(false).to(true)
     end
   end
 
   describe ".hash_representation" do
     context "when model is separate" do
       let(:instance) do
-        TestModel.new(name: "John", age: 18)
+        SerializeableSpec::TestModel.new(name: "John", age: 18)
       end
 
       let(:expected_hash) do
@@ -104,14 +101,14 @@ RSpec.describe Lutaml::Model::Serializable do
       end
 
       it "return hash representation" do
-        generate_hash = TestModelMapper.hash_representation(instance, :yaml)
+        generate_hash = SerializeableSpec::TestModelMapper.hash_representation(instance, :yaml)
         expect(generate_hash).to eq(expected_hash)
       end
     end
 
     context "when model is self" do
       let(:instance) do
-        TestMapper.new(name: "John", age: 18)
+        SerializeableSpec::TestMapper.new(name: "John", age: 18)
       end
 
       let(:expected_hash) do
@@ -122,7 +119,7 @@ RSpec.describe Lutaml::Model::Serializable do
       end
 
       it "return hash representation" do
-        generate_hash = TestMapper.hash_representation(instance, :yaml)
+        generate_hash = SerializeableSpec::TestMapper.hash_representation(instance, :yaml)
         expect(generate_hash).to eq(expected_hash)
       end
     end
@@ -131,7 +128,7 @@ RSpec.describe Lutaml::Model::Serializable do
   describe ".mappings_for" do
     context "when mapping is defined" do
       it "returns the defined mapping" do
-        actual_mappings = TestMapper.mappings_for(:yaml).mappings
+        actual_mappings = SerializeableSpec::TestMapper.mappings_for(:yaml).mappings
 
         expect(actual_mappings[0].name).to eq(:na)
         expect(actual_mappings[0].to).to eq(:name)
@@ -143,9 +140,9 @@ RSpec.describe Lutaml::Model::Serializable do
 
     context "when mapping is not defined" do
       it "maps attributes to mappings" do
-        allow(TestMapper.mappings).to receive(:[]).with(:yaml).and_return(nil)
+        allow(SerializeableSpec::TestMapper.mappings).to receive(:[]).with(:yaml).and_return(nil)
 
-        actual_mappings = TestMapper.mappings_for(:yaml).mappings
+        actual_mappings = SerializeableSpec::TestMapper.mappings_for(:yaml).mappings
 
         expect(actual_mappings[0].name).to eq("name")
         expect(actual_mappings[0].to).to eq(:name)
@@ -204,13 +201,13 @@ RSpec.describe Lutaml::Model::Serializable do
 
   describe "XML root name override" do
     it "uses root name defined at the component class" do
-      record_date = RecordDate.new(content: "2021-01-01")
+      record_date = SerializeableSpec::RecordDate.new(content: "2021-01-01")
       expected_xml = "<recordDate>2021-01-01</recordDate>"
       expect(record_date.to_xml).to eq(expected_xml)
     end
 
     it "uses mapped element name at the aggregating class, overriding root name" do
-      origin_info = OriginInfo.new(date_issued: [RecordDate.new(content: "2021-01-01")])
+      origin_info = SerializeableSpec::OriginInfo.new(date_issued: [SerializeableSpec::RecordDate.new(content: "2021-01-01")])
       expected_xml = <<~XML
         <originInfo><dateIssued>2021-01-01</dateIssued></originInfo>
       XML
@@ -221,7 +218,7 @@ RSpec.describe Lutaml::Model::Serializable do
   describe "String enumeration" do
     context "when assigning an invalid value" do
       it "raises an error after creation after validate" do
-        glaze = GlazeTechnique.new(name: "Celadon")
+        glaze = SerializeableSpec::GlazeTechnique.new(name: "Celadon")
         glaze.name = "Tenmoku"
         expect do
           glaze.validate!
@@ -234,13 +231,13 @@ RSpec.describe Lutaml::Model::Serializable do
 
     context "when assigning a valid value" do
       it "changes the value after creation" do
-        glaze = GlazeTechnique.new(name: "Celadon")
+        glaze = SerializeableSpec::GlazeTechnique.new(name: "Celadon")
         glaze.name = "Raku"
         expect(glaze.name).to eq("Raku")
       end
 
       it "assigns the value during creation" do
-        glaze = GlazeTechnique.new(name: "Majolica")
+        glaze = SerializeableSpec::GlazeTechnique.new(name: "Majolica")
         expect(glaze.name).to eq("Majolica")
       end
     end
@@ -249,7 +246,7 @@ RSpec.describe Lutaml::Model::Serializable do
   describe "Serializable object enumeration" do
     context "when assigning an invalid value" do
       it "raises ValidationError containing InvalidValueError after creation" do
-        glaze = GlazeTechnique.new(name: "Celadon")
+        glaze = SerializeableSpec::GlazeTechnique.new(name: "Celadon")
         glaze.name = "Tenmoku"
         expect do
           glaze.validate!
@@ -261,7 +258,7 @@ RSpec.describe Lutaml::Model::Serializable do
 
       it "raises ValidationError containing InvalidValueError during creation" do
         expect do
-          GlazeTechnique.new(name: "Crystalline").validate!
+          SerializeableSpec::GlazeTechnique.new(name: "Crystalline").validate!
         end.to raise_error(Lutaml::Model::ValidationError) do |error|
           expect(error).to include(Lutaml::Model::InvalidValueError)
           expect(error.error_messages).to include(a_string_matching(/name is `Crystalline`, must be one of the following/))
@@ -271,18 +268,18 @@ RSpec.describe Lutaml::Model::Serializable do
 
     context "when assigning a valid value" do
       it "changes the value after creation" do
-        collection = CeramicCollection.new(
-          featured_piece: Ceramic.new(type: "Porcelain",
+        collection = SerializeableSpec::CeramicCollection.new(
+          featured_piece: SerializeableSpec::Ceramic.new(type: "Porcelain",
                                       firing_temperature: 1300),
         )
-        collection.featured_piece = Ceramic.new(type: "Stoneware",
+        collection.featured_piece = SerializeableSpec::Ceramic.new(type: "Stoneware",
                                                 firing_temperature: 1200)
         expect(collection.featured_piece.type).to eq("Stoneware")
       end
 
       it "assigns the value during creation" do
-        collection = CeramicCollection.new(
-          featured_piece: Ceramic.new(type: "Earthenware",
+        collection = SerializeableSpec::CeramicCollection.new(
+          featured_piece: SerializeableSpec::Ceramic.new(type: "Earthenware",
                                       firing_temperature: 1000),
         )
         expect(collection.featured_piece.type).to eq("Earthenware")

--- a/spec/lutaml/model/serializable_spec.rb
+++ b/spec/lutaml/model/serializable_spec.rb
@@ -270,17 +270,17 @@ RSpec.describe Lutaml::Model::Serializable do
       it "changes the value after creation" do
         collection = SerializeableSpec::CeramicCollection.new(
           featured_piece: SerializeableSpec::Ceramic.new(type: "Porcelain",
-                                      firing_temperature: 1300),
+                                                         firing_temperature: 1300),
         )
         collection.featured_piece = SerializeableSpec::Ceramic.new(type: "Stoneware",
-                                                firing_temperature: 1200)
+                                                                   firing_temperature: 1200)
         expect(collection.featured_piece.type).to eq("Stoneware")
       end
 
       it "assigns the value during creation" do
         collection = SerializeableSpec::CeramicCollection.new(
           featured_piece: SerializeableSpec::Ceramic.new(type: "Earthenware",
-                                      firing_temperature: 1000),
+                                                         firing_temperature: 1000),
         )
         expect(collection.featured_piece.type).to eq("Earthenware")
       end


### PR DESCRIPTION
Do not override parent mappings when inheriting.

Required for -> https://github.com/metanorma/rfcxml/pull/3