### PR TITLE
Fix of the error while parsing comment with Ox adapter

### DIFF
--- a/lib/lutaml/model/xml_adapter/ox_adapter.rb
+++ b/lib/lutaml/model/xml_adapter/ox_adapter.rb
@@ -89,6 +89,8 @@ module Lutaml
         def initialize(node, root_node: nil)
           if node.is_a?(String)
             super("text", {}, [], node, parent_document: root_node)
+          elsif node.is_a?(Ox::Comment)
+            super("comment", {}, [], node.value, parent_document: root_node)
           else
             namespace_attributes(node.attributes).each do |(name, value)|
               if root_node

--- a/spec/lutaml/model/xml_adapter/ox_adapter_spec.rb
+++ b/spec/lutaml/model/xml_adapter/ox_adapter_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Lutaml::Model::XmlAdapter::OxAdapter do
     <<-XML
       <root xmlns="http://example.com/default" xmlns:prefix="http://example.com/prefixed">
         <prefix:child attr="value" prefix:attr="prefixed_value">Text</prefix:child>
+        <!-- just-a-comment -->
       </root>
     XML
   end
@@ -25,6 +26,10 @@ RSpec.describe Lutaml::Model::XmlAdapter::OxAdapter do
       expect(child.name).to eq("prefix:child")
       expect(child.namespace.uri).to eq("http://example.com/prefixed")
       expect(child.namespace.prefix).to eq("prefix")
+    end
+
+    it "parses comment" do
+      expect(document.root.nodes.last.text).to eq("just-a-comment")
     end
 
     it "parses attributes with and without namespaces" do


### PR DESCRIPTION
This PR fixes a crash while parsing a comment using the **Ox** parser.