### PR TITLE
Default to optional liquid dependency

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -34,14 +34,6 @@ Layout/IndentationWidth:
 Layout/LineLength:
   Enabled: false
 
-# Offense count: 4
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyle, IndentationWidth.
-# SupportedStyles: aligned, indented, indented_relative_to_receiver
-Layout/MultilineMethodCallIndentation:
-  Exclude:
-    - 'spec/lutaml/model/liquefiable_spec.rb'
-
 # Offense count: 13
 # Configuration parameters: AllowedMethods.
 # AllowedMethods: enums

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gemspec
 gem "benchmark-ips"
 gem "bigdecimal"
 gem "equivalent-xml"
+gem "liquid"
 gem "lutaml-xsd"
 gem "multi_json"
 gem "nokogiri"

--- a/README.adoc
+++ b/README.adoc
@@ -413,9 +413,11 @@ end
 
 ==== Decimal type
 
-The Decimal type is an optional type that is disabled by default.
+WARNING: Decimal is an optional feature.
 
-NOTE: The reason why the Decimal type is disalbed by default is that the
+The Decimal type is a value type that is disabled by default.
+
+NOTE: The reason why the Decimal type is disabled by default is that the
 `BigDecimal` class became optional to the standard Ruby library from Ruby 3.4
 onwards. The `Decimal` type is only enabled when the `bigdecimal` library is
 loaded.
@@ -4597,18 +4599,19 @@ klin.validate
 
 == Liquid template access
 
+WARNING: The Liquid template feature is optional. To enable it, please
+explicitly require the `liquid` gem.
+
 The https://shopify.github.io/liquid/[Liquid template language] is an
 open-source template language developed by Shopify and written in Ruby.
 
 `Lutaml::Model::Serializable` objects can be safely accessed within Liquid
-templates through a `to_liquid` method that converts the objects into a
+templates through a `to_liquid` method that converts the objects into
 `Liquid::Drop` instances.
 
 * All attributes are accessible in the Liquid template by their names.
-* Nested attributes are also converted into `Liquid::Drop` objects so 
+* Nested attributes are also converted into `Liquid::Drop` objects so
 inner attributes can be accessed using the Liquid dot notation.
-
-NOTE: This feature is optional and requires the `liquid` gem to be explicitly installed and required.
 
 NOTE: Every `Lutaml::Model::Serializable` class extends the `Liquefiable` module
 which generates a corresponding `Liquid::Drop` class.

--- a/README.adoc
+++ b/README.adoc
@@ -4608,6 +4608,8 @@ templates through a `to_liquid` method that converts the objects into a
 * Nested attributes are also converted into `Liquid::Drop` objects so 
 inner attributes can be accessed using the Liquid dot notation.
 
+NOTE: This feature is optional and requires the `liquid` gem to be explicitly installed and required.
+
 NOTE: Every `Lutaml::Model::Serializable` class extends the `Liquefiable` module
 which generates a corresponding `Liquid::Drop` class.
 
@@ -4615,6 +4617,7 @@ NOTE: Methods defined in the `Lutaml::Model::Serializable` class are not
 accessible in the Liquid template.
 
 .Using `to_liquid` to convert model instances into corresponding Liquid drop instances
+
 [example]
 ====
 [source,ruby]

--- a/README.adoc
+++ b/README.adoc
@@ -695,7 +695,7 @@ end
 Lutaml lets you create reusable element and attribute collections using `no_root`. These can be imported into other models using:
 
 - `import_model`: imports both attributes and mappings
-- `import_model_attributes`: imports only attributes  
+- `import_model_attributes`: imports only attributes
 - `import_model_mappings`: imports only mappings
 
 NOTE: This feature works with XML. Import order determines how elements and attributes are overwritten.
@@ -3900,7 +3900,7 @@ class Person < Lutaml::Model::Serializable
     }
   end
 
-  # Mapping-level transformation in XML format  
+  # Mapping-level transformation in XML format
   xml do
     map "full-name", to: :name, transform: {
       export: ->(value) { "Dr. #{value}" },
@@ -4100,39 +4100,39 @@ NOTE: For `NokogiriAdapter`, we can also call `to_xml` on `value.node.adapter_no
 
 # Nokogiri Adapter Node
 
-#<Lutaml::Model::XmlAdapter::NokogiriElement:0x0000000107656ed8                                                                 
-#   @attributes={},                                                                                                                
-#   @children=                                                                                                                     
+#<Lutaml::Model::XmlAdapter::NokogiriElement:0x0000000107656ed8
+#   @attributes={},
+#   @children=
 #   [#<Lutaml::Model::XmlAdapter::NokogiriElement:0x0000000107656cd0 @attributes={}, @children=[], @default_namespace=nil, @name="text", @namespace_prefix=nil, @text="\n    ">,
-#   #<Lutaml::Model::XmlAdapter::NokogiriElement:0x00000001076569b0                                                              
-#     @attributes={},                                                                                                             
-#     @children=                                                                                                                  
+#   #<Lutaml::Model::XmlAdapter::NokogiriElement:0x00000001076569b0
+#     @attributes={},
+#     @children=
 #     [#<Lutaml::Model::XmlAdapter::NokogiriElement:0x00000001076567f8 @attributes={}, @children=[], @default_namespace=nil, @name="text", @namespace_prefix=nil, @text="Metadata">],
-#     @default_namespace=nil,                                                                                                     
-#     @name="category",                                                                                                           
-#     @namespace_prefix=nil,                                                                                                      
-#     @text="Metadata">,                                                                                                          
+#     @default_namespace=nil,
+#     @name="category",
+#     @namespace_prefix=nil,
+#     @text="Metadata">,
 #   #<Lutaml::Model::XmlAdapter::NokogiriElement:0x0000000107656028 @attributes={}, @children=[], @default_namespace=nil, @name="text", @namespace_prefix=nil, @text="\n  ">],
-# @default_namespace=nil,                                                                                                        
+# @default_namespace=nil,
 # @name="metadata",
 # @namespace_prefix=nil,
 # @text="\n    Metadata\n  ">
 
 # Ox Adapter Node
 
-#<Lutaml::Model::XmlAdapter::OxElement:0x0000000107584f78                                                                                      
-# @attributes={},                                                                                                                               
-# @children=                                                                                                                                    
-#   [#<Lutaml::Model::XmlAdapter::OxElement:0x0000000107584e60                                                                                   
-#     @attributes={},                                                                                                                            
+#<Lutaml::Model::XmlAdapter::OxElement:0x0000000107584f78
+# @attributes={},
+# @children=
+#   [#<Lutaml::Model::XmlAdapter::OxElement:0x0000000107584e60
+#     @attributes={},
 #     @children=[#<Lutaml::Model::XmlAdapter::OxElement:0x0000000107584d48 @attributes={}, @children=[], @default_namespace=nil, @name="text", @namespace_prefix=nil, @text="Metadata">],
-#     @default_namespace=nil,                                                                                                                    
-#     @name="category",                                                                                                                          
-#     @namespace_prefix=nil,                                                                                                                     
-#     @text="Metadata">],                                                                                                                        
-# @default_namespace=nil,                                                                                                                       
-# @name="metadata",                                                                                                                             
-# @namespace_prefix=nil,                                                                                                                        
+#     @default_namespace=nil,
+#     @name="category",
+#     @namespace_prefix=nil,
+#     @text="Metadata">],
+# @default_namespace=nil,
+# @name="metadata",
+# @namespace_prefix=nil,
 # @text=nil>
 
 # Oga Adapter Node
@@ -4192,7 +4192,7 @@ class CustomModelParentMapper < Lutaml::Model::Serializable
     map_element :CustomModelChild,
                 with: { to: :child_to_xml, from: :child_from_xml }
   end
-  
+
   def child_to_xml(model, parent, doc)
     child_el = doc.create_element("CustomModelChild")
     street_el = doc.create_element("street")
@@ -4229,7 +4229,7 @@ end
 [source,ruby]
 ----
 > instance = CustomModelParentMapper.from_xml(xml)
-> #<CustomModelParent:0x0000000107c9ca68 @child_mapper=#<CustomModelChild:0x0000000107c95218 @city="London", @street="Oxford Street">, @first_name="John"> 
+> #<CustomModelParent:0x0000000107c9ca68 @child_mapper=#<CustomModelChild:0x0000000107c95218 @city="London", @street="Oxford Street">, @first_name="John">
 > CustomModelParentMapper.to_xml(instance)
 > #<CustomModelParent><first_name>John</first_name><CustomModelChild><street>Oxford Street</street><city>London</city></CustomModelChild></CustomModelParent>
 ----

--- a/lib/lutaml/model/error.rb
+++ b/lib/lutaml/model/error.rb
@@ -6,6 +6,7 @@ module Lutaml
 end
 
 require_relative "error/invalid_value_error"
+require_relative "error/liquid_not_enabled_error"
 require_relative "error/incorrect_mapping_argument_error"
 require_relative "error/pattern_not_matched_error"
 require_relative "error/unknown_adapter_type_error"

--- a/lib/lutaml/model/error/liquid_not_enabled_error.rb
+++ b/lib/lutaml/model/error/liquid_not_enabled_error.rb
@@ -1,0 +1,9 @@
+module Lutaml
+  module Model
+    class LiquidNotEnabledError < Error
+      def to_s
+        "Liquid functionality is not available by default; please install and require `liquid` gem to use this functionality"
+      end
+    end
+  end
+end

--- a/lib/lutaml/model/serialize.rb
+++ b/lib/lutaml/model/serialize.rb
@@ -117,8 +117,6 @@ module Lutaml
             end
           end
 
-          register_drop_method(name)
-
           attr
         end
 

--- a/spec/lutaml/model/liquefiable_spec.rb
+++ b/spec/lutaml/model/liquefiable_spec.rb
@@ -49,8 +49,19 @@ RSpec.describe Lutaml::Model::Liquefiable do
         end.to change {
                  dummy.class.const_defined?(:DummyModelDrop)
                }
-                 .from(false)
-                 .to(true)
+          .from(false)
+          .to(true)
+      end
+    end
+
+    context "when 'liquid' is not available" do
+      before { allow(Object).to receive(:const_defined?).with(:Liquid).and_return(false) }
+
+      it "raises an error" do
+        expect { dummy.class.register_liquid_drop_class }.to raise_error(
+          Lutaml::Model::LiquidNotEnabledError,
+          "Liquid functionality is not available by default; please install and require `liquid` gem to use this functionality",
+        )
       end
     end
 
@@ -94,23 +105,36 @@ RSpec.describe Lutaml::Model::Liquefiable do
       end.to change {
                dummy.to_liquid.respond_to?(:display_name)
              }
-               .from(false)
-               .to(true)
+        .from(false)
+        .to(true)
     end
   end
 
   describe ".to_liquid" do
-    before do
-      dummy.class.register_liquid_drop_class
-      dummy.class.register_drop_method(:display_name)
+    context "when liquid is not enabled" do
+      before { allow(Object).to receive(:const_defined?).with(:Liquid).and_return(false) }
+
+      it "raises an error" do
+        expect { dummy.to_liquid }.to raise_error(
+          Lutaml::Model::LiquidNotEnabledError,
+          "Liquid functionality is not available by default; please install and require `liquid` gem to use this functionality",
+        )
+      end
     end
 
-    it "returns an instance of the drop class" do
-      expect(dummy.to_liquid).to be_a(dummy.class.drop_class)
-    end
+    context "when liquid is enabled" do
+      before do
+        dummy.class.register_liquid_drop_class
+        dummy.class.register_drop_method(:display_name)
+      end
 
-    it "allows access to registered methods via the drop class" do
-      expect(dummy.to_liquid.display_name).to eq("TestName (42)")
+      it "returns an instance of the drop class" do
+        expect(dummy.to_liquid).to be_a(dummy.class.drop_class)
+      end
+
+      it "allows access to registered methods via the drop class" do
+        expect(dummy.to_liquid.display_name).to eq("TestName (42)")
+      end
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "liquid"
 require "rspec/matchers"
 require "equivalent-xml"
 


### PR DESCRIPTION
This PR removes the default registration of classes and methods in **Liquid**, making this functionality optional to the user.

related => plurimath/plurimath#289