### PR TITLE
feat: added support for encoding options

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1302,6 +1302,69 @@ end
 ====
 
 
+==== Encoding Options in XmlAdapter
+
+XmlAdapter supports the encoding in the following ways:
+
+. When encoding is not passed in to_xml:
+** Default encoding is UTF-8.
+
+. When encoding is explicitly passed nil:
+** Encoding will be nil, show the HexCode(Nokogiri) or ASCII-8bit(Ox).
+
+. When encoding is passed with some option:
+** Encoding option will be selected as passed.
+
+
+Syntax:
+
+[source,ruby]
+----
+Example.new(description: " ∑ is my ∏ moniker µ.").to_xml
+Example.new(description: " ∑ is my ∏ moniker µ.").to_xml(encoding: nil)
+Example.new(description: " ∑ is my ∏ moniker µ.").to_xml(encoding: "ASCII")
+----
+
+[example]
+====
+The following class will parse the XML snippet below:
+
+[source,ruby]
+----
+class Example < Lutaml::Model::Serializable
+  attribute :name, :string
+  attribute :description, :string
+  attribute :value, :integer
+
+  xml do
+    root 'example'
+    map_element 'name', to: :name
+    map_content to: :description
+  end
+end
+----
+
+[source,xml]
+----
+<example><name>John &#x0026; Doe</name> &#x2211; is my &#x220F; moniker &#xB5;.</example>
+----
+
+[source,ruby]
+----
+> Example.from_xml(xml)
+> #<Example:0x0000000104ac7240 @name="John & Doe", @description=" ∑ is my ∏ moniker µ.">
+> Example.new(name: "John & Doe", description: " ∑ is my ∏ moniker µ.").to_xml
+> #<example><name>John &amp; Doe</name> ∑ is my ∏ moniker µ.</example>
+
+> Example.new(name: "John & Doe", description: " ∑ is my ∏ moniker µ.").to_xml(encoding: nil)
+> #<example><name>John &amp; Doe</name> &#x2211; is my &#x220F; moniker &#xB5;.</example>
+
+> Example.new(name: "John & Doe", description: " ∑ is my ∏ moniker µ.").to_xml(encoding: "ASCII")
+> #<example><name>John &amp; Doe</name> &#8721; is my &#8719; moniker &#181;.</example>
+----
+====
+
+
 ==== Namespaces
 
 [[root-namespace]]

--- a/lib/lutaml/model/xml_adapter/nokogiri_adapter.rb
+++ b/lib/lutaml/model/xml_adapter/nokogiri_adapter.rb
@@ -13,7 +13,15 @@ module Lutaml
         end
 
         def to_xml(options = {})
-          builder = Builder::Nokogiri.build(encoding: "UTF-8") do |xml|
+          builder_options = {}
+
+          if options.key?(:encoding)
+            builder_options[:encoding] = options[:encoding] unless options[:encoding].nil?
+          else
+            builder_options[:encoding] = "UTF-8"
+          end
+
+          builder = Builder::Nokogiri.build(builder_options) do |xml|
             if root.is_a?(Lutaml::Model::XmlAdapter::NokogiriElement)
               root.build_xml(xml)
             else

--- a/lib/lutaml/model/xml_adapter/ox_adapter.rb
+++ b/lib/lutaml/model/xml_adapter/ox_adapter.rb
@@ -14,8 +14,15 @@ module Lutaml
 
         def to_xml(options = {})
           builder = Builder::Ox.build
-          builder.xml.instruct(:xml, encoding: options[:encoding] || "UTF-8", version: options[:version])
+          builder_options = { version: options[:version] }
 
+          if options.key?(:encoding)
+            builder_options[:encoding] = options[:encoding] unless options[:encoding].nil?
+          else
+            builder_options[:encoding] = "UTF-8"
+          end
+
+          builder.xml.instruct(:xml, builder_options)
           if @root.is_a?(Lutaml::Model::XmlAdapter::OxElement)
             @root.build_xml(builder)
           elsif ordered?(@root, options)

--- a/spec/lutaml/model/delegation_spec.rb
+++ b/spec/lutaml/model/delegation_spec.rb
@@ -148,11 +148,11 @@ RSpec.describe Delegation do
   end
 
   it "provides XML declaration with UTF-8 encoding" \
-     "if encoding: true option provided" do
+     "if encoding: 'UTF-8' option provided" do
     xml_data = delegation.to_xml(
       pretty: true,
       declaration: true,
-      encoding: true,
+      encoding: "UTF-8",
     )
     expect(xml_data).to include('<?xml version="1.0" encoding="UTF-8"?>')
   end


### PR DESCRIPTION
Added Support for Encoding Options

Options:  

- `encoding: nil` (adapter uses its default encoding)
- `encoding: “encoding_name”`  

Default encoding is `UTF-8.` 
Note: if the encoding name is invalid, Nokogiri raises an error, while Ox defaults to its internal encoding.

### Breaking Change:

The previous `encoding: true` option has been updated to accept `encoding: "encoding_name"`. 

resolves #163 