### PR TITLE
fix decimal attribute serializing to ruby object in YAML

### DIFF
--- a/lib/lutaml/model/type/decimal.rb
+++ b/lib/lutaml/model/type/decimal.rb
@@ -36,6 +36,11 @@ module Lutaml
             raise TypeNotEnabledError.new("Decimal", value)
           end
         end
+
+        # Override to avoid serializing ruby object in YAML
+        def to_yaml
+          value&.to_s("F")
+        end
       end
     end
   end

--- a/spec/fixtures/sample_model.rb
+++ b/spec/fixtures/sample_model.rb
@@ -36,5 +36,12 @@ class SampleModel < Lutaml::Model::Serializable
   yaml do
     map "name", to: :name
     map "age", to: :age
+    map "balance", to: :balance
+    map "tags", to: :tags
+    map "preferences", to: :preferences
+    map "status", to: :status
+    map "large_number", to: :large_number
+    map "email", to: :email
+    map "role", to: :role
   end
 end

--- a/spec/sample_model_spec.rb
+++ b/spec/sample_model_spec.rb
@@ -1,0 +1,117 @@
+
+require "spec_helper"
+require_relative "fixtures/sample_model"
+
+RSpec.describe SampleModel do
+
+  describe "default values" do
+    let(:model) { described_class.new }
+
+    it "sets default name" do
+      expect(model.name).to eq("Anonymous")
+    end
+
+    it "sets default age" do
+      expect(model.age).to eq(18)
+    end
+
+    it "sets default balance" do
+      expect(model.balance).to eq(BigDecimal("0.0"))
+    end
+
+    it "sets default tags" do
+      expect(model.tags).to eq([])
+    end
+
+    it "sets default preferences" do
+      expect(model.preferences).to eq({ notifications: true })
+    end
+
+    it "sets default status" do
+      expect(model.status).to eq("active")
+    end
+
+    it "sets default large_number" do
+      expect(model.large_number).to eq(0)
+    end
+
+    it "sets default email" do
+      expect(model.email).to eq("example@example.com")
+    end
+
+    it "sets default role" do
+      expect(model.role).to eq("user")
+    end
+  end
+
+  describe "role validation" do
+    it "accepts valid roles" do
+      %w[user admin guest].each do |role|
+        model.role = role
+        expect(model.role).to eq(role)
+      end
+    end
+
+    it "raises error for invalid role" do
+      model.role = "invalid"
+      expect { model.validate! }.to raise_error(Lutaml::Model::ValidationError)
+    end
+  end
+
+  let(:attributes) do
+    {
+      name: "John Doe",
+      age: 25,
+      balance: BigDecimal('100432423.523142344124'),
+      tags: [
+        SampleModelTag.new(text: "ruby"),
+        SampleModelTag.new(text: "coding")
+      ],
+      preferences: { notifications: false, theme: "dark" },
+      status: "premium",
+      large_number: 9999,
+      email: "john@example.com",
+      role: "admin"
+    }
+  end
+
+  let(:attributes_yaml) do
+    {
+      "name" => "John Doe",
+      "age" => 25,
+      "balance" => '100432423.523142344124',
+      "tags" => [
+        { "text" => "ruby" },
+        { "text" => "coding" }
+      ],
+      "preferences" => { notifications: false, theme: "dark" },
+      "status" => "premium",
+      "large_number" => 9999,
+      "email" => "john@example.com",
+      "role" => "admin"
+    }
+  end
+  let(:model) { described_class.new(attributes) }
+
+  describe "YAML serialization" do
+    it "serializes to YAML" do
+      expect(model.to_yaml).to eq(attributes_yaml.to_yaml)
+    end
+
+    it "deserializes from YAML" do
+      yaml = attributes_yaml.to_yaml
+      sample = described_class.from_yaml(yaml)
+      
+      expect(sample.name).to eq("John Doe")
+      expect(sample.age).to eq(25)
+      expect(sample.balance).to eq(BigDecimal('100432423.523142344124'))
+      expect(sample.tags).to all(be_a(SampleModelTag))
+      expect(sample.tags.map(&:text)).to eq(["ruby", "coding"])
+      expect(sample.preferences).to eq({ notifications: false, theme: "dark" })
+      expect(sample.status).to eq("premium")
+      expect(sample.large_number).to eq(9999)
+      expect(sample.email).to eq("john@example.com")
+      expect(sample.role).to eq("admin")
+    end
+  end
+end

--- a/spec/sample_model_spec.rb
+++ b/spec/sample_model_spec.rb
@@ -1,8 +1,40 @@
-
 require "spec_helper"
 require_relative "fixtures/sample_model"
 
 RSpec.describe SampleModel do
+  let(:model) { described_class.new(attributes) }
+  let(:attributes_yaml) do
+    {
+      "name" => "John Doe",
+      "age" => 25,
+      "balance" => "100432423.523142344124",
+      "tags" => [
+        { "text" => "ruby" },
+        { "text" => "coding" },
+      ],
+      "preferences" => { notifications: false, theme: "dark" },
+      "status" => "premium",
+      "large_number" => 9999,
+      "email" => "john@example.com",
+      "role" => "admin",
+    }
+  end
+  let(:attributes) do
+    {
+      name: "John Doe",
+      age: 25,
+      balance: BigDecimal("100432423.523142344124"),
+      tags: [
+        SampleModelTag.new(text: "ruby"),
+        SampleModelTag.new(text: "coding"),
+      ],
+      preferences: { notifications: false, theme: "dark" },
+      status: "premium",
+      large_number: 9999,
+      email: "john@example.com",
+      role: "admin",
+    }
+  end
 
   describe "default values" do
     let(:model) { described_class.new }
@@ -58,41 +90,6 @@ RSpec.describe SampleModel do
     end
   end
 
-  let(:attributes) do
-    {
-      name: "John Doe",
-      age: 25,
-      balance: BigDecimal('100432423.523142344124'),
-      tags: [
-        SampleModelTag.new(text: "ruby"),
-        SampleModelTag.new(text: "coding")
-      ],
-      preferences: { notifications: false, theme: "dark" },
-      status: "premium",
-      large_number: 9999,
-      email: "john@example.com",
-      role: "admin"
-    }
-  end
-
-  let(:attributes_yaml) do
-    {
-      "name" => "John Doe",
-      "age" => 25,
-      "balance" => '100432423.523142344124',
-      "tags" => [
-        { "text" => "ruby" },
-        { "text" => "coding" }
-      ],
-      "preferences" => { notifications: false, theme: "dark" },
-      "status" => "premium",
-      "large_number" => 9999,
-      "email" => "john@example.com",
-      "role" => "admin"
-    }
-  end
-  let(:model) { described_class.new(attributes) }
-
   describe "YAML serialization" do
     it "serializes to YAML" do
       expect(model.to_yaml).to eq(attributes_yaml.to_yaml)
@@ -101,10 +98,10 @@ RSpec.describe SampleModel do
     it "deserializes from YAML" do
       yaml = attributes_yaml.to_yaml
       sample = described_class.from_yaml(yaml)
-      
+
       expect(sample.name).to eq("John Doe")
       expect(sample.age).to eq(25)
-      expect(sample.balance).to eq(BigDecimal('100432423.523142344124'))
+      expect(sample.balance).to eq(BigDecimal("100432423.523142344124"))
       expect(sample.tags).to all(be_a(SampleModelTag))
       expect(sample.tags.map(&:text)).to eq(["ruby", "coding"])
       expect(sample.preferences).to eq({ notifications: false, theme: "dark" })


### PR DESCRIPTION
Fix decimal serialization to YAML returns ruby object instead of value

fixes [#206](https://github.com/lutaml/lutaml-model/issues/206)