### PR TITLE
Fix for `custom model`'s class won't initialize

### DIFF
--- a/lib/lutaml/model/attribute.rb
+++ b/lib/lutaml/model/attribute.rb
@@ -249,8 +249,8 @@ module Lutaml
 
       def cast(value, format, options = {})
         return value if type <= Serialize && value.is_a?(type.model)
-        value ||= [] if collection?
 
+        value ||= [] if collection?
         if value.is_a?(Array)
           value.map { |v| cast(v, format, options) }
         elsif type <= Serialize && (value.is_a?(Hash) || value.is_a?(Lutaml::Model::XmlAdapter::XmlElement))

--- a/lib/lutaml/model/attribute.rb
+++ b/lib/lutaml/model/attribute.rb
@@ -248,13 +248,12 @@ module Lutaml
       end
 
       def cast(value, format, options = {})
+        return value if type <= Serialize && value.is_a?(type.model)
         value ||= [] if collection?
 
         if value.is_a?(Array)
-          value.map do |v|
-            cast(v, format, options)
-          end
-        elsif type <= Serialize && value.is_a?(Hash)
+          value.map { |v| cast(v, format, options) }
+        elsif type <= Serialize && (value.is_a?(Hash) || value.is_a?(Lutaml::Model::XmlAdapter::XmlElement))
           type.apply_mappings(value, format, options)
         elsif !value.nil? && !value.is_a?(type)
           type.send(:"from_#{format}", value)

--- a/lib/lutaml/model/serialize.rb
+++ b/lib/lutaml/model/serialize.rb
@@ -535,9 +535,7 @@ module Lutaml
             rule.deserialize(instance, value, attributes, self)
           end
 
-          defaults_used.each do |attribute_name|
-            instance.using_default_for(attribute_name)
-          end
+          defaults_used.each { |attr_name| instance.using_default_for(attr_name) }
 
           instance
         end

--- a/lib/lutaml/model/serialize.rb
+++ b/lib/lutaml/model/serialize.rb
@@ -493,8 +493,9 @@ module Lutaml
 
           raise Lutaml::Model::CollectionTrueMissingError(self, option[:caller_class]) if doc.is_a?(Array)
 
+          doc_order = doc.root.order
           if instance.respond_to?(:ordered=)
-            instance.element_order = doc.root.order
+            instance.element_order = doc_order
             instance.ordered = mappings_for(:xml).ordered? || options[:ordered]
             instance.mixed = mappings_for(:xml).mixed_content? || options[:mixed_content]
           end
@@ -512,7 +513,7 @@ module Lutaml
           end
 
           defaults_used = []
-          validate_sequence!(instance.element_order)
+          validate_sequence!(doc_order)
 
           mappings.each do |rule|
             raise "Attribute '#{rule.to}' not found in #{self}" unless valid_rule?(rule)
@@ -570,7 +571,7 @@ module Lutaml
 
             values = children.map do |child|
               if !rule.using_custom_methods? && attr.type <= Serialize
-                attr.type.apply_xml_mapping(child, attr.type.new, options.except(:mappings))
+                attr.cast(child, :xml, options.except(:mappings))
               elsif attr.raw?
                 inner_xml_of(child)
               else

--- a/spec/lutaml/model/custom_model_spec.rb
+++ b/spec/lutaml/model/custom_model_spec.rb
@@ -5,10 +5,50 @@ class CustomModelChild
 end
 
 class CustomModelParent
-  attr_accessor :first_name, :middle_name, :last_name, :child_mapper
+  attr_accessor :first_name, :middle_name, :last_name, :child_mapper, :math
 
   def name
     "#{first_name} #{last_name}"
+  end
+end
+
+class GenericFormulaClass
+  attr_accessor :value
+end
+
+class Mi < Lutaml::Model::Serializable
+  model GenericFormulaClass
+
+  attribute :value, :string
+
+  xml do
+    root "mi"
+
+    map_content to: :value
+  end
+end
+
+class Mstyle < Lutaml::Model::Serializable
+  model GenericFormulaClass
+
+  attribute :value, Mi, collection: true
+
+  xml do
+    root "mstyle"
+
+    map_element :mi, to: :value
+  end
+end
+
+class MmlMath < Lutaml::Model::Serializable
+  model GenericFormulaClass
+
+  attribute :value, Mstyle, collection: true
+
+  xml do
+    root "math"
+
+    map_element :mstyle, to: :value
   end
 end
 
@@ -31,6 +71,7 @@ class CustomModelParentMapper < Lutaml::Model::Serializable
   attribute :middle_name, Lutaml::Model::Type::String
   attribute :last_name, Lutaml::Model::Type::String
   attribute :child_mapper, CustomModelChildMapper
+  attribute :math, MmlMath
 
   xml do
     map_element :first_name, to: :first_name
@@ -38,6 +79,7 @@ class CustomModelParentMapper < Lutaml::Model::Serializable
     map_element :last_name, to: :last_name
     map_element :CustomModelChild,
                 with: { to: :child_to_xml, from: :child_from_xml }
+    map_element :math, to: :math
   end
 
   def child_to_xml(model, parent, doc)
@@ -317,6 +359,11 @@ RSpec.describe "CustomModel" do
             <street>Oxford Street</street>
             <city>London</city>
           </CustomModelChild>
+          <math>
+            <mstyle>
+              <mi>Math</mi>
+            </mstyle>
+          </math>
         </CustomModelParent>
       XML
     end
@@ -333,6 +380,7 @@ RSpec.describe "CustomModel" do
         expect(instance.child_mapper.class).to eq(child_model)
         expect(instance.child_mapper.street).to eq("Oxford Street")
         expect(instance.child_mapper.city).to eq("London")
+        expect(instance.math.value.first.value.first.value).to eq("Math")
       end
     end
 


### PR DESCRIPTION
This PR fixes the behavior of the `model` function in the **Serializable** class. 

should fix plurimath/plurimath#339