### PR TITLE
Fix error when serialize module is included

### DIFF
--- a/lib/lutaml/model/serialize.rb
+++ b/lib/lutaml/model/serialize.rb
@@ -32,6 +32,11 @@ module Lutaml
           subclass.initialize_attrs(self)
         end
 
+        def included(base)
+          base.extend(ClassMethods)
+          base.initialize_attrs(self)
+        end
+
         def initialize_attrs(source_class)
           @mappings = Utils.deep_dup(source_class.instance_variable_get(:@mappings)) || {}
           @attributes = Utils.deep_dup(source_class.instance_variable_get(:@attributes)) || {}
@@ -548,7 +553,7 @@ module Lutaml
                              self.class.hash_representation(self, format,
                                                             options)
                            end
-
+                           
           options[:parse_encoding] = encoding if encoding
           adapter.new(representation).public_send(:"to_#{format}", options)
         end

--- a/lib/lutaml/model/serialize.rb
+++ b/lib/lutaml/model/serialize.rb
@@ -21,6 +21,7 @@ module Lutaml
 
       def self.included(base)
         base.extend(ClassMethods)
+        base.initialize_attrs(base)
       end
 
       module ClassMethods
@@ -28,14 +29,13 @@ module Lutaml
 
         def inherited(subclass)
           super
+          subclass.initialize_attrs(self)
+        end
 
-          @mappings ||= {}
-          @attributes ||= {}
-
-          subclass.instance_variable_set(:@attributes,
-                                         Utils.deep_dup(@attributes))
-          subclass.instance_variable_set(:@mappings, Utils.deep_dup(@mappings))
-          subclass.instance_variable_set(:@model, subclass)
+        def initialize_attrs(source_class)
+          @mappings = Utils.deep_dup(source_class.instance_variable_get(:@mappings)) || {}
+          @attributes = Utils.deep_dup(source_class.instance_variable_get(:@attributes)) || {}
+          instance_variable_set(:@model, self)
         end
 
         def model(klass = nil)

--- a/lib/lutaml/model/serialize.rb
+++ b/lib/lutaml/model/serialize.rb
@@ -553,7 +553,7 @@ module Lutaml
                              self.class.hash_representation(self, format,
                                                             options)
                            end
-                           
+
           options[:parse_encoding] = encoding if encoding
           adapter.new(representation).public_send(:"to_#{format}", options)
         end

--- a/spec/lutaml/model/included_spec.rb
+++ b/spec/lutaml/model/included_spec.rb
@@ -52,26 +52,24 @@ module IncludedSpec
 
   module ParentClass
     include Lutaml::Model::Serialize
-    
+
     attribute :parent_name, Lutaml::Model::Type::String
     attribute :parent_id, Lutaml::Model::Type::String
-    attribute :parent_text, Lutaml::Model::Type::String
-    
+
     xml do
       root "parent"
       map_attribute "id", to: :parent_id
       map_element "parent_name", to: :parent_name
-      map_content to: :parent_text
     end
   end
 
   module ChildClass
     include ParentClass
-    
+
     attribute :child_name, Lutaml::Model::Type::String
     attribute :child_type, Lutaml::Model::Type::String
     attribute :child_text, Lutaml::Model::Type::String
-    
+
     xml do
       root "child"
       map_attribute "type", to: :child_type
@@ -82,11 +80,11 @@ module IncludedSpec
 
   class GrandChildClass
     include ChildClass
-    
+
     attribute :grandchild_name, Lutaml::Model::Type::String
     attribute :grandchild_version, Lutaml::Model::Type::String
     attribute :grandchild_text, Lutaml::Model::Type::String
-    
+
     xml do
       root "grandchild"
       map_attribute "version", to: :grandchild_version
@@ -155,19 +153,18 @@ RSpec.describe "Module Inclusion" do
       IncludedSpec::GrandChildClass.new(
         parent_name: "Parent Name",
         parent_id: "P123",
-        parent_text: "Parent Text",
         child_name: "Child Name",
         child_type: "Type A",
         child_text: "Child Text",
         grandchild_name: "GrandChild Name",
         grandchild_version: "1.0",
-        grandchild_text: "GrandChild Text"
+        grandchild_text: "GrandChild Text",
       )
     end
 
     it "inherits attributes through the chain" do
       expect(IncludedSpec::GrandChildClass.attributes.keys).to include(
-        :parent_name, :parent_id, :parent_text,
+        :parent_name, :parent_id,
         :child_name, :child_type, :child_text,
         :grandchild_name, :grandchild_version, :grandchild_text
       )
@@ -182,7 +179,7 @@ RSpec.describe "Module Inclusion" do
           GrandChild Text
         </grandchild>
       XML
-      
+
       expect(grandchild.to_xml(pretty: true)).to be_equivalent_to(expected_xml)
     end
 

--- a/spec/lutaml/model/included_spec.rb
+++ b/spec/lutaml/model/included_spec.rb
@@ -94,7 +94,7 @@ module IncludedSpec
   end
 end
 
-RSpec.describe "Module Inclusion" do
+RSpec.describe "Included" do
   subject(:impl_object) do
     IncludedSpec::Implementation1.new(
       {

--- a/spec/lutaml/model/included_spec.rb
+++ b/spec/lutaml/model/included_spec.rb
@@ -151,10 +151,15 @@ RSpec.describe "Module Inclusion" do
     end
   
     it "maintains correct XML mappings through inheritance" do
-      expect(grandchild.to_xml(pretty: true))
-        .to include("<parent_name>Parent</parent_name>")
-        .and include("<child_name>Child</child_name>")
-        .and include("<grandchild_name>GrandChild</grandchild_name>")
+      expected_xml = <<~XML
+        <grandchild>
+          <parent_name>Parent</parent_name>
+          <child_name>Child</child_name>
+          <grandchild_name>GrandChild</grandchild_name>
+        </grandchild>
+      XML
+      
+      expect(grandchild.to_xml).to be_equivalent_to(expected_xml)
     end
   
     it "preserves separate mapping configurations" do

--- a/spec/lutaml/model/included_spec.rb
+++ b/spec/lutaml/model/included_spec.rb
@@ -1,0 +1,107 @@
+require "spec_helper"
+require "lutaml/model"
+
+module IncludedSpec
+  class Base
+    include Lutaml::Model::Serialize
+
+    attribute :text, Lutaml::Model::Type::String
+    attribute :id, Lutaml::Model::Type::String
+    attribute :name, Lutaml::Model::Type::String
+
+    xml do
+      map_content to: :text
+      map_attribute "id", to: :id
+      map_element "name", to: :name
+    end
+  end
+
+  class Implementation1
+    include Lutaml::Model::Serialize
+
+    attribute :text, Lutaml::Model::Type::String
+    attribute :id, Lutaml::Model::Type::String
+    attribute :name, Lutaml::Model::Type::String
+    attribute :age, Lutaml::Model::Type::Integer
+
+    xml do
+      root "impl_one"
+      map_content to: :text
+      map_attribute "id", to: :id
+      map_element "name", to: :name
+      map_element "age", to: :age
+    end
+  end
+
+  class Implementation2
+    include Lutaml::Model::Serialize
+
+    attribute :text, Lutaml::Model::Type::String
+    attribute :id, Lutaml::Model::Type::String
+    attribute :name, Lutaml::Model::Type::String
+    attribute :age, Lutaml::Model::Type::Integer
+
+    xml do
+      root "impl_two"
+      map_content to: :text
+      map_attribute "id", to: :id
+      map_element "name", to: :name
+      map_element "gender", to: :age
+    end
+  end
+end
+
+RSpec.describe "Module Inclusion" do
+  subject(:impl_object) do
+    IncludedSpec::Implementation1.new(
+      {
+        text: "Some text",
+        name: "John Doe",
+        id: "foobar",
+        age: 30,
+      },
+    )
+  end
+
+  let(:expected_xml) do
+    '<impl_one id="foobar"><name>John Doe</name><age>30</age>Some text</impl_one>'
+  end
+
+  it "uses included module attributes" do
+    expect(impl_object.to_xml(pretty: true)).to eq(expected_xml)
+  end
+
+  context "with multiple implementing classes" do
+    describe "Implementation1" do
+      let(:impl1) { IncludedSpec::Implementation1 }
+
+      it "has correct mappings" do
+        expect(impl1.mappings_for(:xml).mappings.count).to eq(4)
+      end
+
+      it "has correct attributes" do
+        expect(impl1.attributes.count).to eq(4)
+      end
+
+      it "has correct model" do
+        expect(impl1.model).to eq(impl1)
+      end
+    end
+
+    describe "Implementation2" do
+      let(:impl2) { IncludedSpec::Implementation2 }
+
+      it "has correct mappings" do
+        expect(impl2.mappings_for(:xml).mappings.count).to eq(4)
+      end
+
+      it "has correct attributes" do
+        expect(impl2.attributes.count).to eq(4)
+      end
+
+      it "has correct model" do
+        expect(impl2.model).to eq(impl2)
+      end
+    end
+  end
+end

--- a/spec/lutaml/model/serializable_spec.rb
+++ b/spec/lutaml/model/serializable_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Lutaml::Model::Serializable do
       end.to change(
         described_class, :model
       )
-        .from(nil)
+        .from(Lutaml::Model::Serializable)
         .to(SerializeableSpec::TestModel)
     end
   end

--- a/spec/lutaml/model/serializable_spec.rb
+++ b/spec/lutaml/model/serializable_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Lutaml::Model::Serializable do
       end.to change(
         described_class, :model
       )
-        .from(Lutaml::Model::Serializable)
+        .from(described_class)
         .to(SerializeableSpec::TestModel)
     end
   end


### PR DESCRIPTION
This PR fixes the error when `Lutaml::Model::Serialize` module is `included` instead of `inherited` in a model.

This error resulted from instance variables, such as `@attributes`, not being set in the `def included `method just as they were set in the `def inherited` method.

So, I created a common function for both and called it according to both implementations written in the documentation for using the gem.

Fixes: [#203 ](https://github.com/lutaml/lutaml-model/issues/203)