### PR TITLE
fix: custom Type serialization methods

### DIFF
--- a/lib/lutaml/model/type/time.rb
+++ b/lib/lutaml/model/type/time.rb
@@ -24,10 +24,10 @@ module Lutaml
           value&.iso8601
         end
 
-        # # xs:time format (HH:MM:SS.mmm±HH:MM)
-        # def to_xml
-        #   value&.strftime("%H:%M:%S%:z")
-        # end
+        # # ISO8601 time format
+        def to_xml
+          value&.iso8601
+        end
 
         # # ISO8601 time format
         # def to_json

--- a/spec/ceramic_spec.rb
+++ b/spec/ceramic_spec.rb
@@ -1,0 +1,40 @@
+require "spec_helper"
+require_relative "fixtures/ceramic"
+
+RSpec.describe Ceramic do
+
+  xml = <<~XML
+    <ceramic kilnFiringTimeAttribute="2012-04-07T01:51:37.112+02:00">
+      <kilnFiringTime>2012-04-07T01:51:37.112+02:00</kilnFiringTime>
+    </ceramic>
+  XML
+
+  it "deserializes from XML with high-precision date-time" do
+    ceramic = described_class.from_xml(xml)
+    expect(ceramic.kiln_firing_time.strftime("%Y-%m-%dT%H:%M:%S.%L%:z")).to eq("2012-04-07T01:51:37.112+02:00")
+  end
+
+  it "serializes to XML with high-precision date-time" do
+    ceramic = described_class.from_xml(xml)
+    expect(ceramic.to_xml).to be_equivalent_to(xml)
+  end
+
+  it "deserializes from JSON with high-precision date-time" do
+    json = {
+      kilnFiringTime: "2012-04-07T01:51:37+02:00",
+    }.to_json
+
+    ceramic_from_json = described_class.from_json(json)
+    expect(ceramic_from_json.kiln_firing_time).to eq(DateTime.new(2012, 4, 7, 1, 51, 37, "+02:00"))
+  end
+
+  it "serializes to JSON with high-precision date-time" do
+    ceramic = described_class.from_xml(xml)
+    expected_json = {
+      kilnFiringTime: "2012-04-07T01:51:37+02:00",
+      kilnFiringTimeAttribute: "2012-04-07T01:51:37+02:00",
+    }.to_json
+
+    expect(ceramic.to_json).to eq(expected_json)
+  end
+end

--- a/spec/fixtures/ceramic.rb
+++ b/spec/fixtures/ceramic.rb
@@ -1,0 +1,23 @@
+require "lutaml/model"
+
+class HighPrecisionDateTime < Lutaml::Model::Type::DateTime
+  def to_xml
+    value.strftime("%Y-%m-%dT%H:%M:%S.%L%:z")
+  end
+end
+
+class Ceramic < Lutaml::Model::Serializable
+  attribute :kiln_firing_time, HighPrecisionDateTime
+  attribute :kiln_firing_time_attribute, HighPrecisionDateTime
+
+  xml do
+    root "ceramic"
+    map_element "kilnFiringTime", to: :kiln_firing_time
+    map_attribute "kilnFiringTimeAttribute", to: :kiln_firing_time_attribute
+  end
+
+  json do
+    map "kilnFiringTime", to: :kiln_firing_time
+    map "kilnFiringTimeAttribute", to: :kiln_firing_time_attribute
+  end
+end


### PR DESCRIPTION
# Summary for #199 and Proposed Solutions

## Original Problem
- The `to_json` method of `Type` works as expected, but `to_xml` does not.
- For xml attribute ex: `<tag time="2012"/>` , serialization relies only on `to_s` or a raw string, which is insufficient for certain use cases (e.g., custom serialization for specific types). https://github.com/lutaml/reqif/issues/1
- Additionally, the `from_{format}` methods of `Type` (e.g., `from_xml`, `from_json`) do not function as expected. While this issue isn't directly addressed in this PR, tests have been included to document the problem (currently commented out).

---

## Changes Introduced in This PR

### 1. Added Specs for Issue #199
- **`to_xml` and `to_json` overrides**:
  - Created tests for overriding these methods for a simple custom type.
- **HighPrecisionDateTime example**:
  - Added an example using `Ceramic` and `HighPrecisionDateTime` to demonstrate correct serialization/deserialization as part of the documentation (e.g., in `README.md`).

### 2. Applied `serialize` in Three Areas

- **xml element**:
- **xml attribute**:
- **json**

---

## Considerations and Next Steps
- **Discussion Needed**:
  - These changes may affect other parts of the project or introduce unexpected behavior, as I am new to the codebase.
- **Unresolved Issues**:
  - The `from_{format}` methods (e.g., `from_xml`, `from_json`) of `Type` are still not functioning as intended. Tests documenting this issue are included but commented out.

