### PR TITLE
fix: schema location for mixed content

### DIFF
--- a/lib/lutaml/model/xml_adapter/xml_document.rb
+++ b/lib/lutaml/model/xml_adapter/xml_document.rb
@@ -303,6 +303,10 @@ module Lutaml
                     {}
                   end
 
+          if element.respond_to?(:schema_location) && element.schema_location
+            attrs.merge!(element.schema_location.to_xml_attributes)
+          end
+
           xml_mapping.attributes.each_with_object(attrs) do |mapping_rule, hash|
             next if options[:except]&.include?(mapping_rule.to)
             next if mapping_rule.custom_methods[:to]

--- a/spec/lutaml/model/xml_mapping_spec.rb
+++ b/spec/lutaml/model/xml_mapping_spec.rb
@@ -90,6 +90,18 @@ module XmlMapping
                                        prefix: nil
     end
   end
+
+  class SchemaLocationOrdered < Lutaml::Model::Serializable
+    attribute :content, :string
+    attribute :second, SchemaLocationOrdered
+
+    xml do
+      root "schemaLocationOrdered", mixed: true
+
+      map_content to: :content
+      map_element "schemaLocationOrdered", to: :second
+    end
+  end
 end
 
 RSpec.describe Lutaml::Model::XmlMapping do
@@ -260,20 +272,40 @@ RSpec.describe Lutaml::Model::XmlMapping do
   end
 
   context "with schemaLocation" do
-    let(:xml) do
-      <<~XML
-        <p xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-           xsi:schemaLocation="http://www.opengis.net/gml/3.2 http://schemas.opengis.net/gml/3.2.1/gml.xsd">
-          <p xmlns:xsi="http://another-instance"
-             xsi:schemaLocation="http://www.opengis.net/gml/3.7">
-            Some text inside paragraph
+    context "when mixed: false" do
+      let(:xml) do
+        <<~XML
+          <p xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://www.opengis.net/gml/3.2 http://schemas.opengis.net/gml/3.2.1/gml.xsd">
+            <p xmlns:xsi="http://another-instance"
+               xsi:schemaLocation="http://www.opengis.net/gml/3.7">
+              Some text inside paragraph
+            </p>
           </p>
-        </p>
-      XML
+        XML
+      end
+
+      it "contain schemaLocation attributes" do
+        expect(Paragraph.from_xml(xml).to_xml).to be_equivalent_to(xml)
+      end
     end
 
-    it "contain schemaLocation attributes" do
-      expect(Paragraph.from_xml(xml).to_xml).to be_equivalent_to(xml)
+    context "when mixed: true" do
+      let(:xml) do
+        <<~XML
+          <schemaLocationOrdered xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://www.opengis.net/gml/3.2 http://schemas.opengis.net/gml/3.2.1/gml.xsd">
+            <schemaLocationOrdered xmlns:xsi="http://another-instance"
+               xsi:schemaLocation="http://www.opengis.net/gml/3.7">
+              Some text inside paragraph
+            </schemaLocationOrdered>
+          </schemaLocationOrdered>
+        XML
+      end
+
+      it "contain schemaLocation attributes" do
+        expect(XmlMapping::SchemaLocationOrdered.from_xml(xml).to_xml).to be_equivalent_to(xml)
+      end
     end
   end
 


### PR DESCRIPTION
Fixed `schemaLocation` for models with `mixed: true`. 

For -> https://github.com/lutaml/metaschema/issues/7