### PR TITLE
FIX: `content_mapping` with `mixed: true`

### DIFF
--- a/lib/lutaml/model/xml_adapter/nokogiri_adapter.rb
+++ b/lib/lutaml/model/xml_adapter/nokogiri_adapter.rb
@@ -35,12 +35,11 @@ module Lutaml
 
         def prefix_xml(xml, mapping, options)
           if options.key?(:namespace_prefix)
-            options[:namespace_prefix] ? xml[options[:namespace_prefix]] : xml
+            xml[options[:namespace_prefix]] if options[:namespace_prefix]
           elsif mapping.namespace_prefix
             xml[mapping.namespace_prefix]
-          else
-            xml
           end
+          xml
         end
 
         def build_ordered_element(xml, element, options = {})

--- a/spec/lutaml/model/xml_mapping_spec.rb
+++ b/spec/lutaml/model/xml_mapping_spec.rb
@@ -220,6 +220,30 @@ module XmlMapping
                                       prefix: nil
     end
   end
+
+  class Documentation < Lutaml::Model::Serializable
+    attribute :content, :string
+
+    xml do
+      root "documentation", mixed: true
+      namespace "http://www.w3.org/2001/XMLSchema", "xsd"
+
+      map_content to: :content
+    end
+  end
+
+  class Schema < Lutaml::Model::Serializable
+    attribute :documentation, Documentation, collection: true
+
+    xml do
+      root "schema"
+      namespace "http://www.w3.org/2001/XMLSchema", "xsd"
+
+      map_element :documentation, to: :documentation,
+                                  namespace: "http://www.w3.org/2001/XMLSchema",
+                                  prefix: "xsd"
+    end
+  end
 end
 
 RSpec.describe Lutaml::Model::XmlMapping do
@@ -857,6 +881,20 @@ RSpec.describe Lutaml::Model::XmlMapping do
         XML
 
         expect(XmlMapping::SpecialCharContentWithMapAll.from_xml(xml).to_xml).to eq(expected_xml)
+      end
+    end
+
+    context "when mixed content is true and child is content_mapping" do
+      let(:xml) do
+        <<~XML
+          <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+            <xsd:documentation>asdf</xsd:documentation>
+          </xsd:schema>
+        XML
+      end
+
+      it "round-trips xml" do
+        expect(XmlMapping::Schema.from_xml(xml).to_xml).to be_equivalent_to(xml)
       end
     end
   end


### PR DESCRIPTION
This PR fixes an issue (adding an extra element named `add_text`)with `map_content` used with `mixed: true`.

![Screenshot 2024-11-19 at 7 46 31 PM](https://github.com/user-attachments/assets/b36b97cf-9ed5-4e05-9213-72bc44165d3c)
