### PR TITLE
fix: raw not keeping p tags

### DIFF
--- a/lib/lutaml/model/xml_adapter/builder/nokogiri.rb
+++ b/lib/lutaml/model/xml_adapter/builder/nokogiri.rb
@@ -63,12 +63,9 @@ module Lutaml
             self
           end
 
-
-          def method_missing(method_name, *args)
+          def method_missing(method_name, *args, &block)
             if block_given?
-              xml.public_send(method_name, *args) do |xml|
-                yield(xml)
-              end
+              xml.public_send(method_name, *args, &block)
             else
               xml.public_send(method_name, *args)
             end

--- a/lib/lutaml/model/xml_adapter/builder/nokogiri.rb
+++ b/lib/lutaml/model/xml_adapter/builder/nokogiri.rb
@@ -63,9 +63,10 @@ module Lutaml
             self
           end
 
+
           def method_missing(method_name, *args)
             if block_given?
-              xml.public_send(method_name, *args) do
+              xml.public_send(method_name, *args) do |xml|
                 yield(xml)
               end
             else

--- a/lib/lutaml/model/xml_adapter/nokogiri_adapter.rb
+++ b/lib/lutaml/model/xml_adapter/nokogiri_adapter.rb
@@ -139,8 +139,10 @@ module Lutaml
           if name == "text"
             builder.text(text)
           else
-            builder.send(name, build_attributes(self)) do |xml|
-              children.each { |child| child.to_xml(xml) }
+            builder.public_send(name, build_attributes(self)) do |xml|
+              children.each do |child|
+                child.to_xml(xml)
+              end
             end
           end
 

--- a/lib/lutaml/model/xml_adapter/xml_document.rb
+++ b/lib/lutaml/model/xml_adapter/xml_document.rb
@@ -84,7 +84,7 @@ module Lutaml
                       child.children.map do |c|
                         next c.text if c.text?
 
-                        self.class.new(c).to_xml
+                        c.to_xml.doc.root.to_xml({})
                       end.join
                     else
                       parse_element(child, attr&.type || klass, format)

--- a/spec/lutaml/model/xml_mapping_spec.rb
+++ b/spec/lutaml/model/xml_mapping_spec.rb
@@ -355,7 +355,7 @@ RSpec.describe Lutaml::Model::XmlMapping do
           <address>
             <street>
               <a>N</a>
-              <b>adf</b>
+              <p>adf</p>
             </street>
             <city><a>M</a></city>
           </address>
@@ -365,9 +365,9 @@ RSpec.describe Lutaml::Model::XmlMapping do
 
     let(:expected_street) do
       if Lutaml::Model::Config.xml_adapter == Lutaml::Model::XmlAdapter::OxAdapter
-        "<a>N</a>\n<b>adf</b>\n"
+        "<a>N</a>\n<p>adf</p>\n"
       else
-        "\n      <a>N</a>\n      <b>adf</b>\n    "
+        "\n      <a>N</a>\n      <p>adf</p>\n    "
       end
     end
 


### PR DESCRIPTION
`p` tags were being skipped because we were using `send` and instead of adding a `<p>` tag it was calling the private `p` method of the ruby `Object` class which is used to print to the console.
Updated the code to use `public_send` so this issue should be resolved now.

fix #99 
fix #102 