### PR TITLE
Fixed encoding error `UndefinedConversionError` for Ox adapter

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1409,15 +1409,10 @@ end
 
 XmlAdapter supports the encoding in the following ways:
 
-. When encoding is not passed in to_xml:
 ** Default encoding is UTF-8.
 
-. When encoding is explicitly passed nil:
-** Encoding will be nil, show the HexCode(Nokogiri) or ASCII-8bit(Ox).
-
-. When encoding is passed with some option:
-** Encoding option will be selected as passed.
-
+** When encoding is explicitly passed nil:
+*** shows the UTF-8(**Nokogiri**, **Oga**) or ASCII-8bit(**Ox**).
 
 Syntax:
 

--- a/lib/lutaml/model/xml_adapter/builder/oga.rb
+++ b/lib/lutaml/model/xml_adapter/builder/oga.rb
@@ -6,19 +6,15 @@ module Lutaml
       module Builder
         class Oga
           def self.build(options = {}, &block)
-            if block_given?
-              XmlAdapter::Builder::Oga.new(options, &block)
-            else
-              XmlAdapter::Builder::Oga.new(options)
-            end
+            new(options, &block)
           end
 
-          attr_reader :document, :current_node, :options
+          attr_reader :document, :current_node, :encoding
 
           def initialize(options = {})
             @document = XmlAdapter::Oga::Document.new
             @current_node = @document
-            @options = options
+            @encoding = options[:encoding]
             yield(self) if block_given?
           end
 
@@ -112,9 +108,14 @@ module Lutaml
           end
 
           def add_text(element, text, cdata: false)
+            text = text&.encode(encoding) if encoding && text.is_a?(String)
             return add_cdata(element, text) if cdata
 
             oga_text = ::Oga::XML::Text.new(text: text.to_s)
+            append_text_node(element, oga_text)
+          end
+
+          def append_text_node(element, oga_text)
             if element.is_a?(XmlAdapter::Oga::Document)
               children = element.children
               children.empty? ? children << oga_text : children.last.children << oga_text

--- a/lib/lutaml/model/xml_adapter/nokogiri_adapter.rb
+++ b/lib/lutaml/model/xml_adapter/nokogiri_adapter.rb
@@ -7,7 +7,7 @@ module Lutaml
     module XmlAdapter
       class NokogiriAdapter < XmlDocument
         def self.parse(xml, options = {})
-          parsed = Nokogiri::XML(xml, nil, options[:encoding])
+          parsed = Nokogiri::XML(xml, nil, encoding(xml, options))
           root = NokogiriElement.new(parsed.root)
           new(root, parsed.encoding)
         end

--- a/lib/lutaml/model/xml_adapter/oga_adapter.rb
+++ b/lib/lutaml/model/xml_adapter/oga_adapter.rb
@@ -20,7 +20,7 @@ module Lutaml
           builder_options = {}
 
           builder_options[:encoding] = if options.key?(:encoding)
-                                         options[:encoding] unless options[:encoding].nil?
+                                         options[:encoding]
                                        elsif options.key?(:parse_encoding)
                                          options[:parse_encoding]
                                        else

--- a/lib/lutaml/model/xml_adapter/oga_adapter.rb
+++ b/lib/lutaml/model/xml_adapter/oga_adapter.rb
@@ -9,7 +9,7 @@ module Lutaml
     module XmlAdapter
       class OgaAdapter < XmlDocument
         def self.parse(xml, options = {})
-          encoding = options[:encoding] || xml.encoding.to_s
+          encoding = encoding(xml, options)
           xml = xml.encode("UTF-16").encode("UTF-8") if encoding && encoding != "UTF-8"
           parsed = ::Oga.parse_xml(xml)
           @root = Oga::Element.new(parsed.children.first)
@@ -20,23 +20,23 @@ module Lutaml
           builder_options = {}
 
           builder_options[:encoding] = if options.key?(:encoding)
-                                         options[:encoding] || "UTF-8"
+                                         options[:encoding] unless options[:encoding].nil?
                                        elsif options.key?(:parse_encoding)
                                          options[:parse_encoding]
                                        else
                                          "UTF-8"
                                        end
-          builder = Builder::Oga.build(options) do |xml|
+
+          builder = Builder::Oga.build(builder_options) do |xml|
             if @root.is_a?(Oga::Element)
               @root.build_xml(xml)
             else
               build_element(xml, @root, options)
             end
           end
-          xml_data = builder.to_xml.encode!(builder_options[:encoding])
+
+          xml_data = builder.to_xml
           options[:declaration] ? declaration(options) + xml_data : xml_data
-        rescue Encoding::ConverterNotFoundError
-          invalid_encoding!(builder_options[:encoding])
         end
 
         private
@@ -93,10 +93,6 @@ module Lutaml
 
             el.add_text(el, content.join)
           end
-        end
-
-        def invalid_encoding!(encoding)
-          raise Error, "unknown encoding name - #{encoding}"
         end
       end
     end

--- a/lib/lutaml/model/xml_adapter/xml_document.rb
+++ b/lib/lutaml/model/xml_adapter/xml_document.rb
@@ -22,6 +22,14 @@ module Lutaml
           @root.children
         end
 
+        def self.encoding(xml, options)
+          if options.key?(:encoding)
+            options[:encoding]
+          else
+            xml.encoding.to_s
+          end
+        end
+
         def declaration(options)
           version = "1.0"
           version = options[:declaration] if options[:declaration].is_a?(String)

--- a/spec/lutaml/model/mixed_content_spec.rb
+++ b/spec/lutaml/model/mixed_content_spec.rb
@@ -682,19 +682,29 @@ RSpec.describe "MixedContent" do
 
         context "when encoding: nil xml" do
           let(:expected_encoding_nil_nokogiri_xml) { "&#x2211;computer security&#x220F; type of &#x200B; operation specified &#xB5; by an access right" }
-          let(:expected_encoding_nil_ox_xml) { "∑computer security∏ type of ​ operation specified µ by an access right" }
+          let(:expected_encoding_nil_ox_xml) { "<HexCode> \xE2\x88\x91computer security\xE2\x88\x8F type of \xE2\x80\x8B operation specified \xC2\xB5 by an access right </HexCode>\n".force_encoding("ASCII-8BIT") }
+          let(:expected_encoding_nil_oga_xml) { "<HexCode>\n  ∑computer security∏ type of ​ operation specified µ by an access right\n</HexCode>" }
 
           it "serializes special char mixed content correctly with encoding: nil to get hexcode" do
-            parsed = MixedContentSpec::HexCode.from_xml(xml)
+            parsed = MixedContentSpec::HexCode.from_xml(xml, encoding: nil)
             serialized = parsed.to_xml(encoding: nil)
 
             expected_output = if adapter_class == Lutaml::Model::XmlAdapter::NokogiriAdapter
                                 expected_encoding_nil_nokogiri_xml
-                              else
+                              elsif adapter_class == Lutaml::Model::XmlAdapter::OxAdapter
                                 expected_encoding_nil_ox_xml
+                              else
+                                expected_encoding_nil_oga_xml
                               end
 
-            expect(serialized.strip).to include(expected_output)
+            expect(parsed.encoding).to be_nil
+            expect(serialized.strip).to include(expected_output.strip)
+
+            if adapter_class == Lutaml::Model::XmlAdapter::OxAdapter
+              expect(serialized.encoding.to_s).to eq("ASCII-8BIT")
+            else
+              expect(serialized.encoding.to_s).to eq("UTF-8")
+            end
           end
         end
       end
@@ -724,14 +734,13 @@ RSpec.describe "MixedContent" do
           it "deserializes SHIFT encoded content incorrectly without explicit encoding option" do
             parsed = MixedContentSpec::Shift.from_xml(fixture)
 
-            expected_content = if adapter_class == Lutaml::Model::XmlAdapter::NokogiriAdapter
-                                 "�菑���p���P"
-                               elsif adapter_class == Lutaml::Model::XmlAdapter::OgaAdapter
-                                 "手書き英字１"
+            expected_content = if adapter_class == Lutaml::Model::XmlAdapter::OxAdapter
+                                 "\x8E\xE8\x8F\x91\x82\xAB\x89p\x8E\x9A\x82P".force_encoding("Shift_JIS")
                                else
-                                 "\x8E\xE8\x8F\x91\x82\xAB\x89p\x8E\x9A\x82P".force_encoding("UTF-8")
+                                 "手書き英字１"
                                end
 
+            expect(parsed.encoding).to eq("Shift_JIS")
             expect(parsed.field).to include(expected_content)
           end
         end
@@ -748,13 +757,13 @@ RSpec.describe "MixedContent" do
             parsed = MixedContentSpec::Shift.from_xml(fixture, encoding: "Shift_JIS")
             serialized = parsed.to_xml(encoding: "UTF-8")
 
-            expected_xml = if adapter_class == Lutaml::Model::XmlAdapter::OxAdapter
-                             "\x8E\xE8\x8F\x91\x82\xAB\x89p\x8E\x9A\x82P".force_encoding("Shift_JIS")
-                           else
-                             "手書き英字１"
-                           end
+            parsed_xml = if adapter_class == Lutaml::Model::XmlAdapter::OxAdapter
+                           "\x8E\xE8\x8F\x91\x82\xAB\x89p\x8E\x9A\x82P".force_encoding("Shift_JIS")
+                         else
+                           "手書き英字１"
+                         end
 
-            expect(parsed.field).to include(expected_xml)
+            expect(parsed.field).to include(parsed_xml)
             expect(parsed.encoding).to eq("Shift_JIS")
 
             expect(serialized).to include("手書き英字１")
@@ -788,16 +797,18 @@ RSpec.describe "MixedContent" do
             expect(serialized.encoding.to_s).to eq("Shift_JIS")
           end
 
-          it "serializes SHIFT-JIS content incorrectly bcz no encoding provided during parsing" do
+          it "serializes SHIFT-JIS content correctly bcz xml.encoding used during parsing" do
             parsed = MixedContentSpec::Shift.from_xml(fixture)
             serialized = parsed.to_xml(encoding: "Shift_JIS")
+
             expected_content = if adapter_class == Lutaml::Model::XmlAdapter::NokogiriAdapter
-                                 "<root>\n  <FieldName>&#65533;&#33745;&#65533;&#65533;&#65533;p&#65533;&#65533;&#65533;P</FieldName>\n  <FieldName>123456</FieldName>\n</root>"
+                                 "<root>\n  <FieldName>手書き英字１</FieldName>\n  <FieldName>123456</FieldName>\n</root>".encode("Shift_JIS")
                                elsif adapter_class == Lutaml::Model::XmlAdapter::OxAdapter
-                                 "<root>\n  <FieldName>\x8E菑\x82\xAB\x89p\x8E\x9A\x82P</FieldName>\n  <FieldName>123456</FieldName>\n</root>\n"
+                                 "<root>\n  <FieldName>手書き英字１</FieldName>\n  <FieldName>123456</FieldName>\n</root>\n".encode("Shift_JIS")
                                else
                                  "<root><FieldName>手書き英字１</FieldName><FieldName>123456</FieldName></root>".encode("Shift_JIS")
                                end
+
             expect(serialized).to eq(expected_content)
           end
 
@@ -835,21 +846,21 @@ RSpec.describe "MixedContent" do
                                  ["Müller", "José"]
                                end
 
+            expect(parsed.encoding).to eq("ISO-8859-1")
             expect(parsed.from).to eq(expected_content[0])
             expect(parsed.the).to eq(expected_content[1])
           end
 
-          it "deserializes latin encoded content incorrectly" do
+          it "deserializes latin encoded content correctly, bcz xml.encoding used for parsing" do
             parsed = MixedContentSpec::Latin.from_xml(fixture)
 
-            expected_content = if adapter_class == Lutaml::Model::XmlAdapter::NokogiriAdapter
-                                 ["M�ller", "Jos�"]
-                               elsif adapter_class == Lutaml::Model::XmlAdapter::OgaAdapter
-                                 ["Müller", "José"]
+            expected_content = if adapter_class == Lutaml::Model::XmlAdapter::OxAdapter
+                                 ["M\xFCller".force_encoding("ISO-8859-1"), "Jos\xE9".force_encoding("ISO-8859-1")]
                                else
-                                 ["M\xFCller", "Jos\xE9"]
+                                 ["Müller", "José"]
                                end
 
+            expect(parsed.encoding).to eq("ISO-8859-1")
             expect(parsed.from).to eq(expected_content[0])
             expect(parsed.the).to eq(expected_content[1])
           end


### PR DESCRIPTION
This PR fixes the `UndefinedConversionError` encoding error when the `to_xml` is called using the **Ox** adapter.

An example error fixed in the PR:
```ruby
     Encoding::UndefinedConversionError:
       "\xC2" from ASCII-8BIT to UTF-8
```

originated in unitsml/unitsml-ruby#27