### PR TITLE
Convert doc hash keys to strings

### DIFF
--- a/lib/lutaml/model/serialize.rb
+++ b/lib/lutaml/model/serialize.rb
@@ -180,11 +180,11 @@ module Lutaml
 
             attribute = attributes[name]
 
-            hash[rule.from] = if rule.child_mappings
-                                generate_hash_from_child_mappings(value, rule.child_mappings)
-                              else
-                                attribute.serialize(value, format, options)
-                              end
+            hash[rule.from.to_s] = if rule.child_mappings
+                                     generate_hash_from_child_mappings(value, rule.child_mappings)
+                                   else
+                                     attribute.serialize(value, format, options)
+                                   end
           end
         end
 
@@ -379,8 +379,8 @@ module Lutaml
 
             attr = attribute_for_rule(rule)
 
-            value = if doc.key?(rule.name) || doc.key?(rule.name.to_sym)
-                      doc[rule.name] || doc[rule.name.to_sym]
+            value = if doc.key?(rule.name.to_s) || doc.key?(rule.name.to_sym)
+                      doc[rule.name.to_s] || doc[rule.name.to_sym]
                     else
                       attr.default
                     end

--- a/spec/lutaml/model/serializable_spec.rb
+++ b/spec/lutaml/model/serializable_spec.rb
@@ -131,8 +131,8 @@ RSpec.describe Lutaml::Model::Serializable do
 
       let(:expected_hash) do
         {
-          na: "John",
-          ag: "18",
+          "na" => "John",
+          "ag" => "18",
         }
       end
 


### PR DESCRIPTION
Convert doc hash keys to strings.

fixes #202 