### PR TITLE
warn user about automatic handling of schemaLocation

### DIFF
--- a/lib/lutaml/model.rb
+++ b/lib/lutaml/model.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "model/version"
+require_relative "model/loggable"
 require_relative "model/type"
 require_relative "model/utils"
 require_relative "model/serializable"

--- a/lib/lutaml/model/attribute.rb
+++ b/lib/lutaml/model/attribute.rb
@@ -207,6 +207,8 @@ module Lutaml
       end
 
       def serialize(value, format, options = {})
+        return if value.nil?
+
         if value.is_a?(Array)
           value.map do |v|
             serialize(v, format, options)

--- a/lib/lutaml/model/loggable.rb
+++ b/lib/lutaml/model/loggable.rb
@@ -1,0 +1,15 @@
+module Lutaml
+  module Model
+    module Loggable
+      def self.included(base)
+        base.define_method :warn_auto_handling do |name|
+          caller_file = File.basename(caller_locations(2, 1)[0].path)
+          caller_line = caller_locations(2, 1)[0].lineno
+
+          str = "[Lutaml::Model] WARN: `#{name}` is handled by default. No need to explecitly define at `#{caller_file}:#{caller_line}`"
+          warn(str)
+        end
+      end
+    end
+  end
+end

--- a/lib/lutaml/model/xml_adapter/xml_document.rb
+++ b/lib/lutaml/model/xml_adapter/xml_document.rb
@@ -109,9 +109,9 @@ module Lutaml
                 prefix: attr.namespace_prefix,
                 schema_location: attr.value,
               }
-            else
-              result[attr.namespaced_name] = attr.value
             end
+
+            result[attr.namespaced_name] = attr.value
           end
 
           result
@@ -328,7 +328,7 @@ module Lutaml
                     {}
                   end
 
-          if element.respond_to?(:schema_location) && element.schema_location && !options[:except]&.include?(:schema_location)
+          if element.respond_to?(:schema_location) && element.schema_location.is_a?(Lutaml::Model::SchemaLocation) && !options[:except]&.include?(:schema_location)
             attrs.merge!(element.schema_location.to_xml_attributes)
           end
 

--- a/lib/lutaml/model/xml_mapping.rb
+++ b/lib/lutaml/model/xml_mapping.rb
@@ -3,6 +3,8 @@ require_relative "xml_mapping_rule"
 module Lutaml
   module Model
     class XmlMapping
+      include Lutaml::Model::Loggable
+
       TYPES = {
         attribute: :map_attribute,
         element: :map_element,
@@ -92,6 +94,8 @@ module Lutaml
                  nil)
       )
         validate!(name, to, with, type: TYPES[:attribute])
+        warn_auto_handling(name) if name == "schemaLocation"
+
         rule = XmlMappingRule.new(
           name,
           to: to,

--- a/spec/lutaml/model/xml_mapping_spec.rb
+++ b/spec/lutaml/model/xml_mapping_spec.rb
@@ -620,6 +620,14 @@ RSpec.describe Lutaml::Model::XmlMapping do
         it "contain schemaLocation attributes" do
           expect(Paragraph.from_xml(xml).to_xml).to be_equivalent_to(xml)
         end
+
+        it "prints warning if defined explicitly in class" do
+          error_regex = /\[Lutaml::Model\] WARN: `schemaLocation` is handled by default\. No need to explecitly define at `xml_mapping_spec.rb:\d+`/
+
+          expect do
+            Lutaml::Model::XmlMapping.new.map_attribute("schemaLocation", to: :schema_location)
+          end.to output(error_regex).to_stderr
+        end
       end
 
       context "when mixed: true" do


### PR DESCRIPTION
Warn the user about the automatic handling of `schemaLocation` and use the user-defined attribute if present.

closes #232 
closes #239 