### PR TITLE
chore: add doc to migrate to lutaml

### DIFF
--- a/MIGRATE_TO_LUTAML.adoc
+++ b/MIGRATE_TO_LUTAML.adoc
@@ -1,4 +1,3 @@
-
 = Generic Steps to Migrate a Gem to Use LutaML::Model::Serializable
 :doctype: article
 
@@ -14,10 +13,10 @@ Replace the current data model implementation by inheriting from `LutaML::Model:
 
 [source,ruby]
 ----
-  class MyClass < LutaML::Model::Serializable
-      attribute :name, String
-      attribute :age, Integer
-  end
+class MyClass < LutaML::Model::Serializable
+    attribute :name, String
+    attribute :age, Integer
+end
 ----
 
 * **Define Attributes Explicitly**
@@ -30,14 +29,14 @@ For models requiring a collection of items (e.g., a list of objects), create a d
 
 [source,ruby]
 ----
-  class MyItem < LutaML::Model::Serializable
-      attribute :id, Integer
-      attribute :value, String
-  end
+class MyItem < LutaML::Model::Serializable
+    attribute :id, Integer
+    attribute :value, String
+end
 
-  class MyItemsCollection < LutaML::Model::Serializable
-      attribute :items, MyItem, collection: true
-  end
+class MyItemsCollection < LutaML::Model::Serializable
+    attribute :items, MyItem, collection: true
+end
 ----
 
 This ensures the collection is properly serialized and deserialized, maintaining consistency with `LutaML::Model::Serializable`.
@@ -47,10 +46,12 @@ This ensures the collection is properly serialized and deserialized, maintaining
 For attributes with names that do not directly map between YAML and Ruby (e.g., `temperature-K`), add key mappings:
 
 [source,ruby]
-  key_value do
-      map "geometrical-altitude-m", to: :geometrical_altitude_m
-      map "temperature-K", to: :temperature_k
-  end
+----
+key_value do
+    map "geometrical-altitude-m", to: :geometrical_altitude_m
+    map "temperature-K", to: :temperature_k
+end
+----
 
 This allows YAML keys to be correctly parsed into Ruby-compatible attribute names.
 
@@ -85,6 +86,16 @@ end
 * **Update Documentation**
 
 Ensure the gem's README and other documentation reflect the changes introduced by `LutaML::Model::Serializable`.
+
+== Troubleshooting and Important Considerations
+
+* If the `bigdecimal` library is not loaded, usage of the `Decimal` type will raise a `Lutaml::Model::TypeNotSupportedError`.
+* Ensure the YAML files in the ISO2533 repository are up-to-date and structure the build accordingly.
+* Verify that the gem's current entry points work correctly and produce accurate results.
+* Always require the attributes classes in their respective parent classes.
+* Make sure to require `lutaml-model` wherever serialization functionality is needed.
+* Include the ISO repository as a submodule to read YAML files as fixtures for tests in this gem's specs.
+* Create methods in subclasses to set attributes of attributes classes if objects involve calculated values by default. This ensures proper serialization.
 
 == Conclusion
 

--- a/MIGRATE_TO_LUTAML.adoc
+++ b/MIGRATE_TO_LUTAML.adoc
@@ -1,0 +1,78 @@
+= Generic Steps to Migrate a Gem to Use LutaML::Model::Serializable
+:doctype: article
+
+== Introduction
+This guide provides a comprehensive approach to migrating a Ruby gem to use `LutaML::Model::Serializable`. These steps aim to ensure consistency and leverage LutaML's serialization capabilities for streamlined data handling.
+
+== Steps for Migration
+
+1. **Inherit From LutaML::Model::Serializable**  
+   Replace the current data model implementation by inheriting from `LutaML::Model::Serializable`. Update each class representing the domain model.
+
+   For example:  
+[source,ruby]
+class MyClass < LutaML::Model::Serializable
+    attribute :name, String
+    attribute :age, Integer
+end
+
+2. **Define Attributes Explicitly**  
+   Ensure all attributes in the model are explicitly defined using the `attribute` method.
+
+3. **Create Subclasses as Collections**  
+   For models requiring a collection of items (e.g., a list of objects), create a dedicated subclass to represent the collection.
+
+   For example:  
+[source,ruby]
+class MyItem < LutaML::Model::Serializable
+    attribute :id, Integer
+    attribute :value, String
+end
+
+[source,ruby]
+class MyItemsCollection < LutaML::Model::Serializable
+    attribute :items, MyItem, collection: true
+end
+
+   This ensures the collection can be properly serialized and deserialized, maintaining consistency with `LutaML::Model::Serializable`.
+
+4. **Handle Attribute Name Mismatches**  
+   For attributes with names that do not directly map between YAML and Ruby (e.g., `temperature-K`), add key mappings:
+
+[source,ruby]
+key_value do
+    map "geometrical-altitude-m", to: :geometrical_altitude_m
+    map "temperature-K", to: :temperature_k
+end
+
+5. **Modify YAML Handling**  
+   Ensure YAML serialization and deserialization work correctly. Override any custom logic if necessary to support attribute mapping.
+
+6. **Update Tests to Verify Round-Trip Serialization**  
+   Update the tests to load models from YAML files and verify round-trip serialization.
+
+[source,ruby]
+----
+require 'lutaml/model'
+
+RSpec.describe "MyClass Serialization" do
+     let(:yaml_path) { "spec/fixtures/my_class.yaml" }
+
+     def verify_yaml_round_trip(yaml_path, model_class)
+       original_yaml = File.read(yaml_path)
+       model_instance = model_class.from_yaml(original_yaml)
+       generated_yaml = model_instance.to_yaml
+       expect(YAML.safe_load(generated_yaml)).to eq(YAML.safe_load(original_yaml))
+     end
+
+     it "verifies round-trip serialization" do
+       verify_yaml_round_trip(yaml_path, MyClass)
+     end
+   end
+----
+
+7. **Update Documentation**  
+   Ensure the gem's README and other documentation files reflect the changes introduced by `LutaML::Model::Serializable`.
+
+== Conclusion
+Migrating to `LutaML::Model::Serializable` ensures better serialization support and attribute handling in your gem. Follow these steps systematically for a smooth transition.

--- a/MIGRATE_TO_LUTAML.adoc
+++ b/MIGRATE_TO_LUTAML.adoc
@@ -10,9 +10,7 @@ This guide provides a comprehensive approach to migrating a Ruby gem to use `Lut
 
 * **Inherit From LutaML::Model::Serializable**
 
-  Replace the current data model implementation by inheriting from `LutaML::Model::Serializable`. Update each class representing the domain model.
-
-  For example:
+Replace the current data model implementation by inheriting from `LutaML::Model::Serializable`. Update each class representing the domain model. For example:
 
 [source,ruby]
 ----
@@ -24,11 +22,11 @@ This guide provides a comprehensive approach to migrating a Ruby gem to use `Lut
 
 * **Define Attributes Explicitly**
 
-  Ensure all attributes in the model are explicitly defined using the `attribute` method. This avoids runtime errors and ensures proper serialization.
+Ensure all attributes in the model are explicitly defined using the `attribute` method. This avoids runtime errors and ensures proper serialization.
 
 * **Create Subclasses as Collections**
 
-  For models requiring a collection of items (e.g., a list of objects), create a dedicated subclass to represent the collection.
+For models requiring a collection of items (e.g., a list of objects), create a dedicated subclass to represent the collection.
 
 [source,ruby]
 ----
@@ -42,11 +40,11 @@ This guide provides a comprehensive approach to migrating a Ruby gem to use `Lut
   end
 ----
 
-  This ensures the collection is properly serialized and deserialized, maintaining consistency with `LutaML::Model::Serializable`.
+This ensures the collection is properly serialized and deserialized, maintaining consistency with `LutaML::Model::Serializable`.
 
 * **Handle Attribute Name Mismatches**
 
-  For attributes with names that do not directly map between YAML and Ruby (e.g., `temperature-K`), add key mappings:
+For attributes with names that do not directly map between YAML and Ruby (e.g., `temperature-K`), add key mappings:
 
 [source,ruby]
   key_value do
@@ -54,39 +52,39 @@ This guide provides a comprehensive approach to migrating a Ruby gem to use `Lut
       map "temperature-K", to: :temperature_k
   end
 
-  This allows YAML keys to be correctly parsed into Ruby-compatible attribute names.
+This allows YAML keys to be correctly parsed into Ruby-compatible attribute names.
 
 * **Modify YAML Handling**
 
-  Ensure YAML serialization and deserialization work correctly. Override custom logic, if necessary, to support attribute mapping. Verify that all required keys are correctly handled.
+Ensure YAML serialization and deserialization work correctly. Override custom logic, if necessary, to support attribute mapping. Verify that all required keys are correctly handled.
 
 * **Update Tests to Verify Round-Trip Serialization**
 
-  Update the tests to load models from YAML files and verify round-trip serialization:
+Update the tests to load models from YAML files and verify round-trip serialization:
 
 [source,ruby]
 ----
-  require 'lutaml/model'
+require 'lutaml/model'
 
-  RSpec.describe "MyClass Serialization" do
-       let(:yaml_path) { "spec/fixtures/my_class.yaml" }
+RSpec.describe "MyClass Serialization" do
+    let(:yaml_path) { "spec/fixtures/my_class.yaml" }
 
-       def verify_yaml_round_trip(yaml_path, model_class)
-         original_yaml = File.read(yaml_path)
-         model_instance = model_class.from_yaml(original_yaml)
-         generated_yaml = model_instance.to_yaml
-         expect(YAML.safe_load(generated_yaml)).to eq(YAML.safe_load(original_yaml))
-       end
+    def verify_yaml_round_trip(yaml_path, model_class)
+        original_yaml = File.read(yaml_path)
+        model_instance = model_class.from_yaml(original_yaml)
+        generated_yaml = model_instance.to_yaml
+        expect(YAML.safe_load(generated_yaml)).to eq(YAML.safe_load(original_yaml))
+    end
 
-       it "verifies round-trip serialization" do
-         verify_yaml_round_trip(yaml_path, MyClass)
-       end
-  end
+    it "verifies round-trip serialization" do
+        verify_yaml_round_trip(yaml_path, MyClass)
+    end
+end
 ----
 
 * **Update Documentation**
 
-  Ensure the gem's README and other documentation reflect the changes introduced by `LutaML::Model::Serializable`.
+Ensure the gem's README and other documentation reflect the changes introduced by `LutaML::Model::Serializable`.
 
 == Conclusion
 

--- a/MIGRATE_TO_LUTAML.adoc
+++ b/MIGRATE_TO_LUTAML.adoc
@@ -45,7 +45,7 @@ This ensures the collection is properly serialized and deserialized, maintaining
 
 * **Handle Attribute Name Mismatches**
 
-For attributes with names that do not directly map between formats (e.g., `temperature-K`), add key mappings:
+For attributes with names that do not directly map between formats (e.g., `temperature-K`), add key mappings alongwith other mappings:
 
 [source,ruby]
 ----
@@ -95,7 +95,6 @@ Ensure the gem's README and other documentation reflect the changes introduced b
 * Verify that the gem's current entry points work correctly and produce accurate results.
 * Always require the attributes classes in their respective parent classes.
 * Make sure the `Lutaml::Model` is available wherever serialization functionality is needed
-* Create or import the content files to use as fixtures for specs
 * Create methods in subclasses to set attributes of attributes classes if objects involve calculated values by default. This ensures proper serialization.
 
 == Conclusion

--- a/MIGRATE_TO_LUTAML.adoc
+++ b/MIGRATE_TO_LUTAML.adoc
@@ -1,9 +1,9 @@
-= Generic Steps to Migrate a Gem to Use LutaML::Model::Serializable
+= Generic Steps to Migrate a Gem to Use Lutaml-Model
 :doctype: article
 
 == Introduction
 
-This guide provides a comprehensive approach to migrating a Ruby gem to use `LutaML::Model::Serializable`. These steps ensure consistency and leverage LutaML's serialization capabilities for streamlined data handling.
+This guide provides a comprehensive approach to migrating a Ruby gem to use `Lutaml-Model`. These steps ensure consistency and leverage LutaML's serialization capabilities for streamlined data handling.
 
 == Steps for Migration
 
@@ -65,10 +65,6 @@ end
 
 This allows format keys to be correctly parsed into Ruby-compatible attribute names.
 
-* **Modify content Handling**
-
-Ensure content serialization and deserialization work correctly. Override custom logic, if necessary, to support attribute mapping. Verify that all required keys are correctly handled.
-
 * **Update Tests to Verify Round-Trip Serialization**
 
 Update the tests to load models from content files and verify round-trip serialization, For example in YAML:
@@ -91,17 +87,17 @@ end
 
 * **Update Documentation**
 
-Ensure the gem's README and other documentation reflect the changes introduced by `LutaML::Model::Serializable`.
+Ensure the gem's README and other documentation reflect the changes introduced by `Lutaml-Model`.
 
 == Troubleshooting and Important Considerations
 
 * If the `bigdecimal` library is not loaded, usage of the `Decimal` type will raise a `Lutaml::Model::TypeNotEnabledError`.
 * Verify that the gem's current entry points work correctly and produce accurate results.
 * Always require the attributes classes in their respective parent classes.
-* Make sure the Lutaml::Model is available wherever serialization functionality is needed
+* Make sure the `Lutaml::Model` is available wherever serialization functionality is needed
 * Create or import the content files to use as fixtures for specs
 * Create methods in subclasses to set attributes of attributes classes if objects involve calculated values by default. This ensures proper serialization.
 
 == Conclusion
 
-Migrating to `LutaML::Model::Serializable` ensures better serialization support and attribute handling in your gem. By following these steps and addressing common pitfalls, you can achieve a smooth transition.
+Migrating to `Lutaml-Model` ensures better serialization support and attribute handling in your gem. By following these steps and addressing common pitfalls, you can achieve a smooth transition.

--- a/MIGRATE_TO_LUTAML.adoc
+++ b/MIGRATE_TO_LUTAML.adoc
@@ -3,17 +3,17 @@
 
 == Introduction
 
-This guide provides a comprehensive approach to migrating a Ruby gem to use `Lutaml-Model`. These steps ensure consistency and leverage LutaML's serialization capabilities for streamlined data handling.
+This guide provides a comprehensive approach to migrating a Ruby gem to use `Lutaml-Model`. These steps ensure consistency and leverage Lutaml's serialization capabilities for streamlined data handling.
 
 == Steps for Migration
 
-* **Inherit From LutaML::Model::Serializable**
+* **Inherit From Lutaml::Model::Serializable**
 
-Replace the current data model implementation by inheriting from `LutaML::Model::Serializable`. Update each class representing the domain model. For example:
+Replace the current data model implementation by inheriting from `Lutaml::Model::Serializable`. Update each class representing the domain model. For example:
 
 [source,ruby]
 ----
-class MyClass < LutaML::Model::Serializable
+class MyClass < Lutaml::Model::Serializable
   attribute :name, String
   attribute :age, Integer
 end
@@ -29,19 +29,19 @@ For models requiring a collection of items that are not supported types (e.g., a
 
 [source,ruby]
 ----
-class MyItem < LutaML::Model::Serializable
+class MyItem < Lutaml::Model::Serializable
   attribute :id, :integer
   attribute :value, :string
 end
 
-class MyItemsCollection < LutaML::Model::Serializable
+class MyItemsCollection < Lutaml::Model::Serializable
   attribute :items, MyItem, collection: true
 end
 ----
 
 For more information see https://github.com/lutaml/lutaml-model?tab=readme-ov-file#supported-attribute-value-types[supported types]
 
-This ensures the collection is properly serialized and deserialized, maintaining consistency with `LutaML::Model::Serializable`.
+This ensures the collection is properly serialized and deserialized, maintaining consistency with `Lutaml::Model::Serializable`.
 
 * **Handle Attribute Name Mismatches**
 

--- a/MIGRATE_TO_LUTAML.adoc
+++ b/MIGRATE_TO_LUTAML.adoc
@@ -14,8 +14,8 @@ Replace the current data model implementation by inheriting from `LutaML::Model:
 [source,ruby]
 ----
 class MyClass < LutaML::Model::Serializable
-    attribute :name, String
-    attribute :age, Integer
+  attribute :name, String
+  attribute :age, Integer
 end
 ----
 
@@ -25,61 +25,67 @@ Ensure all attributes in the model are explicitly defined using the `attribute` 
 
 * **Create Subclasses as Collections**
 
-For models requiring a collection of items (e.g., a list of objects), create a dedicated subclass to represent the collection.
+For models requiring a collection of items that are not supported types (e.g., a list of objects), create a dedicated subclass to represent the collection.
 
 [source,ruby]
 ----
 class MyItem < LutaML::Model::Serializable
-    attribute :id, Integer
-    attribute :value, String
+  attribute :id, :integer
+  attribute :value, :string
 end
 
 class MyItemsCollection < LutaML::Model::Serializable
-    attribute :items, MyItem, collection: true
+  attribute :items, MyItem, collection: true
 end
 ----
+
+For more information see https://github.com/lutaml/lutaml-model?tab=readme-ov-file#supported-attribute-value-types[supported types]
 
 This ensures the collection is properly serialized and deserialized, maintaining consistency with `LutaML::Model::Serializable`.
 
 * **Handle Attribute Name Mismatches**
 
-For attributes with names that do not directly map between YAML and Ruby (e.g., `temperature-K`), add key mappings:
+For attributes with names that do not directly map between formats (e.g., `temperature-K`), add key mappings:
 
 [source,ruby]
 ----
+# JSON, YAML, and TOML
+
 key_value do
-    map "geometrical-altitude-m", to: :geometrical_altitude_m
-    map "temperature-K", to: :temperature_k
+  map "geometrical-altitude-m", to: :geometrical_altitude_m
+  map "temperature-K", to: :temperature_k
+end
+
+# For XML
+
+xml do
+  map_element 'geometrical-altitude-m', to: :geometrical_altitude_m
 end
 ----
 
-This allows YAML keys to be correctly parsed into Ruby-compatible attribute names.
+This allows format keys to be correctly parsed into Ruby-compatible attribute names.
 
-* **Modify YAML Handling**
+* **Modify content Handling**
 
-Ensure YAML serialization and deserialization work correctly. Override custom logic, if necessary, to support attribute mapping. Verify that all required keys are correctly handled.
+Ensure content serialization and deserialization work correctly. Override custom logic, if necessary, to support attribute mapping. Verify that all required keys are correctly handled.
 
 * **Update Tests to Verify Round-Trip Serialization**
 
-Update the tests to load models from YAML files and verify round-trip serialization:
+Update the tests to load models from content files and verify round-trip serialization, For example in YAML:
 
 [source,ruby]
 ----
 require 'lutaml/model'
 
 RSpec.describe "MyClass Serialization" do
-    let(:yaml_path) { "spec/fixtures/my_class.yaml" }
+  let(:yaml_path) { "spec/fixtures/my_class.yaml" }
 
-    def verify_yaml_round_trip(yaml_path, model_class)
-        original_yaml = File.read(yaml_path)
-        model_instance = model_class.from_yaml(original_yaml)
-        generated_yaml = model_instance.to_yaml
-        expect(YAML.safe_load(generated_yaml)).to eq(YAML.safe_load(original_yaml))
-    end
-
-    it "verifies round-trip serialization" do
-        verify_yaml_round_trip(yaml_path, MyClass)
-    end
+  it "verifies round-trip serialization" do
+    original_yaml = File.read(yaml_path)
+    model_instance = model_class.from_yaml(original_yaml)
+    generated_yaml = model_instance.to_yaml
+    expect(YAML.safe_load(generated_yaml)).to eq(YAML.safe_load(original_yaml))
+  end
 end
 ----
 
@@ -89,12 +95,11 @@ Ensure the gem's README and other documentation reflect the changes introduced b
 
 == Troubleshooting and Important Considerations
 
-* If the `bigdecimal` library is not loaded, usage of the `Decimal` type will raise a `Lutaml::Model::TypeNotSupportedError`.
-* Ensure the YAML files in the ISO2533 repository are up-to-date and structure the build accordingly.
+* If the `bigdecimal` library is not loaded, usage of the `Decimal` type will raise a `Lutaml::Model::TypeNotEnabledError`.
 * Verify that the gem's current entry points work correctly and produce accurate results.
 * Always require the attributes classes in their respective parent classes.
-* Make sure to require `lutaml-model` wherever serialization functionality is needed.
-* Include the ISO repository as a submodule to read YAML files as fixtures for tests in this gem's specs.
+* Make sure the Lutaml::Model is available wherever serialization functionality is needed
+* Create or import the content files to use as fixtures for specs
 * Create methods in subclasses to set attributes of attributes classes if objects involve calculated values by default. This ensures proper serialization.
 
 == Conclusion

--- a/MIGRATE_TO_LUTAML.adoc
+++ b/MIGRATE_TO_LUTAML.adoc
@@ -1,78 +1,93 @@
+
 = Generic Steps to Migrate a Gem to Use LutaML::Model::Serializable
 :doctype: article
 
 == Introduction
-This guide provides a comprehensive approach to migrating a Ruby gem to use `LutaML::Model::Serializable`. These steps aim to ensure consistency and leverage LutaML's serialization capabilities for streamlined data handling.
+
+This guide provides a comprehensive approach to migrating a Ruby gem to use `LutaML::Model::Serializable`. These steps ensure consistency and leverage LutaML's serialization capabilities for streamlined data handling.
 
 == Steps for Migration
 
-1. **Inherit From LutaML::Model::Serializable**  
-   Replace the current data model implementation by inheriting from `LutaML::Model::Serializable`. Update each class representing the domain model.
+* **Inherit From LutaML::Model::Serializable**
 
-   For example:  
-[source,ruby]
-class MyClass < LutaML::Model::Serializable
-    attribute :name, String
-    attribute :age, Integer
-end
+  Replace the current data model implementation by inheriting from `LutaML::Model::Serializable`. Update each class representing the domain model.
 
-2. **Define Attributes Explicitly**  
-   Ensure all attributes in the model are explicitly defined using the `attribute` method.
-
-3. **Create Subclasses as Collections**  
-   For models requiring a collection of items (e.g., a list of objects), create a dedicated subclass to represent the collection.
-
-   For example:  
-[source,ruby]
-class MyItem < LutaML::Model::Serializable
-    attribute :id, Integer
-    attribute :value, String
-end
-
-[source,ruby]
-class MyItemsCollection < LutaML::Model::Serializable
-    attribute :items, MyItem, collection: true
-end
-
-   This ensures the collection can be properly serialized and deserialized, maintaining consistency with `LutaML::Model::Serializable`.
-
-4. **Handle Attribute Name Mismatches**  
-   For attributes with names that do not directly map between YAML and Ruby (e.g., `temperature-K`), add key mappings:
-
-[source,ruby]
-key_value do
-    map "geometrical-altitude-m", to: :geometrical_altitude_m
-    map "temperature-K", to: :temperature_k
-end
-
-5. **Modify YAML Handling**  
-   Ensure YAML serialization and deserialization work correctly. Override any custom logic if necessary to support attribute mapping.
-
-6. **Update Tests to Verify Round-Trip Serialization**  
-   Update the tests to load models from YAML files and verify round-trip serialization.
+  For example:
 
 [source,ruby]
 ----
-require 'lutaml/model'
-
-RSpec.describe "MyClass Serialization" do
-     let(:yaml_path) { "spec/fixtures/my_class.yaml" }
-
-     def verify_yaml_round_trip(yaml_path, model_class)
-       original_yaml = File.read(yaml_path)
-       model_instance = model_class.from_yaml(original_yaml)
-       generated_yaml = model_instance.to_yaml
-       expect(YAML.safe_load(generated_yaml)).to eq(YAML.safe_load(original_yaml))
-     end
-
-     it "verifies round-trip serialization" do
-       verify_yaml_round_trip(yaml_path, MyClass)
-     end
-   end
+  class MyClass < LutaML::Model::Serializable
+      attribute :name, String
+      attribute :age, Integer
+  end
 ----
 
-7. **Update Documentation**  
-   Ensure the gem's README and other documentation files reflect the changes introduced by `LutaML::Model::Serializable`.
+* **Define Attributes Explicitly**
+
+  Ensure all attributes in the model are explicitly defined using the `attribute` method. This avoids runtime errors and ensures proper serialization.
+
+* **Create Subclasses as Collections**
+
+  For models requiring a collection of items (e.g., a list of objects), create a dedicated subclass to represent the collection.
+
+[source,ruby]
+----
+  class MyItem < LutaML::Model::Serializable
+      attribute :id, Integer
+      attribute :value, String
+  end
+
+  class MyItemsCollection < LutaML::Model::Serializable
+      attribute :items, MyItem, collection: true
+  end
+----
+
+  This ensures the collection is properly serialized and deserialized, maintaining consistency with `LutaML::Model::Serializable`.
+
+* **Handle Attribute Name Mismatches**
+
+  For attributes with names that do not directly map between YAML and Ruby (e.g., `temperature-K`), add key mappings:
+
+[source,ruby]
+  key_value do
+      map "geometrical-altitude-m", to: :geometrical_altitude_m
+      map "temperature-K", to: :temperature_k
+  end
+
+  This allows YAML keys to be correctly parsed into Ruby-compatible attribute names.
+
+* **Modify YAML Handling**
+
+  Ensure YAML serialization and deserialization work correctly. Override custom logic, if necessary, to support attribute mapping. Verify that all required keys are correctly handled.
+
+* **Update Tests to Verify Round-Trip Serialization**
+
+  Update the tests to load models from YAML files and verify round-trip serialization:
+
+[source,ruby]
+----
+  require 'lutaml/model'
+
+  RSpec.describe "MyClass Serialization" do
+       let(:yaml_path) { "spec/fixtures/my_class.yaml" }
+
+       def verify_yaml_round_trip(yaml_path, model_class)
+         original_yaml = File.read(yaml_path)
+         model_instance = model_class.from_yaml(original_yaml)
+         generated_yaml = model_instance.to_yaml
+         expect(YAML.safe_load(generated_yaml)).to eq(YAML.safe_load(original_yaml))
+       end
+
+       it "verifies round-trip serialization" do
+         verify_yaml_round_trip(yaml_path, MyClass)
+       end
+  end
+----
+
+* **Update Documentation**
+
+  Ensure the gem's README and other documentation reflect the changes introduced by `LutaML::Model::Serializable`.
 
 == Conclusion
-Migrating to `LutaML::Model::Serializable` ensures better serialization support and attribute handling in your gem. Follow these steps systematically for a smooth transition.
+
+Migrating to `LutaML::Model::Serializable` ensures better serialization support and attribute handling in your gem. By following these steps and addressing common pitfalls, you can achieve a smooth transition.


### PR DESCRIPTION
### Add Migration Guide for LutaML::Model::Serializable   

---

### Changes in This PR  
- Added a new AsciiDoc file: `migration_to_lutaml_model_serializable.adoc` in the `docs` directory.  
- Included detailed migration steps and example code snippets for better understanding.  

---

### Testing  
Not applicable, as this PR only introduces documentation.  

---

### Additional Notes  
This guide is designed to standardize migration workflows and ensure seamless integration with `LutaML::Model::Serializable`.  

Feedback and suggestions to improve the guide are welcome. Please share any edge cases or scenarios that could be addressed in future updates.  
