### PR TITLE
chore: add example specs for custom adapters

### DIFF
--- a/spec/lutaml/model/custom_bibtex_adapter_spec.rb
+++ b/spec/lutaml/model/custom_bibtex_adapter_spec.rb
@@ -1,0 +1,525 @@
+# = BibTeX Support in Lutaml::Model
+#
+# This extension adds support for BibTeX format serialization and deserialization
+# to Lutaml::Model. While BibTeX is traditionally used for academic citations,
+# its structured format makes it suitable for storing various types of information models.
+#
+# == Key Benefits of BibTeX Format
+#
+# - Built-in support for structured data with fields and values
+# - Natural handling of collections (like authors, dependencies, ingredients)
+# - Familiar citation key system for unique identification
+# - Human-readable text format for easy version control
+# - Extensive tooling support for parsing and manipulation
+#
+# == Basic Setup
+#
+# To use BibTeX format in your model:
+#
+# 1. Include necessary field classes based on your needs:
+#    - BibtexFieldAuthor - For handling names (authors, maintainers, manufacturers)
+#    - BibtexFieldYear - For handling dates and ranges
+#    - BibtexFieldPage - For handling numeric ranges
+#
+# 2. Define your model class inheriting from Lutaml::Model::Serializable
+#
+# 3. Register BibTeX format:
+#
+#    Lutaml::Model::Config.register_format(
+#      :bibtex,
+#      mapping_class: BibtexMapping,
+#      adapter_class: BibtexAdapter
+#    )
+#
+# 4. Define BibTeX mappings using the `bibtex do` block:
+#
+#    bibtex do
+#      map_entry_type to: :entry_type     # Maps entry type (e.g., @article, @book)
+#      map_citekey to: :citekey           # Maps unique identifier
+#      map_field "author", to: :author    # Maps fields to model attributes
+#      map_field "title", to: :title
+#      # Add other field mappings as needed
+#    end
+#
+# == Mapping Methods
+#
+# The bibtex block supports these mapping methods:
+#
+# - map_entry_type: Maps the entry type (e.g., @article, @book)
+# - map_citekey: Maps the unique identifier
+# - map_field: Maps fields to model attributes
+#   Options:
+#   - to: Target attribute name
+#   - render_nil: Whether to render nil values (default: false)
+#
+# == Examples
+#
+# === 1. Traditional Academic Citation
+#
+#   class Publication < Lutaml::Model::Serializable
+#     attribute :entry_type, :string, values: %w[article book inproceedings]
+#     attribute :citekey, :string
+#     attribute :author, BibtexFieldAuthor
+#     attribute :title, :string
+#     attribute :journal, :string
+#     attribute :year, BibtexFieldYear
+#
+#     bibtex do
+#       map_entry_type to: :entry_type
+#       map_citekey to: :citekey
+#       map_field "author", to: :author
+#       map_field "title", to: :title
+#       map_field "journal", to: :journal
+#       map_field "year", to: :year
+#     end
+#   end
+#
+# Usage:
+#   entry = Publication.from_bibtex(bibtex_string)
+#   bibtex_string = entry.to_bibtex
+#
+# === 2. Software Components Registry
+#
+# BibTeX's structured format works well for tracking software components:
+#
+#   class Component < Lutaml::Model::Serializable
+#     attribute :entry_type, :string, values: %w[library framework tool service]
+#     attribute :citekey, :string  # Unique identifier
+#     attribute :name, :string
+#     attribute :maintainers, BibtexFieldAuthor, collection: true
+#     attribute :version, :string
+#     attribute :dependencies, :string, collection: true
+#     attribute :license, :string
+#
+#     bibtex do
+#       map_entry_type to: :entry_type
+#       map_citekey to: :citekey
+#       map_field "name", to: :name
+#       map_field "maintainers", to: :maintainers
+#       map_field "version", to: :version
+#       map_field "dependencies", to: :dependencies
+#       map_field "license", to: :license
+#     end
+#   end
+#
+# === 3. Equipment Inventory
+#
+#   class Equipment < Lutaml::Model::Serializable
+#     attribute :entry_type, :string, values: %w[machine tool vehicle equipment]
+#     attribute :citekey, :string  # Asset ID
+#     attribute :model, :string
+#     attribute :manufacturer, BibtexFieldAuthor
+#     attribute :purchase_date, BibtexFieldYear
+#     attribute :location, :string
+#     attribute :maintenance_history, :string, collection: true
+#
+#     bibtex do
+#       map_entry_type to: :entry_type
+#       map_citekey to: :citekey
+#       map_field "model", to: :model
+#       map_field "manufacturer", to: :manufacturer
+#       map_field "purchase_date", to: :purchase_date
+#       map_field "location", to: :location
+#       map_field "maintenance_history", to: :maintenance_history
+#     end
+#   end
+#
+# === 4. Recipe Database
+#
+#   class Recipe < Lutaml::Model::Serializable
+#     attribute :entry_type, :string, values: %w[appetizer main dessert beverage]
+#     attribute :citekey, :string  # Recipe ID
+#     attribute :name, :string
+#     attribute :chef, BibtexFieldAuthor
+#     attribute :prep_time, :string
+#     attribute :ingredients, :string, collection: true
+#     attribute :instructions, :string, collection: true
+#     attribute :servings, :string
+#
+#     bibtex do
+#       map_entry_type to: :entry_type
+#       map_citekey to: :citekey
+#       map_field "name", to: :name
+#       map_field "chef", to: :chef
+#       map_field "prep_time", to: :prep_time
+#       map_field "ingredients", to: :ingredients
+#       map_field "instructions", to: :instructions
+#       map_field "servings", to: :servings
+#     end
+#   end
+#
+require "spec_helper"
+
+# This is a custom BibTeX adapter that can serialize and deserialize BibTeX
+# entries. It is used to demonstrate how to create a custom adapter for a
+# specific format.
+#
+
+module CustomBibtexAdapterSpec
+  class BibtexAdapter < Lutaml::Model::SerializationAdapter
+    handles_format :bibtex
+    document_class BibtexDocument
+  end
+
+  class BibtexDocument
+    attr_reader :attributes
+
+    def initialize(attributes = {}, options = {})
+      @attributes = attributes
+      @mapping = options.delete(:mapping)
+    end
+
+    def [](key)
+      @attributes[key]
+    end
+
+    def []=(key, value)
+      @attributes[key] = value
+    end
+
+    def to_h
+      @attributes
+    end
+
+    def self.parse(bibtex_data, _options = {})
+      mapping = options.delete(:mapping)
+      entries = bibtex_data.scan(/@(\w+)\{([^,]*),(.*?)\}/m).map do |type, key, fields|
+        BibtexDocumentEntry.parse(type, key, fields, mapping)
+      end
+
+      new(entries)
+    end
+
+    def to_bibtex(*)
+      @attributes.map do |entry|
+        entry.to_bibtex
+      end.join("\n")
+    end
+  end
+
+  class BibtexDocumentEntry
+    attr_reader :entry_type, :citekey, :fields, :mapping
+
+    def initialize(entry_type:, citekey:, fields:, mapping: nil)
+      @entry_type = entry_type
+      @citekey = citekey
+      @fields = fields
+      @mapping = mapping
+    end
+
+    def self.parse(type, key, fields, mapping)
+      fields_hash = fields.scan(/(\w+)\s*=\s*[{"](.+?)[}"]/m).to_h
+      new(
+        entry_type: type.downcase,
+        citekey: key.strip,
+        fields: fields_hash.transform_keys(&:downcase),
+        mapping: mapping,
+      )
+    end
+
+    def to_bibtex(*)
+      <<~BIBTEX
+        @#{entry_type}{#{citekey},
+        #{fields.map { |k, v| "#{k} = {#{v}}" }.join(",\n")}
+        }
+      BIBTEX
+    end
+  end
+
+  class BibtexMappingRule < Lutaml::Model::MappingRule
+    # Can be :entry_type, :citekey, or :field
+    attr_reader :field_type
+
+    def initialize(
+      name,
+      to:,
+      render_nil: false,
+      render_default: false,
+      with: {},
+      delegate: nil,
+      field_type: :field,
+      transform: {}
+    )
+      super(name, to: to, render_nil: render_nil, render_default: render_default,
+                  with: with, delegate: delegate, transform: transform)
+      @field_type = field_type
+    end
+
+    def deep_dup
+      self.class.new(
+        name.dup,
+        to: to.dup,
+        render_nil: render_nil.dup,
+        with: Utils.deep_dup(custom_methods),
+        delegate: delegate,
+        field_type: field_type,
+        transform: Utils.deep_dup(transform),
+      )
+    end
+  end
+
+  class BibtexMapping < Lutaml::Model::Mapping
+    attr_reader :mappings
+
+    def initialize
+      super
+      @mappings = []
+    end
+
+    def map_entry_type(name, to:)
+      add_mapping(name, to, field_type: :entry_type)
+    end
+
+    def map_citekey(name, to:)
+      add_mapping(name, to, field_type: :citekey)
+    end
+
+    def map_field(name, to:, render_nil: false)
+      add_mapping(name, to, field_type: :field, render_nil: render_nil)
+    end
+
+    private
+
+    def add_mapping(name, to, **options)
+      validate!(name, to, {})
+      @mappings << BibtexMappingRule.new(name, to: to, **options)
+    end
+
+    def mapping_for_field(field)
+      @mappings.find { |m| m.name == field }
+    end
+
+    # Assume we have a method `model_class` set at the Lutaml::Model::Mapping level
+    def data_to_model(data) # a BibtexDocumentEntry object
+      entry_type = data[mapping_for_field(:entry_type).to]
+      citekey = data[mapping_for_field(:citekey).to]
+      fields = mapping.mappings.each_with_object({}) do |m, acc|
+        next if %i[entry_type citekey].include?(m.field_type)
+
+        acc[m.to] = data[m.name]
+      end
+
+      model_class.new(
+        entry_type: entry_type,
+        citekey: citekey,
+        **fields,
+      )
+    end
+
+    def model_to_data(model) # a BibtexEntry object
+      entry_type = model.entry_type
+      citekey = model.citekey
+      fields = mapping.mappings.each_with_object({}) do |m, acc|
+        next if %i[entry_type citekey].include?(m.field_type)
+
+        acc[m.name] = model.send(m.to)
+      end
+
+      BibtexDocumentEntry.new(
+        entry_type: entry_type,
+        citekey: citekey,
+        fields: fields,
+      )
+    end
+
+    def validate_mapping
+      entry_type = @mappings.find { |m| m.field_type == :entry_type }
+      raise "Entry type mapping is required" unless entry_type
+
+      cite_key = @mappings.find { |m| m.field_type == :citekey }
+      raise "Cite key mapping is required" unless cite_key
+    end
+  end
+
+  # Define BibTeX field classes
+  class BibtexFieldPage < Lutaml::Model::Serializable
+    attribute :first, :string
+    attribute :last, :string
+
+    def to_bibtex
+      first && last ? "#{first}--#{last}" : (first || last || "")
+    end
+  end
+
+  class BibtexFieldAuthor < Lutaml::Model::Serializable
+    attribute :given, :string    # First name
+    attribute :family, :string   # Last name
+    attribute :particle, :string # Particle (von, van, de, etc.)
+    attribute :suffix, :string   # Suffix (Jr., III, etc.)
+
+    def self.from_bibtex(value)
+      parts = value.split(/\s+and\s+/)
+      parts.map do |part|
+        given, family = part.split(/\s*,\s*/)
+        particle, family = family.split(/\s+/) if family&.include?(" ")
+        suffix = family.split(/\s+/).last if family&.include?(" ")
+        BibtexFieldAuthor.new(given: given, family: family, particle: particle, suffix: suffix)
+      end
+    end
+
+    def to_bibtex
+      [
+        particle,
+        family,
+        ",",
+        suffix,
+        given,
+      ].compact.join(" ")
+    end
+  end
+
+  class BibtexFieldAuthorCollection < Lutaml::Model::Collection
+    instance BibtexFieldAuthor
+
+    # BibTeX uses "and" to separate authors
+    def self.from_bibtex(value)
+      authors = value.split(/\s+and\s+/)
+      authors.map do |author|
+        BibtexFieldAuthor.from_bibtex(author)
+      end
+    end
+
+    def to_bibtex
+      authors.map(&:to_bibtex).join(" and ")
+    end
+  end
+
+  class BibtexFieldYear < Lutaml::Model::Serializable
+    attribute :from, :string
+    attribute :to, :string
+
+    def self.from_bibtex(value)
+      # If the year is a range, split it into from and to parts
+      # Otherwise, set the from part and leave the to part empty
+      # BibtexFieldYear.
+      if value.include?("--")
+        from, to = value.split("--")
+        BibtexFieldYear.new(from: from, to: to)
+      else
+        BibtexFieldYear.new(from: value)
+      end
+    end
+
+    def to_bibtex
+      from && to ? "#{from}--#{to}" : (from || to || "")
+    end
+  end
+
+  # Define BibTeX entry class
+  class BibtexEntry < Lutaml::Model::Serializable
+    attribute :entry_type, :string, values: %w[
+      article book inproceedings conference phdthesis
+      mastersthesis techreport manual misc
+    ]
+    attribute :citekey, :string
+    attribute :author, BibtexFieldAuthor, collection: BibtexFieldAuthorCollection
+    attribute :title, :string
+    attribute :journal, :string
+    attribute :year, BibtexFieldYear
+    attribute :volume, :string
+    attribute :number, :string
+    attribute :pages, BibtexFieldPage
+
+    # Register BibTeX format
+    Lutaml::Model::Config.register_format(
+      :bibtex,
+      mapping_class: BibtexMapping,
+      adapter_class: BibtexAdapter,
+    )
+
+    # Define BibTeX mappings
+    bibtex do
+      map_entry_type to: :entry_type
+      map_citekey to: :citekey
+      map_field "author", to: :author
+      map_field "title", to: :title
+      map_field "journal", to: :journal
+      map_field "year", to: :year
+      map_field "volume", to: :volume
+      map_field "number", to: :number, render_nil: true
+      map_field "pages", to: :pages
+    end
+  end
+end
+
+RSpec.describe "Custom BibTeX adapter" do
+  let(:article) do
+    CustomBibtexAdapterSpec::BibtexEntry.new(
+      entry_type: "book",
+      citekey: "schenck1997",
+      title: "The EXPRESS way",
+      author: [
+        CustomBibtexAdapterSpec::BibtexFieldAuthor.new(given: "Doug", family: "Schenck"),
+        CustomBibtexAdapterSpec::BibtexFieldAuthor.new(given: "Peter", family: "Wilson"),
+      ],
+      year: CustomBibtexAdapterSpec::BibtexFieldYear.new(from: "1997"),
+      publisher: "Addison-Wesley",
+      address: "Reading, Massachusetts",
+      pages: "1--100",
+    )
+  end
+
+  let(:bibtex_string) do
+    <<~BIBTEX
+      @book{schenck1997,
+        title = {The EXPRESS way},
+        author = {Doug Schenck and Peter Wilson},
+        year = {1997},
+        publisher = {Addison-Wesley},
+        address = {Reading, Massachusetts},
+        pages = {1--100}
+      }
+
+      @misc{iso10303-11,
+        author = {ISO/TC 184/SC 4},
+        title = {Industrial automation systems and integration -- Product data representation and exchange -- Part 11: Description methods: The EXPRESS language reference manual},
+        year = {2004},
+        url = {https://www.iso.org/standard/38051.html},
+        publisher = {ISO},
+        address = {Geneva, Switzerland}
+      }
+    BIBTEX
+  end
+
+  describe "#to_bibtex" do
+    it "serializes to BibTeX format" do
+      expect(article.to_bibtex.gsub(/\s+/, " ").strip).to eq(
+        bibtex_string.gsub(/\s+/, " ").strip,
+      )
+    end
+  end
+
+  describe ".from_bibtex" do
+    it "deserializes from BibTeX format" do
+      result = CustomBibtexAdapterSpec::BibtexEntry.from_bibtex(bibtex_string)
+
+      expect(result.size).to eq(2)
+
+      result[0].tap do |book|
+        expect(book.entry_type).to eq("book")
+        expect(book.citekey).to eq("schenck1997")
+        expect(book.title).to eq("The EXPRESS way")
+        expect(book.author.size).to eq(2)
+        expect(book.author[0].given).to eq("Doug")
+        expect(book.author[0].family).to eq("Schenck")
+        expect(book.author[1].given).to eq("Peter")
+        expect(book.author[1].family).to eq("Wilson")
+        expect(book.year.from).to eq("1997")
+        expect(book.publisher).to eq("Addison-Wesley")
+        expect(book.address).to eq("Reading, Massachusetts")
+      end
+
+      result[1].tap do |misc|
+        expect(misc.entry_type).to eq("misc")
+        expect(misc.citekey).to eq("iso10303-11")
+        expect(misc.title).to eq("Industrial automation systems and integration -- Product data representation and exchange -- Part 11: Description methods: The EXPRESS language reference manual")
+        expect(misc.author.size).to eq(1)
+        expect(misc.author[0].given).to eq("ISO/TC 184/SC 4")
+        expect(misc.year.from).to eq("2004")
+        expect(misc.url).to eq("https://www.iso.org/standard/38051.html")
+        expect(misc.publisher).to eq("ISO")
+        expect(misc.address).to eq("Geneva, Switzerland")
+      end
+    end
+  end
+end

--- a/spec/lutaml/model/custom_vobject_adapter_spec.rb
+++ b/spec/lutaml/model/custom_vobject_adapter_spec.rb
@@ -1,0 +1,996 @@
+# The vObject Serialization Format for Lutaml::Model
+#
+# This module provides support for serializing and deserializing models to/from
+# vObject format, a text-based data format used by standards like vCard and iCalendar.
+#
+# == Basic Usage
+#
+# To use vObject serialization in your models:
+#
+#   class MyModel < Lutaml::Model::Serializable
+#     attribute :field1, :string
+#     attribute :field2, :string
+#
+#     vobject do
+#       type :component          # Declare as component (like VCARD, VCALENDAR)
+#       component_root "MYCOMP"  # Root component name
+#
+#       # Map vObject properties to model attributes
+#       map_property "PROP1", to: :field1
+#       map_property "PROP2", to: :field2
+#     end
+#   end
+#
+# == Creating Custom Components
+#
+# For non-standardized vObject components:
+#
+#   class MyCustomComponent < Lutaml::Model::Serializable
+#     attribute :name, :string
+#     attribute :details, MyCustomDetails
+#
+#     vobject do
+#       type :component
+#       component_root "X-CUSTOM"  # Use X- prefix for custom components
+#
+#       map_property "X-NAME", to: :name
+#       map_property "X-DETAILS", to: :details, type: :structured
+#     end
+#   end
+#
+# == Custom Properties
+#
+# Define custom properties with parameters:
+#
+#   class MyCustomProperty < Lutaml::Model::Serializable
+#     attribute :value, :string
+#     attribute :param1, :string
+#     attribute :param2, :integer
+#
+#     vobject do
+#       type :property
+#       property_name "X-CUSTOM-PROP"
+#
+#       map_value to: :value
+#       map_property "PARAM1", to: :param1
+#       map_property "PARAM2", to: :param2
+#     end
+#   end
+#
+# == Value Types
+#
+# Support for different value types:
+#
+# - Text (default)
+# - URI
+# - Binary (Base64)
+# - Boolean
+# - Integer
+# - Float
+# - UTC-Offset
+# - Language-Tag
+# - IsoDateAndOrTime
+#
+# == Custom Value Types
+#
+# Create custom value types by extending VobjectValueType::Base:
+#
+#   class MyCustomValue < VobjectValueType::Base
+#     def valid?
+#       # Add validation logic
+#     end
+#   end
+#
+# == Structured Values
+#
+# For properties with multiple fields:
+#
+#   vobject do
+#     type :property
+#     property_name "X-STRUCTURED"
+#
+#     map_field_set count: 3, item_type: :list
+#     map_field 0, to: :first_field
+#     map_field 1, to: :second_field
+#     map_field 2, to: :third_field
+#   end
+#
+# == Registration
+#
+# Register your custom format:
+#
+#   Lutaml::Model::Config.register_format(
+#     :vobject,
+#     mapping_class: YourMapping,
+#     adapter_class: YourAdapter
+#   )
+#
+# == Component Types
+#
+# Four types of elements are supported:
+# - :component - Container components like VCARD
+# - :property - Properties with values and parameters
+# - :property_parameter - Parameters for properties
+# - :property_group - Grouping of related properties
+require "spec_helper"
+
+module CustomVojectAdapterSpec
+  class VobjectAdapter < Lutaml::Model::SerializationAdapter
+    handles_format :vobject
+    document_class Document
+  end
+
+  class VobjectDocument
+    attr_reader :objects
+
+    def initialize(objects = [])
+      @objects = objects
+    end
+
+    def self.parse(vobject_data, _options = {})
+      parser = Parser.new(vobject_data)
+      new(parser.parse)
+    end
+
+    def to_vobject
+      objects.map do |obj|
+        [
+          "BEGIN:#{obj.name}",
+          *obj.properties.flat_map { |prop, entries| format_entries(prop, entries) },
+          "END:#{obj.name}",
+        ].join("\n")
+      end.join("\n\n")
+    end
+
+    private
+
+    def format_entries(prop, entries)
+      entries.map do |entry|
+        params = entry[:params].map { |k, v| "#{k}=#{v}" }.join(";")
+        prop_line = params.empty? ? prop : "#{prop};#{params}"
+        "#{prop_line}:#{entry[:value]}"
+      end
+    end
+  end
+
+  class VobjectParser
+    def initialize(data)
+      @data = data
+      @current_object = nil
+      @objects = []
+    end
+
+    def parse
+      @data.each_line do |line|
+        line.chomp!
+        process_line(line)
+      end
+      @objects
+    end
+
+    private
+
+    def process_line(line)
+      case line
+      when /^BEGIN:/
+        @current_object = { name: line.split(":", 2).last, properties: {} }
+      when /^END:/
+        @objects << @current_object
+        @current_object = nil
+      else
+        add_property(line) if @current_object
+      end
+    end
+
+    def add_property(line)
+      prop_part, value = line.split(":", 2)
+      name, params = parse_property(prop_part)
+      @current_object[:properties][name] ||= []
+      @current_object[:properties][name] << { value: value, params: params }
+    end
+
+    def parse_property(prop_part)
+      parts = prop_part.split(";")
+      name = parts.shift.downcase
+      params = parts.each_with_object({}) do |part, hash|
+        k, v = part.split("=")
+        hash[k.downcase] = v
+      end
+      [name, params]
+    end
+  end
+
+  class VobjectMapping < Lutaml::Model::Mapping
+    def initialize
+      super
+      @structure_definitions = {}
+      @component_root = nil
+      @property_root = nil
+      @element_type = nil
+    end
+
+    def component_root(name)
+      @component_root = name
+    end
+
+    def property_root(name)
+      @property_root = name
+    end
+
+    def type(element_type)
+      unless %i[component property property_parameter property_group].include?(element_type)
+        raise ArgumentError, "Invalid element type: #{element_type}"
+      end
+
+      @element_type = element_type
+    end
+
+    def map_value(to:, **options)
+      add_mapping(:value, to, type: :simple, **options)
+    end
+
+    def map_property(name, to:, type: :simple, **options)
+      add_mapping(name.downcase, to, type: type, **options)
+    end
+
+    def map_component(name, to:, **options)
+      add_mapping(name.downcase, to, type: :component, **options)
+    end
+
+    def map_field_set(count:, item_type:, item_options: {})
+      @field_set = {
+        count: count,
+        item_type: item_type,
+        options: item_options,
+      }
+    end
+
+    def map_field(index, to:, **options)
+      validate!(index, to, options)
+      @mappings << FieldMappingRule.new(
+        index,
+        to: to,
+        type: @field_set[:item_type],
+        options: @field_set[:options].merge(options),
+      )
+    end
+
+    private
+
+    def add_mapping(name, to, **options)
+      validate!(name, to, options)
+      @mappings << VobjectMappingRule.new(
+        name,
+        to: to,
+        type: options[:type],
+        structure: @structure_definitions[to],
+        options: options,
+      )
+    end
+  end
+
+  class VobjectMappingRule < Lutaml::Model::MappingRule
+    attr_reader :structure, :type, :options
+
+    def initialize(name, to:, type: :simple, structure: nil, options: {})
+      super(name, to: to)
+      @type = type
+      @structure = structure
+      @options = options
+    end
+  end
+
+  class FieldMappingRule < VobjectMappingRule
+    def initialize(index, to:, type:, options: {})
+      super
+    end
+  end
+
+  module ElementType
+    COMPONENT = :component
+    PROPERTY = :property
+    PROPERTY_PARAMETER = :property_parameter
+    PROPERTY_GROUP = :property_group
+  end
+
+  module ValueType
+    PROPERTY_VALUE = :property_value
+    PARAMETER_VALUE = :parameter_value
+  end
+
+  class Vcard < Lutaml::Model::Serializable
+    attribute :version, :string
+    attribute :fn, :string
+    attribute :n, VcardName
+    attribute :tel, VcardTel, collection: true
+    attribute :email, :string, collection: true
+    attribute :org, :string
+    attribute :bday, VcardBday # Using the enhanced VcardBday class
+
+    vobject do
+      type :component
+      component_root "VCARD"
+
+      map_property "VERSION", to: :version
+      map_property "FN", to: :fn
+      map_property "N", to: :n, type: :structured
+      map_property "TEL", to: :tel
+      map_property "EMAIL", to: :email
+      map_property "ORG", to: :org
+      map_property "BDAY", to: :bday
+    end
+
+    Lutaml::Model::Config.register_format(
+      :vobject,
+      mapping_class: CustomBibtexAdapterSpec::VobjectMapping,
+      adapter_class: CustomBibtexAdapterSpec::VobjectAdapter,
+    )
+  end
+
+  module VobjectValueType
+    class Base < Lutaml::Model::Value
+      attr_accessor :element_type
+
+      def initialize(value)
+        super
+        @element_type = :property_value
+      end
+
+      def as_property_value
+        @element_type = :property_value
+        self
+      end
+
+      def as_parameter_value
+        @element_type = :parameter_value
+        self
+      end
+    end
+
+    class Text < Base
+    end
+
+    # URI as defined in Section 3 of [RFC3986]
+    class Uri < Base
+      def valid?
+        uri = URI.parse(@value)
+        !!(uri.scheme && uri.host)
+      rescue URI::InvalidURIError
+        false
+      end
+    end
+
+    class Binary < Base
+      def valid?
+        Base64.strict_encode64(Base64.strict_decode64(@value)) == @value
+      rescue ArgumentError
+        false
+      end
+    end
+
+    class IsoDateAndOrTime < Base
+      attr_reader :type
+
+      def initialize(value)
+        super
+        @type = detect_type(value)
+      end
+
+      private
+
+      def detect_type(value)
+        case value
+        when /^\d{8}T\d{6}(Z|[+-]\d{4})?$/,
+             /^--\d{4}T\d{4}$/,
+             /^---\d{2}T\d{2}$/,
+             /^T\d{6}(Z|[+-]\d{4})?$/,
+             /^T\d{4}$/,
+             /^T\d{2}$/,
+             /^T-\d{4}$/,
+             /^T--\d{2}$/
+          :date_time
+        when /^\d{8}$/,
+             /^\d{6}$/,
+             /^\d{4}$/,
+             /^--\d{4}$/,
+             /^---\d{2}$/
+          :date
+        else
+          :text
+        end
+      end
+    end
+
+    class Boolean < Base
+      VALID_VALUES = %w[TRUE FALSE true false].freeze
+
+      def initialize(value)
+        super(value.to_s.upcase)
+      end
+
+      def valid?
+        VALID_VALUES.include?(@value)
+      end
+
+      def to_bool
+        @value.upcase == "TRUE"
+      end
+    end
+
+    class Integer < Lutaml::Model::Value::Integer
+    end
+
+    class Float < Lutaml::Model::Value::Float
+    end
+
+    class UtcOffset < Base
+      def valid?
+        @value.match?(/^[+-]\d{4}$/)
+      end
+
+      def hours
+        @value[1..2].to_i * (@value[0] == "-" ? -1 : 1)
+      end
+
+      def minutes
+        @value[3..4].to_i * (@value[0] == "-" ? -1 : 1)
+      end
+    end
+
+    # Language-Tag as defined in [RFC5646]
+    class Language < Base
+      def valid?
+        # Basic validation for language tags
+        @value.match?(/^[a-zA-Z]{2,3}(-[a-zA-Z]{2,3})?$/)
+      end
+    end
+  end
+
+  class VcardBday < Lutaml::Model::Serializable
+    attribute :value, VobjectValueType::IsoDateAndOrTime
+
+    vobject do
+      type :property
+      property_name "BDAY"
+      map_value to: :value
+    end
+
+    def value_type
+      value.type
+    end
+  end
+
+  class VcardTel < Lutaml::Model::Serializable
+    attribute :value, :string
+    attribute :type, :string
+    attribute :pref, :integer
+
+    vobject do
+      type :property
+      property_name "TEL"
+
+      map_property "TYPE", to: :type
+      map_property "PREF", to: :pref
+      map_value to: :value
+    end
+  end
+
+  class VcardName < Lutaml::Model::Serializable
+    attribute :family, :string
+    attribute :given, :string
+    attribute :additional, :string
+    attribute :prefix, :string
+    attribute :suffix, :string
+
+    vobject do
+      type :property
+      property_name "N"
+
+      map_field_set(
+        count: 5,
+        item_type: :list,
+        item_options: { type: :text },
+      )
+      map_field 0, to: :family
+      map_field 1, to: :given
+      map_field 2, to: :additional
+      map_field 3, to: :prefix
+      map_field 4, to: :suffix
+    end
+  end
+
+  class VobjectPropertyValue
+    def self.parse(value_str, value_type = nil, element_type = :property_value)
+      unless %i[property_value parameter_value].include?(element_type)
+        raise ArgumentError, "Invalid element type: #{element_type}"
+      end
+
+      value = case value_type&.upcase
+              when "URI" then VobjectValueType::Uri.new(value_str)
+              when "BINARY" then VobjectValueType::Binary.new(value_str)
+              when "BOOLEAN" then VobjectValueType::Boolean.new(value_str)
+              when "INTEGER" then VobjectValueType::Integer.new(value_str)
+              when "FLOAT" then VobjectValueType::Float.new(value_str)
+              when "UTC-OFFSET" then VobjectValueType::UtcOffset.new(value_str)
+              when "LANGUAGE-TAG" then VobjectValueType::Language.new(value_str)
+              when "DATE", "DATE-TIME", "DATE-AND-OR-TIME"
+                VobjectValueType::IsoDateAndOrTime.new(value_str)
+              else
+                # Default to Text type for nil or "TEXT"
+                VobjectValueType::Text.new(value_str)
+              end
+
+      value.element_type = element_type
+      value
+    end
+  end
+
+  RSpec.describe VobjectValueType do
+    describe VobjectValueType::Text do
+      it "handles text values" do
+        text = described_class.new("Sample text")
+        expect(text.to_s).to eq("Sample text")
+      end
+    end
+
+    describe VobjectValueType::Uri do
+      it "validates valid URIs" do
+        uri = described_class.new("https://example.com")
+        expect(uri).to be_valid
+      end
+
+      it "invalidates malformed URIs" do
+        uri = described_class.new("not-a-uri")
+        expect(uri).not_to be_valid
+      end
+    end
+
+    describe VobjectValueType::Binary do
+      it "validates base64 encoded data" do
+        binary = described_class.new("SGVsbG8gV29ybGQ=") # "Hello World" in base64
+        expect(binary).to be_valid
+      end
+
+      it "invalidates malformed base64 data" do
+        binary = described_class.new("not-base64!")
+        expect(binary).not_to be_valid
+      end
+    end
+
+    describe VobjectValueType::Boolean do
+      it "handles true values" do
+        bool = described_class.new("TRUE")
+        expect(bool).to be_valid
+        expect(bool.to_bool).to be true
+      end
+
+      it "handles false values" do
+        bool = described_class.new("false")
+        expect(bool).to be_valid
+        expect(bool.to_bool).to be false
+      end
+
+      it "invalidates non-boolean values" do
+        bool = described_class.new("maybe")
+        expect(bool).not_to be_valid
+      end
+    end
+
+    describe VobjectValueType::Integer do
+      it "validates integer values" do
+        int = described_class.new("42")
+        expect(int).to be_valid
+        expect(int.to_i).to eq(42)
+      end
+
+      it "handles negative integers" do
+        int = described_class.new("-42")
+        expect(int).to be_valid
+        expect(int.to_i).to eq(-42)
+      end
+
+      it "invalidates non-integer values" do
+        int = described_class.new("4.2")
+        expect(int).not_to be_valid
+      end
+    end
+
+    describe VobjectValueType::Float do
+      it "validates float values" do
+        float = described_class.new("4.2")
+        expect(float).to be_valid
+        expect(float.to_f).to eq(4.2)
+      end
+
+      it "handles negative floats" do
+        float = described_class.new("-4.2")
+        expect(float).to be_valid
+        expect(float.to_f).to eq(-4.2)
+      end
+
+      it "handles integer-like floats" do
+        float = described_class.new("42")
+        expect(float).to be_valid
+        expect(float.to_f).to eq(42.0)
+      end
+    end
+
+    describe VobjectValueType::UtcOffset do
+      it "validates UTC offset format" do
+        offset = described_class.new("+0200")
+        expect(offset).to be_valid
+        expect(offset.hours).to eq(2)
+        expect(offset.minutes).to eq(0)
+      end
+
+      it "handles negative offsets" do
+        offset = described_class.new("-0500")
+        expect(offset).to be_valid
+        expect(offset.hours).to eq(-5)
+        expect(offset.minutes).to eq(0)
+      end
+
+      it "invalidates malformed offsets" do
+        offset = described_class.new("0200")
+        expect(offset).not_to be_valid
+      end
+    end
+
+    describe VobjectValueType::Language do
+      it "validates language tags" do
+        lang = described_class.new("en-US")
+        expect(lang).to be_valid
+      end
+
+      it "validates simple language codes" do
+        lang = described_class.new("en")
+        expect(lang).to be_valid
+      end
+
+      it "invalidates malformed language tags" do
+        lang = described_class.new("not-a-language")
+        expect(lang).not_to be_valid
+      end
+    end
+
+    # ... existing IsoDateAndOrTime tests ...
+  end
+
+  RSpec.describe VobjectValueType::IsoDateAndOrTime do
+    subject(:date_time) { described_class.new(value) }
+
+    context "when parsing date-time values" do
+      {
+        "19961022T140000" => :date_time,
+        "19961022T140000Z" => :date_time,
+        "--1022T1400" => :date_time,
+        "---22T14" => :date_time,
+        "T102200" => :date_time,
+        "T1022" => :date_time,
+        "T10" => :date_time,
+        "T-2200" => :date_time,
+        "T--00" => :date_time,
+        "T102200Z" => :date_time,
+        "T102200-0800" => :date_time,
+      }.each do |input, expected_type|
+        context "with #{input}" do
+          let(:value) { input }
+
+          it "detects correct type" do
+            expect(date_time.type).to eq(expected_type)
+          end
+
+          it "preserves original value" do
+            expect(date_time.to_s).to eq(input)
+          end
+        end
+      end
+    end
+
+    context "when parsing date values" do
+      {
+        "19850412" => :date,
+        "1985-04" => :date,
+        "1985" => :date,
+        "--0412" => :date,
+        "---12" => :date,
+      }.each do |input, expected_type|
+        context "with #{input}" do
+          let(:value) { input }
+
+          it "detects correct type" do
+            expect(date_time.type).to eq(expected_type)
+          end
+
+          it "preserves original value" do
+            expect(date_time.to_s).to eq(input)
+          end
+        end
+      end
+    end
+
+    context "when parsing text values" do
+      let(:value) { "Early April 1985" }
+
+      it "detects as text type" do
+        expect(date_time.type).to eq(:text)
+      end
+
+      it "preserves original value" do
+        expect(date_time.to_s).to eq(value)
+      end
+    end
+  end
+
+  RSpec.describe VobjectPropertyValue do
+    describe ".parse" do
+      it "creates Text value by default" do
+        value = described_class.parse("some text")
+        expect(value).to be_a(VobjectValueType::Text)
+      end
+
+      it "creates URI value" do
+        value = described_class.parse("https://example.com", "URI")
+        expect(value).to be_a(VobjectValueType::Uri)
+        expect(value).to be_valid
+      end
+
+      it "creates Binary value" do
+        value = described_class.parse("SGVsbG8=", "BINARY")
+        expect(value).to be_a(VobjectValueType::Binary)
+        expect(value).to be_valid
+      end
+
+      it "creates Boolean value" do
+        value = described_class.parse("TRUE", "BOOLEAN")
+        expect(value).to be_a(VobjectValueType::Boolean)
+        expect(value).to be_valid
+        expect(value.to_bool).to be true
+      end
+
+      it "creates Integer value" do
+        value = described_class.parse("42", "INTEGER")
+        expect(value).to be_a(VobjectValueType::Integer)
+        expect(value).to be_valid
+        expect(value.to_i).to eq(42)
+      end
+
+      it "creates Float value" do
+        value = described_class.parse("4.2", "FLOAT")
+        expect(value).to be_a(VobjectValueType::Float)
+        expect(value).to be_valid
+        expect(value.to_f).to eq(4.2)
+      end
+
+      it "creates UTC-OFFSET value" do
+        value = described_class.parse("+0200", "UTC-OFFSET")
+        expect(value).to be_a(VobjectValueType::UtcOffset)
+        expect(value).to be_valid
+        expect(value.hours).to eq(2)
+      end
+
+      it "creates LANGUAGE-TAG value" do
+        value = described_class.parse("en-US", "LANGUAGE-TAG")
+        expect(value).to be_a(VobjectValueType::Language)
+        expect(value).to be_valid
+      end
+
+      it "creates DATE-AND-OR-TIME value" do
+        value = described_class.parse("19961022T140000", "DATE-AND-OR-TIME")
+        expect(value).to be_a(VobjectValueType::IsoDateAndOrTime)
+        expect(value.type).to eq(:date_time)
+      end
+    end
+  end
+end
+
+RSpec.describe "Custom vObject adapter" do
+  let(:full_vcard) do
+    Vcard.new(
+      version: "4.0",
+      fn: "John Doe",
+      n: VcardName.new(
+        family: "Doe",
+        given: "John",
+        additional: "Middle",
+        prefix: "Dr.",
+        suffix: "PhD",
+      ),
+      tel: [
+        VcardTel.new(number: "tel:+1-555-555-5555"),
+        VcardTel.new(number: "tel:+1-555-555-1234"),
+      ],
+      email: ["john.doe@example.com", "j.doe@company.com"],
+      org: "Example Corp",
+      bday: VcardBday.new("1970-01-01"),
+    )
+  end
+
+  let(:vobject_data) do
+    <<~VCARD
+      BEGIN:VCARD
+      VERSION:4.0
+      FN:John Doe
+      N:Doe;John;Middle;Dr.;PhD
+      TEL:tel:+1-555-555-5555
+      TEL:tel:+1-555-555-1234
+      EMAIL:john.doe@example.com
+      EMAIL:j.doe@company.com
+      ORG:Example Corp
+      BDAY:1970-01-01
+      END:VCARD
+    VCARD
+  end
+
+  describe "#to_vobject" do
+    it "serializes all fields correctly" do
+      output = full_vcard.to_vobject.gsub(/\s+/, " ").strip
+      expected = vobject_data.gsub(/\s+/, " ").strip
+
+      expect(output).to eq(expected)
+    end
+  end
+
+  describe ".from_vobject" do
+    it "parses all fields correctly" do
+      card = Vcard.from_vobject(vobject_data).first
+
+      expect(card.version).to eq("4.0")
+      expect(card.fn).to eq("John Doe")
+      expect(card.n.family).to eq("Doe")
+      expect(card.n.given).to eq("John")
+      expect(card.n.additional).to eq("Middle")
+      expect(card.n.prefix).to eq("Dr.")
+      expect(card.n.suffix).to eq("PhD")
+      expect(card.tel).to contain_exactly(
+        "tel:+1-555-555-5555",
+        "tel:+1-555-555-1234",
+      )
+      expect(card.email).to contain_exactly(
+        "john.doe@example.com",
+        "j.doe@company.com",
+      )
+      expect(card.org).to eq("Example Corp")
+      expect(card.bday).to eq("1970-01-01")
+    end
+  end
+
+  # Add test cases for different BDAY formats
+  let(:iso_date_time_vcard) do
+    <<~VCARD
+      BEGIN:VCARD
+      VERSION:4.0
+      FN:John Doe
+      BDAY:19961022T140000Z
+      END:VCARD
+    VCARD
+  end
+
+  let(:iso_date_vcard) do
+    <<~VCARD
+      BEGIN:VCARD
+      VERSION:4.0
+      FN:John Doe
+      BDAY:19850412
+      END:VCARD
+    VCARD
+  end
+
+  let(:text_date_vcard) do
+    <<~VCARD
+      BEGIN:VCARD
+      VERSION:4.0
+      FN:John Doe
+      BDAY:Early April 1985
+      END:VCARD
+    VCARD
+  end
+
+  describe ".from_vobject" do
+    it "parses ISO date-time BDAY correctly" do
+      card = Vcard.from_vobject(iso_date_time_vcard).first
+      expect(card.bday.value.to_s).to eq("19961022T140000Z")
+      expect(card.bday.type).to eq(:date_time)
+    end
+
+    it "parses ISO date BDAY correctly" do
+      card = Vcard.from_vobject(iso_date_vcard).first
+      expect(card.bday.value.to_s).to eq("19850412")
+      expect(card.bday.type).to eq(:date)
+    end
+
+    it "parses text BDAY correctly" do
+      card = Vcard.from_vobject(text_date_vcard).first
+      expect(card.bday.value.to_s).to eq("Early April 1985")
+      expect(card.bday.type).to eq(:text)
+    end
+  end
+end
+
+RSpec.describe VobjectMapping do
+  let(:mapping) { described_class.new }
+
+  describe "#type" do
+    it "accepts valid element types" do
+      expect { mapping.type(:component) }.not_to raise_error
+      expect { mapping.type(:property) }.not_to raise_error
+      expect { mapping.type(:property_parameter) }.not_to raise_error
+      expect { mapping.type(:property_group) }.not_to raise_error
+    end
+
+    it "rejects invalid element types" do
+      expect { mapping.type(:invalid) }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe "#component_root" do
+    it "sets the component root" do
+      mapping.component_root("VCARD")
+      expect(mapping.instance_variable_get(:@component_root)).to eq("VCARD")
+    end
+  end
+
+  describe "#property_root" do
+    it "sets the property root" do
+      mapping.property_root("TEL")
+      expect(mapping.instance_variable_get(:@property_root)).to eq("TEL")
+    end
+  end
+
+  describe "#map_field_set and #map_field" do
+    it "maps fields correctly" do
+      mapping.map_field_set(
+        count: 3,
+        item_type: :list,
+        item_options: { type: :text },
+      )
+
+      mapping.map_field(0, to: :first)
+      mapping.map_field(1, to: :second)
+      mapping.map_field(2, to: :third)
+
+      mappings = mapping.instance_variable_get(:@mappings)
+      expect(mappings.size).to eq(3)
+      expect(mappings[0].name).to eq(0)
+      expect(mappings[0].to).to eq(:first)
+      expect(mappings[0].type).to eq(:list)
+    end
+  end
+end
+
+RSpec.describe VobjectPropertyValue do
+  describe ".parse" do
+    it "sets element type correctly" do
+      value = described_class.parse("test", "TEXT", :property_value)
+      expect(value.element_type).to eq(:property_value)
+
+      value = described_class.parse("test", "TEXT", :parameter_value)
+      expect(value.element_type).to eq(:parameter_value)
+    end
+
+    it "rejects invalid element types" do
+      expect do
+        described_class.parse("test", "TEXT", :invalid)
+      end.to raise_error(ArgumentError)
+    end
+  end
+end
+
+RSpec.describe VobjectValueType::Base do
+  let(:value) { described_class.new("test") }
+
+  describe "#as_property_value" do
+    it "changes element type to property_value" do
+      value.as_parameter_value
+      value.as_property_value
+      expect(value.element_type).to eq(:property_value)
+    end
+  end
+
+  describe "#as_parameter_value" do
+    it "changes element type to parameter_value" do
+      value.as_parameter_value
+      expect(value.element_type).to eq(:parameter_value)
+    end
+  end
+end


### PR DESCRIPTION
This is for #322 .

This PR provides two sample custom serialization adapter implementations (in pseudocode):
* BibTeX
* vObject (https://datatracker.ietf.org/doc/html/draft-calconnect-vobject-vformat-04)

The BibTeX implementation is more complete. The vObject implementation does parse simple vCards but as the vObject schema is much more complex it is incomplete.

## Custom serialization adapter implementation

The user is meant to provide the following:
* `Mapping` class that stores a set of mappings for the serialization format
* `MappingRule` class, that defines how the mappings work to the target format's elements (e.g. BibTeX has "field", "citekey" and "type key". vObject has "component", "property", "value", etc)
* `Document` class (an instance of raw data to parse, e.g. we have `JsonDocument`) (user can also specify smaller components
* `Adapter` class that links the Document and Mapping and to register the `{type} do #...` block
* A format may also provide its own set of Value Types, e.g. vObject defines a series of its own value types.

The following content is AI-generated that describes from the content the requirements I've listed above.

# BibTeX adapter 

`spec/lutaml/model/custom_bibtex_adapter_spec.rb`

This extension adds support for BibTeX format serialization and deserialization to Lutaml::Model. While BibTeX is traditionally used for academic citations, its structured format makes it suitable for storing various types of information models.

## Key Benefits of BibTeX Format

- Built-in support for structured data with fields and values  
- Natural handling of collections (like authors, dependencies, ingredients)  
- Familiar citation key system for unique identification  
- Human-readable text format for easy version control  
- Extensive tooling support for parsing and manipulation  

## Basic Setup

To use BibTeX format in your model:

1. Include necessary field classes based on your needs:
   - `BibtexFieldAuthor` - For handling names (authors, maintainers, manufacturers)
   - `BibtexFieldYear` - For handling dates and ranges
   - `BibtexFieldPage` - For handling numeric ranges

2. Define your model class inheriting from `Lutaml::Model::Serializable`

3. Register BibTeX format:

```ruby
Lutaml::Model::Config.register_format(
  :bibtex,
  mapping_class: BibtexMapping,
  adapter_class: BibtexAdapter
)
```

4. Define BibTeX mappings using the `bibtex do` block:

```ruby
bibtex do
  map_entry_type to: :entry_type     # Maps entry type (e.g., @article, @book)
  map_citekey to: :citekey           # Maps unique identifier
  map_field "author", to: :author    # Maps fields to model attributes
  map_field "title", to: :title
  # Add other field mappings as needed
end
```

## Mapping Methods

The bibtex block supports these mapping methods:

- `map_entry_type`: Maps the entry type (e.g., @article, @book)  
- `map_citekey`: Maps the unique identifier  
- `map_field`: Maps fields to model attributes  
  Options:
  - `to`: Target attribute name  
  - `render_nil`: Whether to render nil values (default: false)  

## Examples

### 1. Traditional Academic Citation

```ruby
class Publication < Lutaml::Model::Serializable
  attribute :entry_type, :string, values: %w[article book inproceedings]
  attribute :citekey, :string
  attribute :author, BibtexFieldAuthor
  attribute :title, :string
  attribute :journal, :string
  attribute :year, BibtexFieldYear

  bibtex do
    map_entry_type to: :entry_type
    map_citekey to: :citekey
    map_field "author", to: :author
    map_field "title", to: :title
    map_field "journal", to: :journal
    map_field "year", to: :year
  end
end
```

**Usage:**  
```ruby
entry = Publication.from_bibtex(bibtex_string)
bibtex_string = entry.to_bibtex
```

### 2. Software Components Registry

BibTeX's structured format works well for tracking software components:

```ruby
class Component < Lutaml::Model::Serializable
  attribute :entry_type, :string, values: %w[library framework tool service]
  attribute :citekey, :string  # Unique identifier
  attribute :name, :string
  attribute :maintainers, BibtexFieldAuthor, collection: true
  attribute :version, :string
  attribute :dependencies, :string, collection: true
  attribute :license, :string

  bibtex do
    map_entry_type to: :entry_type
    map_citekey to: :citekey
    map_field "name", to: :name
    map_field "maintainers", to: :maintainers
    map_field "version", to: :version
    map_field "dependencies", to: :dependencies
    map_field "license", to: :license
  end
end
```

### 3. Equipment Inventory

```ruby
class Equipment < Lutaml::Model::Serializable
  attribute :entry_type, :string, values: %w[machine tool vehicle equipment]
  attribute :citekey, :string  # Asset ID
  attribute :model, :string
  attribute :manufacturer, BibtexFieldAuthor
  attribute :purchase_date, BibtexFieldYear
  attribute :location, :string
  attribute :maintenance_history, :string, collection: true

  bibtex do
    map_entry_type to: :entry_type
    map_citekey to: :citekey
    map_field "model", to: :model
    map_field "manufacturer", to: :manufacturer
    map_field "purchase_date", to: :purchase_date
    map_field "location", to: :location
    map_field "maintenance_history", to: :maintenance_history
  end
end
```

### 4. Recipe Database

```ruby
class Recipe < Lutaml::Model::Serializable
  attribute :entry_type, :string, values: %w[appetizer main dessert beverage]
  attribute :citekey, :string  # Recipe ID
  attribute :name, :string
  attribute :chef, BibtexFieldAuthor
  attribute :prep_time, :string
  attribute :ingredients, :string, collection: true
  attribute :instructions, :string, collection: true
  attribute :servings, :string

  bibtex do
    map_entry_type to: :entry_type
    map_citekey to: :citekey
    map_field "name", to: :name
    map_field "chef", to: :chef
    map_field "prep_time", to: :prep_time
    map_field "ingredients", to: :ingredients
    map_field "instructions", to: :instructions
    map_field "servings", to: :servings
  end
end
```


# vObject adapter

`spec/lutaml/model/custom_vobject_adapter_spec.rb`

This module provides support for serializing and deserializing models to/from vObject format, a text-based data format used by standards like vCard and iCalendar.

## Basic Usage

To use vObject serialization in your models:

```ruby
class MyModel < Lutaml::Model::Serializable
  attribute :field1, :string
  attribute :field2, :string

  vobject do
    type :component          # Declare as component (like VCARD, VCALENDAR)
    component_root "MYCOMP"  # Root component name

    # Map vObject properties to model attributes
    map_property "PROP1", to: :field1
    map_property "PROP2", to: :field2
  end
end
```

## Creating Custom Components

For non-standardized vObject components:

```ruby
class MyCustomComponent < Lutaml::Model::Serializable
  attribute :name, :string
  attribute :details, MyCustomDetails

  vobject do
    type :component
    component_root "X-CUSTOM"  # Use X- prefix for custom components

    map_property "X-NAME", to: :name
    map_property "X-DETAILS", to: :details, type: :structured
  end
end
```

## Custom Properties

Define custom properties with parameters:

```ruby
class MyCustomProperty < Lutaml::Model::Serializable
  attribute :value, :string
  attribute :param1, :string
  attribute :param2, :integer

  vobject do
    type :property
    property_name "X-CUSTOM-PROP"

    map_value to: :value
    map_property "PARAM1", to: :param1
    map_property "PARAM2", to: :param2
  end
end
```

## Value Types

Support for different value types:

- `Text` (default)
- `URI`
- `Binary` (Base64)
- `Boolean`
- `Integer`
- `Float`
- `UTC-Offset`
- `Language-Tag`
- `IsoDateAndOrTime`

## Custom Value Types

Create custom value types by extending `VobjectValueType::Base`:

```ruby
class MyCustomValue < VobjectValueType::Base
  def valid?
    # Add validation logic
  end
end
```

## Structured Values

For properties with multiple fields:

```ruby
vobject do
  type :property
  property_name "X-STRUCTURED"

  map_field_set count: 3, item_type: :list
  map_field 0, to: :first_field
  map_field 1, to: :second_field
  map_field 2, to: :third_field
end
```

## Registration

Register your custom format:

```ruby
Lutaml::Model::Config.register_format(
  :vobject,
  mapping_class: YourMapping,
  adapter_class: YourAdapter
)
```

## Component Types

Four types of elements are supported:
- `:component` - Container components like VCARD  
- `:property` - Properties with values and parameters  
- `:property_parameter` - Parameters for properties  
- `:property_group` - Grouping of related properties
