### PR TITLE
Fix error with custom methods and separate model

### DIFF
--- a/lib/lutaml/model/xml_adapter/xml_document.rb
+++ b/lib/lutaml/model/xml_adapter/xml_document.rb
@@ -233,20 +233,16 @@ module Lutaml
             end
 
             process_content_mapping(element, xml_mapping.content_mapping,
-                                    prefixed_xml)
+                                    prefixed_xml, mapper_class)
           end
         end
 
-        def process_content_mapping(element, content_rule, xml)
+        def process_content_mapping(element, content_rule, xml, mapper_class)
           return unless content_rule
-
+          
           if content_rule.custom_methods[:to]
-            @root.send(
-              content_rule.custom_methods[:to],
-              element,
-              xml.parent,
-              xml,
-            )
+            mapper_class.new.send(content_rule.custom_methods[:to], element,
+                                              xml.parent, xml)
           else
             text = content_rule.serialize(element)
             text = text.join if text.is_a?(Array)

--- a/lib/lutaml/model/xml_adapter/xml_document.rb
+++ b/lib/lutaml/model/xml_adapter/xml_document.rb
@@ -239,10 +239,10 @@ module Lutaml
 
         def process_content_mapping(element, content_rule, xml, mapper_class)
           return unless content_rule
-          
+
           if content_rule.custom_methods[:to]
             mapper_class.new.send(content_rule.custom_methods[:to], element,
-                                              xml.parent, xml)
+                                  xml.parent, xml)
           else
             text = content_rule.serialize(element)
             text = text.join if text.is_a?(Array)

--- a/spec/lutaml/model/custom_model_spec.rb
+++ b/spec/lutaml/model/custom_model_spec.rb
@@ -147,6 +147,27 @@ module CustomModelSpecs
       end
     end
   end
+
+  class CustomId < Lutaml::Model::Serializable
+    model Id
+    attribute :id, :string
+    attribute :prefix, :string
+  
+    xml do
+      root "custom-id"
+      map_content with: { to: :id_to_xml, from: :id_from_xml }
+    end
+  
+    def id_to_xml(model, parent, doc)
+      content = "ABC-#{model.id}"
+      doc.add_text(doc, content)
+    end
+  
+    def id_from_xml(model, value)
+      id = value.split('-').last
+      model.id = id.to_i
+    end
+  end
 end
 
 RSpec.describe "CustomModel" do
@@ -407,4 +428,29 @@ RSpec.describe "CustomModel" do
       end
     end
   end
+
+  context "with custom methods" do
+    describe ".xml serialization" do
+      it "handles custom content mapping methods" do
+        xml = "<custom-id>ABC-123</custom-id>"
+        
+        instance = CustomModelSpecs::Id.new
+        instance.id = 123
+        result_xml = CustomModelSpecs::CustomId.to_xml(instance)
+        expect(result_xml).to eq(xml)
+
+        CustomModelSpecs::CustomId.from_xml(xml)
+      end
+    end
+
+    describe ".xml deserialization" do
+      it "handles custom content mapping methods" do
+        xml = "<custom-id>ABC-123</custom-id>"
+        instance = CustomModelSpecs::CustomId.from_xml(xml)
+
+        expect(instance.id).to eq(123)
+      end
+    end
+  end
+
 end

--- a/spec/lutaml/model/custom_model_spec.rb
+++ b/spec/lutaml/model/custom_model_spec.rb
@@ -78,7 +78,7 @@ module CustomModelSpecs
   end
 
   class Id
-    attr_accessor :id
+    attr_accessor :id, :prefix
   end
 
   class Docid < Lutaml::Model::Serializable
@@ -152,19 +152,20 @@ module CustomModelSpecs
     model Id
     attribute :id, :string
     attribute :prefix, :string
-  
+
     xml do
       root "custom-id"
+      map_attribute "prefix", to: :prefix
       map_content with: { to: :id_to_xml, from: :id_from_xml }
     end
-  
-    def id_to_xml(model, parent, doc)
+
+    def id_to_xml(model, _parent, doc)
       content = "ABC-#{model.id}"
       doc.add_text(doc, content)
     end
-  
+
     def id_from_xml(model, value)
-      id = value.split('-').last
+      id = value.split("-").last
       model.id = id.to_i
     end
   end
@@ -432,25 +433,24 @@ RSpec.describe "CustomModel" do
   context "with custom methods" do
     describe ".xml serialization" do
       it "handles custom content mapping methods" do
-        xml = "<custom-id>ABC-123</custom-id>"
-        
+        xml = '<custom-id prefix="ABC">ABC-123</custom-id>'
+
         instance = CustomModelSpecs::Id.new
         instance.id = 123
+        instance.prefix = "ABC"
         result_xml = CustomModelSpecs::CustomId.to_xml(instance)
         expect(result_xml).to eq(xml)
-
-        CustomModelSpecs::CustomId.from_xml(xml)
       end
     end
 
     describe ".xml deserialization" do
       it "handles custom content mapping methods" do
-        xml = "<custom-id>ABC-123</custom-id>"
+        xml = '<custom-id prefix="ABC">ABC-123</custom-id>'
         instance = CustomModelSpecs::CustomId.from_xml(xml)
 
         expect(instance.id).to eq(123)
+        expect(instance.prefix).to eq("ABC")
       end
     end
   end
-
 end


### PR DESCRIPTION
This PR fixes an issue with `map_content` when a separate model is used and custom methods are used with it.
Also added specs to ensure it doesn't break in the future.

fixes [#200](https://github.com/lutaml/lutaml-model/issues/200)