### PR TITLE
render nil not working for empty object

### DIFF
--- a/lib/lutaml/model/serialize.rb
+++ b/lib/lutaml/model/serialize.rb
@@ -269,15 +269,17 @@ module Lutaml
 
             value = instance.send(name)
 
-            next if Utils.blank?(value) && !rule.render_nil
-
             attribute = attributes[name]
 
-            hash[rule.from.to_s] = if rule.child_mappings
-                                     generate_hash_from_child_mappings(value, rule.child_mappings)
-                                   else
-                                     attribute.serialize(value, format, options)
-                                   end
+            value = if rule.child_mappings
+                      generate_hash_from_child_mappings(value, rule.child_mappings)
+                    else
+                      attribute.serialize(value, format, options)
+                    end
+
+            next if Utils.blank?(value) && !rule.render_nil
+
+            hash[rule.from.to_s] = value
           end
         end
 

--- a/spec/lutaml/model/render_nil_spec.rb
+++ b/spec/lutaml/model/render_nil_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe RenderNil do
       clay_type: nil,
       glaze: nil,
       dimensions: nil,
-      render_nil_nested: RenderNilNested.new
+      render_nil_nested: RenderNilNested.new,
     }
   end
 

--- a/spec/lutaml/model/render_nil_spec.rb
+++ b/spec/lutaml/model/render_nil_spec.rb
@@ -42,6 +42,7 @@ class RenderNil < Lutaml::Model::Serializable
     map "clay_type", to: :clay_type, render_nil: false
     map "glaze", to: :glaze, render_nil: true
     map "dimensions", to: :dimensions, render_nil: false
+    map "render_nil_nested", to: :render_nil_nested, render_nil: false
   end
 
   toml do
@@ -59,8 +60,10 @@ RSpec.describe RenderNil do
       clay_type: nil,
       glaze: nil,
       dimensions: nil,
+      render_nil_nested: RenderNilNested.new
     }
   end
+
   let(:model) { described_class.new(attributes) }
 
   it "serializes to JSON with render_nil option" do


### PR DESCRIPTION
The issue occurred because we checked for the nil value before converting the instance to the specified format.

fixes #226 