### PR TITLE
Fix key value requires "to:" with custom methods

### DIFF
--- a/lib/lutaml/model/serialize.rb
+++ b/lib/lutaml/model/serialize.rb
@@ -382,7 +382,7 @@ module Lutaml
             value = if doc.key?(rule.name) || doc.key?(rule.name.to_sym)
                       doc[rule.name] || doc[rule.name.to_sym]
                     else
-                      attr.default
+                      attr&.default
                     end
 
             if rule.custom_methods[:from]

--- a/spec/lutaml/model/custom_serialization_spec.rb
+++ b/spec/lutaml/model/custom_serialization_spec.rb
@@ -138,6 +138,22 @@ RSpec.describe CustomSerialization do
     end
   end
 
+  context "with partial JSON input" do
+    it "deserializes from JSON with missing attributes" do
+      json = {
+        name: "JSON Masterpiece: Vase",
+        color: "BLUE"
+      }.to_json
+  
+      ceramic = described_class.from_json(json)
+  
+      expect(ceramic.full_name).to eq("Vase")
+      expect(ceramic.color).to eq("blue")
+      expect(ceramic.size).to be_nil
+      expect(ceramic.description).to be_nil
+    end
+  end
+
   context "with XML serialization" do
     it "serializes to XML with custom methods" do
       expected_xml = <<~XML

--- a/spec/lutaml/model/custom_serialization_spec.rb
+++ b/spec/lutaml/model/custom_serialization_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe CustomSerialization do
     it "deserializes from JSON with missing attributes" do
       json = {
         name: "JSON Masterpiece: Vase",
-        color: "BLUE"
+        color: "BLUE",
       }.to_json
   
       ceramic = described_class.from_json(json)


### PR DESCRIPTION
This PR fixes the attribute from being fetched when no `to:` parameter is given in the mapping in case of missing attributes. It tries to fetch the attribute and returns `nil,` which breaks the code in the case of custom methods.

Added specs to ensure that the model instance is correctly instantiated in case of missing attributes as well.

Fixes -> [#211](https://github.com/lutaml/lutaml-model/issues/211)