### PR TITLE
feat: add ordered: true option

### DIFF
--- a/lib/lutaml/model/serialize.rb
+++ b/lib/lutaml/model/serialize.rb
@@ -55,6 +55,14 @@ module Lutaml
             !!@ordered
           end
 
+          Utils.add_method_if_not_defined(klass, :mixed=) do |mixed|
+            @mixed = mixed
+          end
+
+          Utils.add_method_if_not_defined(klass, :mixed?) do
+            !!@mixed
+          end
+
           Utils.add_method_if_not_defined(klass, :element_order=) do |order|
             @element_order = order
           end
@@ -337,7 +345,8 @@ module Lutaml
 
           if instance.respond_to?(:ordered=) && doc.is_a?(Lutaml::Model::MappingHash)
             instance.element_order = doc.item_order
-            instance.ordered = mappings_for(:xml).mixed_content? || options[:mixed_content]
+            instance.ordered = mappings_for(:xml).ordered? || options[:ordered]
+            instance.mixed = mappings_for(:xml).mixed_content? || options[:mixed_content]
           end
 
           if doc["__schema_location"]
@@ -420,6 +429,7 @@ module Lutaml
       end
 
       attr_accessor :element_order, :schema_location
+      attr_writer :ordered, :mixed
 
       def initialize(attrs = {})
         @validate_on_set = attrs.delete(:validate_on_set) || false
@@ -469,11 +479,11 @@ module Lutaml
       end
 
       def ordered?
-        @ordered
+        !!@ordered
       end
 
-      def ordered=(ordered)
-        @ordered = ordered
+      def mixed?
+        !!@mixed
       end
 
       def key_exist?(hash, key)

--- a/lib/lutaml/model/xml_adapter/nokogiri_adapter.rb
+++ b/lib/lutaml/model/xml_adapter/nokogiri_adapter.rb
@@ -55,6 +55,7 @@ module Lutaml
             end
 
             index_hash = {}
+            content = []
 
             element.element_order.each do |name|
               index_hash[name] ||= -1
@@ -71,7 +72,11 @@ module Lutaml
                 text = xml_mapping.content_mapping.serialize(element)
                 text = text[curr_index] if text.is_a?(Array)
 
-                prefixed_xml.text text
+                if element.mixed?
+                  prefixed_xml.text text
+                else
+                  content << text
+                end
               elsif !value.nil? || element_rule.render_nil?
                 value = value[curr_index] if attribute_def.collection?
 
@@ -87,6 +92,8 @@ module Lutaml
                 )
               end
             end
+
+            prefixed_xml.text content.join
           end
         end
       end

--- a/lib/lutaml/model/xml_adapter/ox_adapter.rb
+++ b/lib/lutaml/model/xml_adapter/ox_adapter.rb
@@ -42,6 +42,7 @@ module Lutaml
           builder.create_and_add_element(tag_name,
                                          attributes: attributes) do |el|
             index_hash = {}
+            content = []
 
             element.element_order.each do |name|
               index_hash[name] ||= -1
@@ -58,7 +59,11 @@ module Lutaml
                 text = element.send(xml_mapping.content_mapping.to)
                 text = text[curr_index] if text.is_a?(Array)
 
-                el.add_text(el, text)
+                if element.mixed?
+                  el.add_text(el, text)
+                else
+                  content << text
+                end
               elsif !value.nil? || element_rule.render_nil?
                 value = value[curr_index] if attribute_def.collection?
 
@@ -74,6 +79,8 @@ module Lutaml
                 )
               end
             end
+
+            el.add_text(el, content.join)
           end
         end
       end

--- a/lib/lutaml/model/xml_mapping.rb
+++ b/lib/lutaml/model/xml_mapping.rb
@@ -6,7 +6,8 @@ module Lutaml
       attr_reader :root_element,
                   :namespace_uri,
                   :namespace_prefix,
-                  :mixed_content
+                  :mixed_content,
+                  :ordered
 
       def initialize
         @elements = {}
@@ -16,10 +17,12 @@ module Lutaml
       end
 
       alias mixed_content? mixed_content
+      alias ordered? ordered
 
-      def root(name, mixed: false)
+      def root(name, mixed: false, ordered: false)
         @root_element = name
         @mixed_content = mixed
+        @ordered = ordered || mixed # mixed contenet will always be ordered
       end
 
       def prefixed_root

--- a/spec/lutaml/model/ordered_content_spec.rb
+++ b/spec/lutaml/model/ordered_content_spec.rb
@@ -77,8 +77,7 @@ RSpec.describe "OrderedContent" do
     it_behaves_like "ordered content behavior", described_class
   end
 
-  # Not implemented yet
-  xdescribe Lutaml::Model::XmlAdapter::OgaAdapter do
+  describe Lutaml::Model::XmlAdapter::OgaAdapter, skip: "Not implemented yet" do
     it_behaves_like "ordered content behavior", described_class
   end
 end

--- a/spec/lutaml/model/ordered_content_spec.rb
+++ b/spec/lutaml/model/ordered_content_spec.rb
@@ -1,0 +1,84 @@
+# spec/lutaml/model/ordered_content_spec.rb
+
+require "spec_helper"
+require "lutaml/model"
+require "lutaml/model/xml_adapter/nokogiri_adapter"
+require "lutaml/model/xml_adapter/ox_adapter"
+require "lutaml/model/xml_adapter/oga_adapter"
+require_relative "../../fixtures/sample_model"
+
+module OrderedContentSpec
+  class RootOrderedContent < Lutaml::Model::Serializable
+    attribute :id, :string
+    attribute :bold, :string, collection: true
+    attribute :italic, :string, collection: true
+    attribute :underline, :string
+    attribute :content, :string
+
+    xml do
+      root "RootOrderedContent", ordered: true
+      map_attribute :id, to: :id
+      map_element :bold, to: :bold
+      map_element :italic, to: :italic
+      map_element :underline, to: :underline
+      map_content to: :content
+    end
+  end
+end
+
+RSpec.describe "OrderedContent" do
+  shared_examples "ordered content behavior" do |adapter_class|
+    around do |example|
+      old_adapter = Lutaml::Model::Config.xml_adapter
+      Lutaml::Model::Config.xml_adapter = adapter_class
+      example.run
+    ensure
+      Lutaml::Model::Config.xml_adapter = old_adapter
+    end
+
+    context "when ordered: true is set at root" do
+      let(:xml) do
+        <<~XML
+          <RootOrderedContent id="123">
+            The Earth's Moon rings like a <bold>bell</bold> when struck by
+            meteroids. Distanced from the Earth by <italic>384,400 km</italic>,
+            its surface is covered in <underline>craters</underline>.
+            Ain't that <bold>cool</bold>?
+          </RootOrderedContent>
+        XML
+      end
+
+      let(:expected_xml) do
+        <<~XML
+          <RootOrderedContent id="123">
+            <bold>bell</bold>
+            <italic>384,400 km</italic>
+            <underline>craters</underline>
+            <bold>cool</bold>
+            The Earth's Moon rings like a  when struck by
+            meteroids. Distanced from the Earth by ,
+            its surface is covered in . Ain't that ?
+          </RootOrderedContent>
+        XML
+      end
+
+      it "deserializes and serializes ordered content correctly" do
+        serialized = OrderedContentSpec::RootOrderedContent.from_xml(xml).to_xml
+        expect(serialized).to be_equivalent_to(expected_xml)
+      end
+    end
+  end
+
+  describe Lutaml::Model::XmlAdapter::NokogiriAdapter do
+    it_behaves_like "ordered content behavior", described_class
+  end
+
+  describe Lutaml::Model::XmlAdapter::OxAdapter do
+    it_behaves_like "ordered content behavior", described_class
+  end
+
+  # Not implemented yet
+  xdescribe Lutaml::Model::XmlAdapter::OgaAdapter do
+    it_behaves_like "ordered content behavior", described_class
+  end
+end


### PR DESCRIPTION
Added option `ordered: true` in root for only ordering the tags.

as discussed here -> https://github.com/lutaml/metaschema/issues/6#issuecomment-2426064137