### PR TITLE
fix: overriding classes from lutaml type not working

### DIFF
--- a/lib/lutaml/model/attribute.rb
+++ b/lib/lutaml/model/attribute.rb
@@ -235,6 +235,8 @@ module Lutaml
           end
         elsif type <= Serialize && value.is_a?(Hash)
           type.apply_mappings(value, format, options)
+        elsif !value.nil? && !value.is_a?(type)
+          type.send(:"from_#{format}", value)
         else
           type.cast(value)
         end

--- a/lib/lutaml/model/type/decimal.rb
+++ b/lib/lutaml/model/type/decimal.rb
@@ -27,10 +27,6 @@ module Lutaml
           value.to_s("F") # Use fixed-point notation to match test expectations
         end
 
-        def self.from_xml(value)
-          cast(value.text)
-        end
-
         def self.check_dependencies!(value)
           unless defined?(BigDecimal)
             raise TypeNotEnabledError.new("Decimal", value)

--- a/lib/lutaml/model/type/time.rb
+++ b/lib/lutaml/model/type/time.rb
@@ -25,9 +25,9 @@ module Lutaml
         end
 
         # # xs:time format (HH:MM:SS.mmm±HH:MM)
-        # def to_xml
-        #   value&.strftime("%H:%M:%S%:z")
-        # end
+        def to_xml
+          value&.iso8601
+        end
 
         # # ISO8601 time format
         # def to_json

--- a/lib/lutaml/model/xml_adapter/xml_document.rb
+++ b/lib/lutaml/model/xml_adapter/xml_document.rb
@@ -161,7 +161,7 @@ module Lutaml
 
         def add_value(xml, value, attribute, cdata: false)
           if !value.nil?
-            serialized_value = attribute.type.serialize(value)
+            serialized_value = attribute.serialize(value, :xml)
             if attribute.raw?
               xml.add_xml_fragment(xml, value)
             elsif attribute.type == Lutaml::Model::Type::Hash
@@ -339,6 +339,9 @@ module Lutaml
             end
 
             value = mapping_rule.to_value_for(element)
+            attr = attribute_definition_for(element, mapping_rule, mapper_class: options[:mapper_class])
+            value = attr.serialize(value, :xml) if attr
+
             if render_element?(mapping_rule, element, value)
               hash[mapping_rule.prefixed_name] = value ? value.to_s : value
             end

--- a/spec/ceramic_spec.rb
+++ b/spec/ceramic_spec.rb
@@ -1,0 +1,39 @@
+require "spec_helper"
+require_relative "fixtures/ceramic"
+
+RSpec.describe Ceramic do
+  xml = <<~XML
+    <ceramic kilnFiringTimeAttribute="2012-04-07T01:51:37.112+02:00">
+      <kilnFiringTime>2012-04-07T01:51:37.112+02:00</kilnFiringTime>
+    </ceramic>
+  XML
+
+  it "deserializes from XML with high-precision date-time" do
+    ceramic = described_class.from_xml(xml)
+    expect(ceramic.kiln_firing_time.strftime("%Y-%m-%dT%H:%M:%S.%L%:z")).to eq("2012-04-07T01:51:37.112+02:00")
+  end
+
+  it "serializes to XML with high-precision date-time" do
+    ceramic = described_class.from_xml(xml)
+    expect(ceramic.to_xml).to be_equivalent_to(xml)
+  end
+
+  it "deserializes from JSON with high-precision date-time" do
+    json = {
+      kilnFiringTime: "2012-04-07T01:51:37+02:00",
+    }.to_json
+
+    ceramic_from_json = described_class.from_json(json)
+    expect(ceramic_from_json.kiln_firing_time).to eq(DateTime.new(2012, 4, 7, 1, 51, 37, "+02:00"))
+  end
+
+  it "serializes to JSON with high-precision date-time" do
+    ceramic = described_class.from_xml(xml)
+    expected_json = {
+      kilnFiringTime: "2012-04-07T01:51:37+02:00",
+      kilnFiringTimeAttribute: "2012-04-07T01:51:37+02:00",
+    }.to_json
+
+    expect(ceramic.to_json).to eq(expected_json)
+  end
+end

--- a/spec/fixtures/ceramic.rb
+++ b/spec/fixtures/ceramic.rb
@@ -1,0 +1,23 @@
+require "lutaml/model"
+
+class HighPrecisionDateTime < Lutaml::Model::Type::DateTime
+  def to_xml
+    value.strftime("%Y-%m-%dT%H:%M:%S.%L%:z")
+  end
+end
+
+class Ceramic < Lutaml::Model::Serializable
+  attribute :kiln_firing_time, HighPrecisionDateTime
+  attribute :kiln_firing_time_attribute, HighPrecisionDateTime
+
+  xml do
+    root "ceramic"
+    map_element "kilnFiringTime", to: :kiln_firing_time
+    map_attribute "kilnFiringTimeAttribute", to: :kiln_firing_time_attribute
+  end
+
+  json do
+    map "kilnFiringTime", to: :kiln_firing_time
+    map "kilnFiringTimeAttribute", to: :kiln_firing_time_attribute
+  end
+end

--- a/spec/lutaml/model/type_spec.rb
+++ b/spec/lutaml/model/type_spec.rb
@@ -272,5 +272,98 @@ RSpec.describe Lutaml::Model::Type do
         expect(deserialized.hash_value).to eq({ "key" => "value" })
       end
     end
+
+    describe "Serialization Of Custom Type" do
+      class CustomSerializationType < Lutaml::Model::Type::Value
+        def self.from_xml(_xml_string)
+          "from_xml_overrided"
+        end
+
+        def self.from_json(_value)
+          "from_json_overrided"
+        end
+
+        def self.serialize(_value)
+          "serialize_overrided"
+        end
+
+        def to_xml
+          "to_xml_overrided"
+        end
+
+        def to_json(*_args)
+          "to_json_overrided"
+        end
+      end
+
+      class SampleModel < Lutaml::Model::Serializable
+        attribute :custom_type, CustomSerializationType
+        xml do
+          root "sample"
+          map_element "custom_type", to: :custom_type
+        end
+        json do
+          map_element "custom_type", to: :custom_type
+        end
+      end
+
+      class SampleModelAttribute < Lutaml::Model::Serializable
+        attribute :custom_type, CustomSerializationType
+        xml do
+          root "sample"
+          map_attribute "custom_type", to: :custom_type
+        end
+        json do
+          map_element "custom_type", to: :custom_type
+        end
+      end
+
+      let(:xml) do
+        <<~XML
+          <sample>
+            <custom_type>test_string</custom_type>
+          </sample>
+        XML
+      end
+
+      let(:xml_attribute) do
+        <<~XML
+          <sample custom_type="test_string"/>
+        XML
+      end
+
+      let(:sample_instance) { SampleModel.from_xml(xml) }
+      let(:sample_instance_attribute) { SampleModelAttribute.from_xml(xml_attribute) }
+
+      it "correctly serializes to XML" do
+        expected_xml = <<~XML
+          <sample>
+            <custom_type>to_xml_overrided</custom_type>
+          </sample>
+        XML
+        expect(sample_instance.to_xml).to be_equivalent_to(expected_xml)
+      end
+
+      it "correctly serializes to XML attribute" do
+        expected_xml = <<~XML
+          <sample custom_type="to_xml_overrided"/>
+        XML
+        expect(sample_instance_attribute.to_xml).to be_equivalent_to(expected_xml)
+      end
+
+      it "correctly serializes to JSON" do
+        expect(sample_instance.to_json).to eq('{"custom_type":"to_json_overrided"}')
+      end
+
+      it "correctly deserializes from XML" do
+        expect(sample_instance.custom_type).to eq("from_xml_overrided")
+      end
+
+      it "correctly deserializes from JSON" do
+        json_sample_instance = SampleModel.from_json('{"custom_type":"test_string"}')
+        json_sample_instance.to_json
+        expect(json_sample_instance.custom_type).to eq("from_json_overrided")
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR fixes the issue of the overrided methods in the inherited classes from `Lutaml::Model::Type` not working.

closes #224, closes #199 