### PR TITLE
fix: missing attributes when elements have same name but different prefix

### DIFF
--- a/lib/lutaml/model/xml_adapter/nokogiri_adapter.rb
+++ b/lib/lutaml/model/xml_adapter/nokogiri_adapter.rb
@@ -124,7 +124,11 @@ module Lutaml
           end
 
           attributes = {}
-          node.attributes.transform_values do |attr|
+
+          # Using `attribute_nodes` instead of `attributes` because
+          # `attribute_nodes` handles name collisions as well
+          # More info: https://devdocs.io/nokogiri/nokogiri/xml/node#method-i-attributes
+          node.attribute_nodes.each do |attr|
             name = if attr.namespace
                      "#{attr.namespace.prefix}:#{attr.name}"
                    else


### PR DESCRIPTION
This PR contains code to fix the issue where attributes are missing when they have the same name but different prefix.
Specs are also added to ensure the functionality works correctly.

closes #254 