### PR TITLE
prefix not added when defined explicitly

### DIFF
--- a/lib/lutaml/model/xml_adapter/xml_document.rb
+++ b/lib/lutaml/model/xml_adapter/xml_document.rb
@@ -66,7 +66,7 @@ module Lutaml
           options[:tag_name] = rule.name
 
           options[:mapper_class] = attribute&.type if attribute
-          options[:namespace_set] = set_namespace?(rule)
+          options[:set_namespace] = set_namespace?(rule)
 
           options
         end
@@ -185,6 +185,7 @@ module Lutaml
           attributes = options[:xml_attributes] ||= {}
           attributes = build_attributes(element,
                                         xml_mapping, options).merge(attributes)&.compact
+
           if element.respond_to?(:schema_location) && element.schema_location
             attributes.merge!(element.schema_location.to_xml_attributes)
           end
@@ -275,7 +276,7 @@ module Lutaml
         end
 
         def set_namespace?(rule)
-          rule.nil? || !rule.namespace_set? || !rule.namespace.nil?
+          rule.nil? || !rule.namespace_set?
         end
 
         def render_element?(rule, element, value)
@@ -336,7 +337,7 @@ module Lutaml
         end
 
         def build_attributes(element, xml_mapping, options = {})
-          attrs = if options.fetch(:namespace_set, true)
+          attrs = if options.fetch(:set_namespace, true)
                     namespace_attributes(xml_mapping)
                   else
                     {}

--- a/spec/lutaml/model/xml_mapping_spec.rb
+++ b/spec/lutaml/model/xml_mapping_spec.rb
@@ -127,6 +127,17 @@ module XmlMapping
     end
   end
 
+  class OverrideDefaultNamespacePrefix < Lutaml::Model::Serializable
+    attribute :same_element_name, SameNameDifferentNamespace
+
+    xml do
+      root "OverrideDefaultNamespacePrefix"
+      map_element :SameElementName, to: :same_element_name,
+                                    namespace: "http://www.omg.org/spec/XMI/20131001",
+                                    prefix: "abc"
+    end
+  end
+
   class SchemaLocationOrdered < Lutaml::Model::Serializable
     attribute :content, :string
     attribute :second, SchemaLocationOrdered
@@ -242,6 +253,25 @@ RSpec.describe Lutaml::Model::XmlMapping do
     it "nil namespace" do
       parsed = XmlMapping::MmlMath.from_xml(mml)
       expect(parsed.to_xml).to be_equivalent_to(mml)
+    end
+  end
+
+  context "overriding child namespace prefix" do
+    let(:input_xml) do
+      <<~XML
+        <OverrideDefaultNamespacePrefix xmlns:abc="http://www.omg.org/spec/XMI/20131001" xmlns:GML="http://www.sparxsystems.com/profiles/GML/1.0" xmlns:CityGML="http://www.sparxsystems.com/profiles/CityGML/1.0">
+          <abc:SameElementName App="hello">
+            <GML:ApplicationSchema>GML App</GML:ApplicationSchema>
+            <CityGML:ApplicationSchema>CityGML App</CityGML:ApplicationSchema>
+            <abc:ApplicationSchema>App</abc:ApplicationSchema>
+          </abc:SameElementName>
+        </OverrideDefaultNamespacePrefix>
+      XML
+    end
+
+    it "expect to round-trips" do
+      parsed = XmlMapping::OverrideDefaultNamespacePrefix.from_xml(input_xml)
+      expect(parsed.to_xml).to be_equivalent_to(input_xml)
     end
   end
 


### PR DESCRIPTION
Fixes the issue when a prefix is not being added to the XML when passed explicitly when mapping an element.

fixes #152 