### PR TITLE
boolean false breaking

### DIFF
--- a/spec/address_spec.rb
+++ b/spec/address_spec.rb
@@ -100,6 +100,7 @@ RSpec.describe Address do
     expect(address_from_json.post_code).to eq("01001")
     expect(address_from_json.person.first.first_name).to eq("Tom")
     expect(address_from_json.person.last.first_name).to eq("Jack")
+    expect(address_from_json.person.last.active).to be(false)
   end
 
   it "serializes to XML with a collection of persons" do

--- a/spec/lutaml/model/type/boolean_spec.rb
+++ b/spec/lutaml/model/type/boolean_spec.rb
@@ -4,12 +4,14 @@ module BooleanSpec
   class Employee < Lutaml::Model::Serializable
     attribute :name, :string
     attribute :full_time, :boolean
+    attribute :on_leave, :boolean
     attribute :remote, :boolean
     attribute :active, :boolean
 
     key_value do
       map "name", to: :name
       map "full_time", to: :full_time
+      map "on_leave", to: :on_leave
       map "remote", to: :remote, render_nil: true
       map "active", to: :active, render_nil: false
     end
@@ -73,6 +75,7 @@ RSpec.describe Lutaml::Model::Type::Boolean do
       {
         "name" => "John Smith",
         "full_time" => true,
+        "on_leave" => false,
         "remote" => nil,
         "active" => nil,
       }.to_yaml
@@ -82,6 +85,7 @@ RSpec.describe Lutaml::Model::Type::Boolean do
       {
         "name" => "John Smith",
         "full_time" => true,
+        "on_leave" => false,
         "remote" => nil,
       }.to_yaml
     end
@@ -91,6 +95,7 @@ RSpec.describe Lutaml::Model::Type::Boolean do
 
       expect(employee.name).to eq("John Smith")
       expect(employee.full_time).to be true
+      expect(employee.on_leave).to be false
       expect(employee.remote).to be_nil
       expect(employee.active).to be_nil
     end
@@ -99,6 +104,7 @@ RSpec.describe Lutaml::Model::Type::Boolean do
       employee = BooleanSpec::Employee.new(
         name: "John Smith",
         full_time: true,
+        on_leave: false,
         remote: nil,
         active: nil,
       )

--- a/spec/lutaml/model/type/boolean_spec.rb
+++ b/spec/lutaml/model/type/boolean_spec.rb
@@ -1,5 +1,19 @@
 require "spec_helper"
 
+module BooleanSpec
+  class Employee < Lutaml::Model::Serializable
+    attribute :name, :string
+    attribute :full_time, :boolean
+    attribute :remote, :boolean
+
+    key_value do
+      map "name", to: :name
+      map "full_time", to: :full_time
+      map "remote", to: :remote
+    end
+  end
+end
+
 RSpec.describe Lutaml::Model::Type::Boolean do
   describe ".cast" do
     let(:truthy_values) { [true, "true", "t", "yes", "y", "1"] }
@@ -49,6 +63,36 @@ RSpec.describe Lutaml::Model::Type::Boolean do
     it "preserves input boolean values" do
       expect(described_class.serialize(false)).to be false
       expect(described_class.serialize(true)).to be true
+    end
+  end
+
+  context "with key-value serialization" do
+    let(:yaml) do
+      <<~YAML
+        ---
+        name: John Smith
+        full_time: true
+        remote: false
+      YAML
+    end
+
+    it "deserializes boolean values correctly" do
+      employee = BooleanSpec::Employee.from_yaml(yaml)
+
+      expect(employee.name).to eq("John Smith")
+      expect(employee.full_time).to be true
+      expect(employee.remote).to be false
+    end
+
+    it "serializes boolean values correctly" do
+      employee = BooleanSpec::Employee.new(
+        name: "John Smith",
+        full_time: true,
+        remote: false,
+      )
+
+      yaml_output = employee.to_yaml
+      expect(yaml_output).to eq(yaml)
     end
   end
 end

--- a/spec/lutaml/model/type/boolean_spec.rb
+++ b/spec/lutaml/model/type/boolean_spec.rb
@@ -5,11 +5,13 @@ module BooleanSpec
     attribute :name, :string
     attribute :full_time, :boolean
     attribute :remote, :boolean
+    attribute :active, :boolean
 
     key_value do
       map "name", to: :name
       map "full_time", to: :full_time
-      map "remote", to: :remote
+      map "remote", to: :remote, render_nil: true
+      map "active", to: :active, render_nil: false
     end
   end
 end
@@ -68,12 +70,20 @@ RSpec.describe Lutaml::Model::Type::Boolean do
 
   context "with key-value serialization" do
     let(:yaml) do
-      <<~YAML
-        ---
-        name: John Smith
-        full_time: true
-        remote: false
-      YAML
+      {
+        "name" => "John Smith",
+        "full_time" => true,
+        "remote" => nil,
+        "active" => nil,
+      }.to_yaml
+    end
+
+    let(:expected_yaml) do
+      {
+        "name" => "John Smith",
+        "full_time" => true,
+        "remote" => nil,
+      }.to_yaml
     end
 
     it "deserializes boolean values correctly" do
@@ -81,18 +91,20 @@ RSpec.describe Lutaml::Model::Type::Boolean do
 
       expect(employee.name).to eq("John Smith")
       expect(employee.full_time).to be true
-      expect(employee.remote).to be false
+      expect(employee.remote).to be_nil
+      expect(employee.active).to be_nil
     end
 
     it "serializes boolean values correctly" do
       employee = BooleanSpec::Employee.new(
         name: "John Smith",
         full_time: true,
-        remote: false,
+        remote: nil,
+        active: nil,
       )
 
       yaml_output = employee.to_yaml
-      expect(yaml_output).to eq(yaml)
+      expect(yaml_output).to eq(expected_yaml)
     end
   end
 end


### PR DESCRIPTION
This happened because `||` was used to check whether the value existed, and `false` caused it to think that the value did not exist.

fixes #225 