### PR TITLE
make validation flow consistent

### DIFF
--- a/lib/lutaml/model/validation.rb
+++ b/lib/lutaml/model/validation.rb
@@ -6,13 +6,14 @@ module Lutaml
         self.class.attributes.each do |name, attr|
           value = public_send(:"#{name}")
           begin
-            if value.respond_to?(:validate!)
-              value.validate!
+            if value.respond_to?(:validate)
+              errors.concat(value.validate)
             else
               attr.validate_value!(value)
             end
           rescue Lutaml::Model::InvalidValueError,
                  Lutaml::Model::CollectionCountOutOfRangeError,
+                 Lutaml::Model::CollectionTrueMissingError,
                  PatternNotMatchedError => e
             errors << e
           end


### PR DESCRIPTION
This PR will make validation flow consistent by not calling `validate!` inside `validate` method as explained by @ronaldtse in this [comment](https://github.com/lutaml/lutaml-model/issues/282#issuecomment-2627815943)
> I agree that this trace is weird because validate should not call validate!. Seems like a bug to me.

closes #282 