### PR TITLE
fix: same element and attribute name issue

### DIFF
--- a/lib/lutaml/model/mapping_hash.rb
+++ b/lib/lutaml/model/mapping_hash.rb
@@ -36,6 +36,14 @@ module Lutaml
         key?("#cdata-section") || key?("text")
       end
 
+      def assign_or_append_value(key, value)
+        self[key] = if self[key]
+                      [self[key], value].flatten
+                    else
+                      value
+                    end
+      end
+
       def ordered?
         @ordered
       end

--- a/lib/lutaml/model/type/hash.rb
+++ b/lib/lutaml/model/type/hash.rb
@@ -19,18 +19,18 @@ module Lutaml
 
           hash = hash.to_h if hash.is_a?(Lutaml::Model::MappingHash)
 
-          hash = hash.except("text")
-
-          hash.transform_values do |value|
-            if value.is_a?(::Hash)
-              # Only process if value is a Hash
-              nested = normalize_hash(value)
-              # Only include non-text nodes in nested hashes if it's a hash
-              nested.is_a?(::Hash) ? nested.except("text") : nested
-            else
-              value
-            end
+          normalized_hash = hash.transform_values do |value|
+            normalize_value(value)
           end
+
+          normalized_hash["elements"] || normalized_hash
+        end
+
+        def self.normalize_value(value)
+          return value unless value.is_a?(::Hash)
+
+          nested = normalize_hash(value)
+          nested.is_a?(::Hash) ? nested.except("text") : nested
         end
 
         def self.serialize(value)

--- a/lib/lutaml/model/xml_mapping_rule.rb
+++ b/lib/lutaml/model/xml_mapping_rule.rb
@@ -107,6 +107,7 @@ module Lutaml
           prefix: prefix.dup,
           mixed_content: mixed_content,
           namespace_set: namespace_set?,
+          attribute: attribute,
           prefix_set: prefix_set?,
           default_namespace: default_namespace.dup,
         )

--- a/spec/lutaml/model/cdata_spec.rb
+++ b/spec/lutaml/model/cdata_spec.rb
@@ -118,8 +118,8 @@ module CDATA
     def child_from_xml(model, value)
       model.child_mapper ||= CustomModelChild.new
 
-      model.child_mapper.street = value["street"].text
-      model.child_mapper.city = value["city"].text
+      model.child_mapper.street = value["elements"]["street"].text
+      model.child_mapper.city = value["elements"]["city"].text
     end
   end
 

--- a/spec/lutaml/model/custom_model_spec.rb
+++ b/spec/lutaml/model/custom_model_spec.rb
@@ -56,8 +56,8 @@ class CustomModelParentMapper < Lutaml::Model::Serializable
   def child_from_xml(model, value)
     model.child_mapper ||= CustomModelChild.new
 
-    model.child_mapper.street = value["street"].text
-    model.child_mapper.city = value["city"].text
+    model.child_mapper.street = value["elements"]["street"].text
+    model.child_mapper.city = value["elements"]["city"].text
   end
 end
 
@@ -126,10 +126,10 @@ module CustomModelSpecs
 
     def bibdata_from_xml(model, value)
       model.bibdata = BibliographicItem.new(
-        "type" => value["type"],
-        "title" => value["title"],
-        "language" => value["title"]["language"],
-        "schema_version" => value["schema-version"],
+        "type" => value["attributes"]["type"],
+        "title" => value["elements"]["title"],
+        "language" => value["elements"]["title"]["attributes"]["language"],
+        "schema_version" => value["attributes"]["schema-version"],
       )
     end
 


### PR DESCRIPTION
Resolves these issue by separating the `elements`, `attributes`, and `text` in `mapping_hash`

closes #231
closes #217 