### PR TITLE
raw true option should keep strings unescaped in to_xml output

### DIFF
--- a/lib/lutaml/model/xml_adapter/xml_document.rb
+++ b/lib/lutaml/model/xml_adapter/xml_document.rb
@@ -167,8 +167,9 @@ module Lutaml
         def add_value(xml, value, attribute, cdata: false)
           if !value.nil?
             serialized_value = attribute.type.serialize(value)
-
-            if attribute.type == Lutaml::Model::Type::Hash
+            if attribute.raw?
+              xml.add_xml_fragment(xml, value)
+            elsif attribute.type == Lutaml::Model::Type::Hash
               serialized_value.each do |key, val|
                 xml.create_and_add_element(key) do |element|
                   element.text(val)

--- a/spec/lutaml/model/custom_model_spec.rb
+++ b/spec/lutaml/model/custom_model_spec.rb
@@ -410,22 +410,9 @@ RSpec.describe "CustomModel" do
           </MixedWithNestedContent>
         XML
 
-        expected_xml = <<~XML
-          <MixedWithNestedContent>
-            <street>
-              A &lt;p&gt;b&lt;/p&gt; B &lt;p&gt;c&lt;/p&gt; C
-            </street>
-            <bibdata type="collection" schema-version="v1.2.8">
-              <title language="en">
-                JCGM Collection 1
-              </title>
-            </bibdata>
-          </MixedWithNestedContent>
-        XML
-
         bibdata = CustomModelSpecs::MixedWithNestedContent.from_xml(xml)
 
-        expect(bibdata.to_xml).to be_equivalent_to(expected_xml)
+        expect(bibdata.to_xml).to be_equivalent_to(xml)
       end
     end
   end

--- a/spec/lutaml/model/mixed_content_spec.rb
+++ b/spec/lutaml/model/mixed_content_spec.rb
@@ -539,10 +539,10 @@ RSpec.describe "MixedContent" do
         let(:expected_nokogiri_xml) do
           <<~XML
             <SpecialCharContentWithRawOptionAndMixedOption><special>
-                B &lt;p&gt;R&amp;amp;C&lt;/p&gt;
-                C &lt;p&gt;J&amp;#x2014;C&lt;/p&gt;
-                O &lt;p&gt;A &amp;amp; B &lt;/p&gt;
-                F &lt;p&gt;Z &amp;#xA9;S&lt;/p&gt;
+                B <p>R&amp;C</p>
+                C <p>J—C</p>
+                O <p>A &amp; B </p>
+                F <p>Z ©S</p>
               </special></SpecialCharContentWithRawOptionAndMixedOption>
           XML
         end
@@ -550,10 +550,10 @@ RSpec.describe "MixedContent" do
         let(:expected_ox_xml) do
           <<~XML
             <SpecialCharContentWithRawOptionAndMixedOption>
-              <special> B &lt;p&gt;R&amp;amp;C&lt;/p&gt;
-                C &lt;p&gt;J—C&lt;/p&gt;
-                O &lt;p&gt;A &amp;amp; B &lt;/p&gt;
-                F &lt;p&gt;Z ©S&lt;/p&gt;
+              <special> B <p>R&amp;C</p>
+                C <p>J—C</p>
+                O <p>A &amp; B </p>
+                F <p>Z ©S</p>
               </special>
               </SpecialCharContentWithRawOptionAndMixedOption>
           XML
@@ -562,10 +562,10 @@ RSpec.describe "MixedContent" do
         let(:expected_oga_xml) do
           <<~XML
             <SpecialCharContentWithRawOptionAndMixedOption>
-              <special> B &lt;p&gt;R&amp;C&lt;/p&gt;
-                C &lt;p&gt;J—C&lt;/p&gt;
-                O &lt;p&gt;A &amp; B &lt;/p&gt;
-                F &lt;p&gt;Z ©S&lt;/p&gt;
+              <special> B <p>R&amp;C</p>
+                C <p>J—C</p>
+                O <p>A &amp; B </p>
+                F <p>Z ©S</p>
               </special>
             </SpecialCharContentWithRawOptionAndMixedOption>
           XML
@@ -604,9 +604,9 @@ RSpec.describe "MixedContent" do
       end
 
       describe ".to_xml" do
-        let(:expected_nokogiri_xml) { "B &lt;p&gt;R&lt;/p&gt;" }
-        let(:expected_oga_xml) { "B &lt;p&gt;R&amp;C&lt;/p&gt;" }
-        let(:expected_ox_xml) { "B &lt;p&gt;R&amp;amp;C&lt;/p&gt;" }
+        let(:expected_nokogiri_xml) { "B <p>R</p>" }
+        let(:expected_oga_xml) { "B <p>R&amp;C</p>" }
+        let(:expected_ox_xml) { "B <p>R&amp;C</p>" }
 
         it "serializes special char mixed content correctly" do
           parsed = MixedContentSpec::SpecialCharContentWithRawAndMixedOption.from_xml(xml)


### PR DESCRIPTION
This PR adds fix for the unescaping of characters such as `<` and `>` when using `raw: true` option with attribute.

fixes #241 