### PR TITLE
allow string validations using pattern

### DIFF
--- a/lib/lutaml/model/error.rb
+++ b/lib/lutaml/model/error.rb
@@ -7,6 +7,7 @@ end
 
 require_relative "error/invalid_value_error"
 require_relative "error/incorrect_mapping_argument_error"
+require_relative "error/pattern_not_matched_error"
 require_relative "error/unknown_adapter_type_error"
 require_relative "error/collection_count_out_of_range_error"
 require_relative "error/validation_error"

--- a/lib/lutaml/model/error/pattern_not_matched_error.rb
+++ b/lib/lutaml/model/error/pattern_not_matched_error.rb
@@ -1,0 +1,17 @@
+module Lutaml
+  module Model
+    class PatternNotMatchedError < Error
+      def initialize(attr_name, pattern, value)
+        @attr_name = attr_name
+        @pattern = pattern
+        @value = value
+
+        super()
+      end
+
+      def to_s
+        "#{@attr_name}: \"#{@value}\" does not match #{@pattern.inspect}"
+      end
+    end
+  end
+end

--- a/lib/lutaml/model/validation.rb
+++ b/lib/lutaml/model/validation.rb
@@ -8,7 +8,8 @@ module Lutaml
           begin
             attr.validate_value!(value)
           rescue Lutaml::Model::InvalidValueError,
-                 Lutaml::Model::CollectionCountOutOfRangeError => e
+                 Lutaml::Model::CollectionCountOutOfRangeError,
+                 PatternNotMatchedError => e
             errors << e
           end
         end

--- a/spec/lutaml/model/attribute_spec.rb
+++ b/spec/lutaml/model/attribute_spec.rb
@@ -33,6 +33,33 @@ RSpec.describe Lutaml::Model::Attribute do
       .to("avatar.png")
   end
 
+  describe "#validate_options!" do
+    let(:validate_options) { name_attr.method(:validate_options!) }
+
+    Lutaml::Model::Attribute::ALLOWED_OPTIONS.each do |option|
+      it "return true if option is `#{option}`" do
+        expect(validate_options.call({ option => "value" })).to be(true)
+      end
+    end
+
+    it "raise exception if option is not allowed" do
+      expect do
+        validate_options.call({ foo: "bar" })
+      end.to raise_error(StandardError, "Invalid options given for `name` [:foo]")
+    end
+
+    it "raise exception if pattern is given with non string type" do
+      age_attr = described_class.new("age", :integer)
+
+      expect do
+        age_attr.send(:validate_options!, { pattern: /[A-Za-z ]/ })
+      end.to raise_error(
+        StandardError,
+        "Invalid option `pattern` given for `age`, `pattern` is only allowed for :string type",
+      )
+    end
+  end
+
   describe "#validate_type!" do
     let(:validate_type) { name_attr.method(:validate_type!) }
 

--- a/spec/lutaml/model/serializable_validation_spec.rb
+++ b/spec/lutaml/model/serializable_validation_spec.rb
@@ -2,6 +2,7 @@ require "spec_helper"
 
 class TestSerializable < Lutaml::Model::Serializable
   attribute :name, :string, values: ["Alice", "Bob", "Charlie"]
+  attribute :email, :string, pattern: /.*?\S+@.+\.\S+/
   attribute :age, :integer, collection: 1..3
 
   xml do
@@ -27,9 +28,12 @@ class TestSerializable < Lutaml::Model::Serializable
 end
 
 RSpec.describe Lutaml::Model::Serializable do
-  let(:valid_instance) { TestSerializable.new(name: "Alice", age: [30]) }
+  let(:valid_instance) do
+    TestSerializable.new(name: "Alice", age: [30], email: "alice@gmail.com")
+  end
+
   let(:invalid_instance) do
-    TestSerializable.new(name: "David", age: [25, 30, 35, 40])
+    TestSerializable.new(name: "David", age: [25, 30, 35, 40], email: "david@gmail")
   end
 
   describe "serialization methods" do
@@ -66,8 +70,9 @@ RSpec.describe Lutaml::Model::Serializable do
     it "returns errors for invalid attributes" do
       errors = invalid_instance.validate
       expect(errors).not_to be_empty
-      expect(errors.first).to be_a(Lutaml::Model::InvalidValueError)
-      expect(errors.last).to be_a(Lutaml::Model::CollectionCountOutOfRangeError)
+      expect(errors[0]).to be_a(Lutaml::Model::InvalidValueError)
+      expect(errors[1]).to be_a(Lutaml::Model::PatternNotMatchedError)
+      expect(errors[2]).to be_a(Lutaml::Model::CollectionCountOutOfRangeError)
     end
   end
 


### PR DESCRIPTION
Allow string validations using `pattern`.

resolves #158 