### PR TITLE
fix: XML element named text not parsing

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -282,3 +282,9 @@ Style/RedundantStringEscape:
   Exclude:
     - 'lib/lutaml/model/schema/templates/simple_type.rb'
     - 'lib/lutaml/model/schema/xml_compiler.rb'
+
+# Offense count: 1
+# Configuration parameters: Max.
+Style/SafeNavigationChainLength:
+  Exclude:
+    - 'lib/lutaml/model/serialize.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -282,9 +282,3 @@ Style/RedundantStringEscape:
   Exclude:
     - 'lib/lutaml/model/schema/templates/simple_type.rb'
     - 'lib/lutaml/model/schema/xml_compiler.rb'
-
-# Offense count: 1
-# Configuration parameters: Max.
-Style/SafeNavigationChainLength:
-  Exclude:
-    - 'lib/lutaml/model/serialize.rb'

--- a/lib/lutaml/model/serialize.rb
+++ b/lib/lutaml/model/serialize.rb
@@ -548,9 +548,8 @@ module Lutaml
             doc.root.find_attribute_value(rule_names)
           else
             attr = attribute_for_rule(rule)
-
             children = doc.children.select do |child|
-              rule_names.include?(child.namespaced_name)
+              rule_names.include?(child.namespaced_name) && !child.text?
             end
 
             if rule.using_custom_methods? || attr.type == Lutaml::Model::Type::Hash

--- a/spec/lutaml/model/xml_mapping_spec.rb
+++ b/spec/lutaml/model/xml_mapping_spec.rb
@@ -57,6 +57,7 @@ module XmlMapping
   class Address < Lutaml::Model::Serializable
     attribute :street, ::Lutaml::Model::Type::String, raw: true
     attribute :city, :string, raw: true
+    attribute :text, :string
     attribute :address, Address
 
     xml do
@@ -64,6 +65,7 @@ module XmlMapping
 
       map_element "street", to: :street
       map_element "city", to: :city
+      map_element "text", to: :text
     end
   end
 
@@ -838,6 +840,7 @@ RSpec.describe Lutaml::Model::XmlMapping do
                 <p>adf</p>
               </street>
               <city><a>M</a></city>
+              <text>Building near ABC</text>
             </address>
           </person>
         XML
@@ -856,6 +859,27 @@ RSpec.describe Lutaml::Model::XmlMapping do
       it "expect to contain raw xml" do
         expect(model.address.street).to eq(expected_street)
         expect(model.address.city.strip).to eq("<a>M</a>")
+      end
+    end
+
+    context "with element named `text`" do
+      let(:input_xml) do
+        <<~XML
+          <address>
+            <street>
+              <a>N</a>
+              <p>adf</p>
+            </street>
+            <city><a>M</a></city>
+            <text>Building near ABC</text>
+          </address>
+        XML
+      end
+
+      let(:model) { XmlMapping::Address.from_xml(input_xml) }
+
+      it "expect to contain raw xml" do
+        expect(model.text).to eq("Building near ABC")
       end
     end
 


### PR DESCRIPTION
Fixed an issue where an element named `text` is not being parsed.

fixes #308 