### PR TITLE
fix: from_xml not working for without namespaced elements

### DIFF
--- a/lib/lutaml/model/xml_adapter/nokogiri_adapter.rb
+++ b/lib/lutaml/model/xml_adapter/nokogiri_adapter.rb
@@ -128,7 +128,9 @@ module Lutaml
             )
           end
 
-          default_namespace = node.namespace&.href if root_node.nil?
+          if root_node.nil? && !node.namespace&.prefix
+            default_namespace = node.namespace&.href
+          end
 
           super(
             node,


### PR DESCRIPTION
Default namespace was being applied even if it was not defined on the root element. 

fix #147 