### PR TITLE
`import_model` for all supported formats

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1541,8 +1541,8 @@ end
 
 Where,
 
-`min`:: The minimum number of elements that must be included.
-`max`:: The maximum number of elements that can be included.
+`min`:: The minimum number of elements that must be included. The minimum value can be `0`.
+`max`:: The maximum number of elements that can be included. The maximum value can go up to `Float::INFINITY`.
 `block`:: The block of elements that must be included. The block can contain
 multiple `attribute` and `choice` directives.
 
@@ -1591,7 +1591,7 @@ directives:
 
 `import_model_mappings`:: imports only mappings.
 
-NOTE: This feature only works with XML for now. The import order determines how
+NOTE: This feature works both with XML and Key-Value formats. The import order determines how
 elements and attributes are overwritten.
 
 Models with `no_root` can only be parsed through **parent models**.

--- a/README.adoc
+++ b/README.adoc
@@ -1579,11 +1579,14 @@ attributes.
 An importable model is a model that can be imported into another model using the
 `import_*` directive.
 
-Such a model is specified by setting the model's XML serialization configuration
-with the `no_root` directive.
+This feature works both with XML and key-value formats.
 
-As a result, the model can be imported into another model using the following
-directives:
+* The import order determines how elements and attributes are overwritten.
+
+* An importable model with XML serialization mappings requires setting the model's
+XML serialization configuration with the `no_root` directive.
+
+The model can be imported into another model using the following directives:
 
 `import_model`:: imports both attributes and mappings.
 
@@ -1591,16 +1594,13 @@ directives:
 
 `import_model_mappings`:: imports only mappings.
 
-NOTE: This feature works both with XML and Key-Value formats. The import order determines how
-elements and attributes are overwritten.
-
-Models with `no_root` can only be parsed through **parent models**.
+NOTE: Models with `no_root` can only be parsed through parent models.
 Direct calling `NoRootModel.from_xml` will raise a `NoRootMappingError`.
 
-Namespaces are not supported in importable models. If `namespace` is defined with
-`no_root`, `NoRootNamespaceError` will raise.
+NOTE: Namespaces are not currently supported in importable models.
+If `namespace` is defined with `no_root`, `NoRootNamespaceError` will be raised.
 
-
+.Importing model components using an importable model
 [example]
 ====
 [source,ruby]

--- a/lib/lutaml/model/attribute.rb
+++ b/lib/lutaml/model/attribute.rb
@@ -290,6 +290,10 @@ module Lutaml
         end
       end
 
+      def deep_dup
+        self.class.new(name, type, Utils.deep_dup(options))
+      end
+
       private
 
       def resolve_polymorphic_class(type, value, options)

--- a/lib/lutaml/model/choice.rb
+++ b/lib/lutaml/model/choice.rb
@@ -15,6 +15,13 @@ module Lutaml
         raise Lutaml::Model::InvalidChoiceRangeError.new(@min, @max) if @min.negative? || @max.negative?
       end
 
+      def ==(other)
+        @attributes == other.attributes &&
+          @min == other.min &&
+          @max == other.max &&
+          @model == other.model
+      end
+
       def attribute(name, type, options = {})
         options[:choice] = self
         @attributes << @model.attribute(name, type, options)

--- a/lib/lutaml/model/mapping/xml_mapping.rb
+++ b/lib/lutaml/model/mapping/xml_mapping.rb
@@ -322,6 +322,32 @@ module Lutaml
         end
       end
 
+      def mapping_attributes_hash
+        @attributes
+      end
+
+      def mapping_elements_hash
+        @elements
+      end
+
+      def merge_mapping_attributes(mapping)
+        mapping_attributes_hash.merge!(mapping.mapping_attributes_hash)
+      end
+
+      def merge_mapping_elements(mapping)
+        mapping_elements_hash.merge!(mapping.mapping_elements_hash)
+      end
+
+      def merge_elements_sequence(mapping)
+        mapping.element_sequence.each do |sequence|
+          element_sequence << Lutaml::Model::Sequence.new(self).tap do |instance|
+            sequence.attributes.each do |attr|
+              instance.attributes << attr.deep_dup
+            end
+          end
+        end
+      end
+
       def deep_dup
         self.class.new.tap do |xml_mapping|
           xml_mapping.root(@root_element.dup, mixed: @mixed_content,

--- a/lib/lutaml/model/sequence.rb
+++ b/lib/lutaml/model/sequence.rb
@@ -1,8 +1,8 @@
 module Lutaml
   module Model
     class Sequence
-      attr_reader :attributes,
-                  :model
+      attr_accessor :model
+      attr_reader :attributes
 
       def initialize(model)
         @attributes = []

--- a/lib/lutaml/model/serialize.rb
+++ b/lib/lutaml/model/serialize.rb
@@ -136,7 +136,9 @@ module Lutaml
         end
 
         def import_model_with_root_error(model)
-          raise Lutaml::Model::ImportModelWithRootError.new(model) if model.root?
+          return unless model.mappings.key?(:xml) && model.root?
+
+          raise Lutaml::Model::ImportModelWithRootError.new(model)
         end
 
         def import_model_attributes(model)

--- a/spec/lutaml/model/attribute_spec.rb
+++ b/spec/lutaml/model/attribute_spec.rb
@@ -167,4 +167,38 @@ RSpec.describe Lutaml::Model::Attribute do
       end
     end
   end
+
+  describe "#deep_dup" do
+    let(:duplicate_attribute) { Lutaml::Model::Utils.deep_dup(attribute) }
+
+    context "when deep_dup method is not defined and instance is deep_duplicated" do
+      let(:attribute) { described_class.new("name", :string) }
+
+      before do
+        described_class.alias_method :orig_deep_dup, :deep_dup
+        described_class.undef_method :deep_dup
+      end
+
+      after do
+        described_class.alias_method :deep_dup, :orig_deep_dup
+        attribute.options.delete(:foo)
+      end
+
+      it "confirms that options values are linked of original and duplicate instances" do
+        duplicate_attribute
+        attribute.options[:foo] = "bar"
+        expect(duplicate_attribute.options).to include(:foo)
+      end
+    end
+
+    context "when deep_dup method is defined and instance is deep_duplicated" do
+      let(:attribute) { described_class.new("name", :string) }
+
+      it "confirms that options values are not linked of original and duplicate instances" do
+        duplicate_attribute
+        attribute.options[:foo] = "bar"
+        expect(duplicate_attribute.options).not_to include(:foo)
+      end
+    end
+  end
 end

--- a/spec/lutaml/model/group_spec.rb
+++ b/spec/lutaml/model/group_spec.rb
@@ -148,6 +148,22 @@ module GroupSpec
       map_element "organization", to: :organization
     end
   end
+
+  class Identifier < Lutaml::Model::Serializable
+    attribute :id, :string
+    attribute :remarks, :string, collection: true
+    attribute :remark_items, :string, collection: true
+
+    key_value do
+      map "id", to: :id
+      map "remarks", to: :remarks
+      map "remark_items", to: :remark_items
+    end
+  end
+
+  class ModelElement < Lutaml::Model::Serializable
+    import_model Identifier
+  end
 end
 
 RSpec.describe "Group" do
@@ -273,6 +289,11 @@ RSpec.describe "Group" do
     describe GroupSpec::SimpleType do
       it_behaves_like "imports attributes from", GroupSpec::GroupOfItems, described_class
       it_behaves_like "imports mappings from", GroupSpec::GroupOfItems, described_class
+    end
+
+    describe GroupSpec::ModelElement do
+      it_behaves_like "imports attributes from", GroupSpec::Identifier, described_class
+      it_behaves_like "imports mappings from", GroupSpec::Identifier, described_class
     end
 
     describe GroupSpec::Mrow do

--- a/spec/lutaml/model/group_spec.rb
+++ b/spec/lutaml/model/group_spec.rb
@@ -3,13 +3,18 @@ require "lutaml/model"
 
 module GroupSpec
   class Ceramic < Lutaml::Model::Serializable
-    attribute :type, :string
-    attribute :name, :string
+    attribute :type, :string, default: "Data"
+    attribute :name, :string, default: "Starc"
 
     xml do
       no_root
       map_element :type, to: :type
       map_element :name, to: :name
+    end
+
+    key_value do
+      map :type, to: :type
+      map :name, to: :name
     end
   end
 
@@ -75,9 +80,123 @@ module GroupSpec
       map_element :name, to: :name
     end
   end
+
+  class CommonAttributes < Lutaml::Model::Serializable
+    choice do
+      attribute :mstyle, :string
+      attribute :mcol, :string
+      attribute :mr, :string
+    end
+
+    xml do
+      no_root
+      sequence do
+        map_element :mstyle, to: :mstyle
+        map_element :mr, to: :mr
+      end
+      map_attribute :mcol, to: :mcol
+    end
+  end
+
+  class Mrow < Lutaml::Model::Serializable
+    attribute :mi, :string
+    import_model CommonAttributes
+
+    xml do
+      root "mrow"
+      map_element :mi, to: :mi
+    end
+
+    import_model GroupOfItems
+
+    key_value do
+      map :mcol, to: :mcol
+    end
+
+    import_model Ceramic
+  end
+
+  class Mfrac < Lutaml::Model::Serializable
+    attribute :num, :string
+    import_model CommonAttributes
+
+    xml do
+      root "mfrac"
+      map_element :num, to: :num
+    end
+  end
+
+  class ContributionInfo < Lutaml::Model::Serializable
+    attribute :person, :string
+    attribute :organization, :string
+
+    xml do
+      no_root
+      map_element "person", to: :person
+      map_element "organization", to: :organization
+    end
+  end
+
+  class Contributor < Lutaml::Model::Serializable
+    attribute :role, :string
+    import_model_attributes ContributionInfo
+
+    xml do
+      root "contributor"
+      map_element "role", to: :role
+      map_element "person", to: :person
+      map_element "organization", to: :organization
+    end
+  end
 end
 
 RSpec.describe "Group" do
+  context "when serializing and deserializing import model having no_root" do
+    let(:xml) do
+      <<~XML
+        <mrow xmlns:ex1="http://www.example.com" xmlns:GML="http://www.sparxsystems.com/profiles/GML/1.0">
+          <mstyle>italic</mstyle>
+          <mr>y</mr>
+          <mi>x</mi>
+          <name>Smith</name>
+          <type>product</type>
+          <GML:description>Item</GML:description>
+        </mrow>
+      XML
+    end
+
+    let(:input_xml) do
+      <<~XML
+        <contributor>
+          <role>author</role>
+          <person>John Doe</person>
+          <organization>ACME</organization>
+        </contributor>
+      XML
+    end
+
+    it "parse the imported model correctly" do
+      parsed = GroupSpec::Mrow.from_xml(xml)
+      expect(parsed.mi).to eq("x")
+      expect(parsed.mstyle).to eq("italic")
+      expect(parsed.name).to eq("Smith")
+      expect(parsed.type).to eq("product")
+      expect(parsed.description).to eq("Item")
+    end
+
+    it "parse the imported model attributes correctly" do
+      parsed = GroupSpec::Contributor.from_xml(input_xml)
+      expect(parsed.person).to eq("John Doe")
+      expect(parsed.role).to eq("author")
+      expect(parsed.organization).to eq("ACME")
+    end
+
+    it "serialize the imported model correctly" do
+      instance = GroupSpec::Mrow.new(mi: "x", mstyle: "italic", mr: "y", name: "Smith", type: "product", description: "Item")
+      expect(instance.to_xml).to be_equivalent_to(xml)
+    end
+  end
+
   context "with no_root" do
     let(:mapper) { GroupSpec::CeramicCollection }
 
@@ -116,26 +235,188 @@ RSpec.describe "Group" do
   end
 
   context "with model" do
-    it "import attributes" do
-      expect(GroupSpec::ComplexType.attributes).to include(GroupSpec::GroupOfItems.attributes)
+    shared_examples "imports attributes from" do |source_class, target_class|
+      it "#{source_class.name} correctly" do
+        source_attributes = source_class.attributes
+        target_attributes = target_class.attributes
+
+        source_attributes.each do |name, attr|
+          expect(target_attributes[name].name).to eq(attr.name)
+          expect(target_attributes[name].type).to eq(attr.type)
+          expect(target_attributes[name].options).to eq(attr.options)
+        end
+      end
     end
 
-    it "import mappings in xml block" do
-      expect(GroupSpec::ComplexType.mappings_for(:xml).elements).to include(*GroupSpec::GroupOfItems.mappings_for(:xml).elements)
+    shared_examples "imports mappings from" do |source_class, target_class|
+      it "#{source_class.name} correctly" do
+        source_elements = source_class.mappings_for(:xml).elements
+        target_elements = target_class.mappings_for(:xml).elements
+
+        source_elements.each do |element|
+          matching_element = target_elements.find { |e| e.name == element.name }
+          expect(matching_element).not_to be_nil
+          expect(matching_element.to).to eq(element.to)
+        end
+      end
     end
 
-    it "import mappings outside xml block" do
-      expect(GroupSpec::GenericType.mappings_for(:xml).elements).to include(*GroupSpec::GroupOfItems.mappings_for(:xml).elements)
+    describe GroupSpec::ComplexType do
+      it_behaves_like "imports attributes from", GroupSpec::GroupOfItems, described_class
+      it_behaves_like "imports mappings from", GroupSpec::GroupOfItems, described_class
     end
 
-    it "import attributes and mappings in xml block" do
-      expect(GroupSpec::ComplexType.attributes).to include(GroupSpec::GroupOfItems.attributes)
-      expect(GroupSpec::ComplexType.mappings_for(:xml).elements).to include(*GroupSpec::GroupOfItems.mappings_for(:xml).elements)
+    describe GroupSpec::GenericType do
+      it_behaves_like "imports mappings from", GroupSpec::GroupOfItems, described_class
     end
 
-    it "import attributes and mappings outside the xml block" do
-      expect(GroupSpec::SimpleType.attributes).to include(GroupSpec::GroupOfItems.attributes)
-      expect(GroupSpec::SimpleType.mappings_for(:xml).elements).to include(*GroupSpec::GroupOfItems.mappings_for(:xml).elements)
+    describe GroupSpec::SimpleType do
+      it_behaves_like "imports attributes from", GroupSpec::GroupOfItems, described_class
+      it_behaves_like "imports mappings from", GroupSpec::GroupOfItems, described_class
+    end
+
+    describe GroupSpec::Mrow do
+      it_behaves_like "imports attributes from", GroupSpec::CommonAttributes, described_class
+      it_behaves_like "imports attributes from", GroupSpec::Ceramic, described_class
+      it_behaves_like "imports mappings from", GroupSpec::CommonAttributes, described_class
+      it_behaves_like "imports mappings from", GroupSpec::Ceramic, described_class
+    end
+
+    describe GroupSpec::Contributor do
+      it_behaves_like "imports attributes from", GroupSpec::ContributionInfo, described_class
+    end
+
+    context "when importing multiple models with overlapping attributes" do
+      let(:mrow_instance) do
+        GroupSpec::Mrow.new
+      end
+
+      it "uses Ceramic's default values for overlapping attributes" do
+        expect(mrow_instance.type).to eq("Data")
+        expect(mrow_instance.name).to eq("Starc")
+      end
+
+      it "maintains the correct XML serialization order from last import" do
+        xml = mrow_instance.to_xml
+        expected_xml = "<mrow xmlns:ex1='http://www.example.com' xmlns:GML='http://www.sparxsystems.com/profiles/GML/1.0'/>"
+
+        expect(xml).to be_equivalent_to(expected_xml)
+      end
+    end
+
+    context "when update the imported attribute" do
+      it "updates the attribute `mstyle` only in `Mrow`" do
+        GroupSpec::Mrow.attributes[:mstyle].instance_variable_set(:@type, :integer)
+        expect(GroupSpec::Mrow.attributes[:mstyle].type).to eq(:integer)
+      end
+
+      it "maintains original type for the attribute `mstyle` in `Mfrac`" do
+        expect(GroupSpec::Mfrac.attributes[:mstyle].type).to eq(Lutaml::Model::Type::String)
+      end
+
+      it "maintains original type for the attribute `mstyle` in importable class `CommonAttributes`" do
+        expect(GroupSpec::CommonAttributes.attributes[:mstyle].type).to eq(Lutaml::Model::Type::String)
+      end
+    end
+
+    context "when updating imported choice" do
+      it "updates choice min/max only in Mrow" do
+        choice = GroupSpec::Mrow.choice_attributes.first
+        choice.instance_variable_set(:@min, 2)
+        choice.instance_variable_set(:@max, 3)
+
+        expect(choice.min).to eq(2)
+        expect(choice.max).to eq(3)
+      end
+
+      it "maintains original choice min/max in Mfrac" do
+        choice = GroupSpec::Mfrac.choice_attributes.first
+        expect(choice.min).to eq(1)
+        expect(choice.max).to eq(1)
+      end
+
+      it "maintains original choice min/max in CommonAttributes" do
+        choice = GroupSpec::CommonAttributes.choice_attributes.first
+        expect(choice.min).to eq(1)
+        expect(choice.max).to eq(1)
+      end
+    end
+
+    context "when updating imported mappings" do
+      let(:new_namespace) { "http://www.example.com/new" }
+      let(:new_prefix) { "test" }
+
+      context "with element mappings" do
+        it "updates the mapping namespace only in `Mrow`" do
+          mapping = GroupSpec::Mrow.mappings_for(:xml).elements.find { |e| e.name == :mstyle }
+          mapping.instance_variable_set(:@namespace, new_namespace)
+          mapping.instance_variable_set(:@prefix, new_prefix)
+
+          expect(mapping.namespace).to eq(new_namespace)
+          expect(mapping.prefix).to eq(new_prefix)
+        end
+
+        it "maintains original namespace for `mstyle` mapping in `Mfrac`" do
+          mapping = GroupSpec::Mfrac.mappings_for(:xml).elements.find { |e| e.name == :mstyle }
+          expect(mapping.namespace).to be_nil
+          expect(mapping.prefix).to be_nil
+        end
+
+        it "maintains original namespace for `mstyle` mapping in `CommonAttributes`" do
+          mapping = GroupSpec::CommonAttributes.mappings_for(:xml).elements.find { |e| e.name == :mstyle }
+          expect(mapping.namespace).to be_nil
+          expect(mapping.prefix).to be_nil
+        end
+      end
+
+      context "with attribute mappings" do
+        it "updates attribute mapping only in `Mrow`" do
+          mapping = GroupSpec::Mrow.mappings_for(:xml).attributes.find { |a| a.name == :mcol }
+          mapping.instance_variable_set(:@namespace, new_namespace)
+
+          expect(mapping.namespace).to eq(new_namespace)
+        end
+
+        it "maintains original attribute mapping in `Mfrac`" do
+          mapping = GroupSpec::Mfrac.mappings_for(:xml).attributes.find { |a| a.name == :mcol }
+          expect(mapping.namespace).to be_nil
+        end
+
+        it "maintains original attribute mapping in `CommonAttributes`" do
+          mapping = GroupSpec::CommonAttributes.mappings_for(:xml).attributes.find { |a| a.name == :mcol }
+          expect(mapping.namespace).to be_nil
+        end
+      end
+
+      context "with sequence elements" do
+        it "updates sequence elements only in `Mrow`" do
+          sequence = GroupSpec::Mrow.mappings_for(:xml).element_sequence.first
+          sequence.attributes << Lutaml::Model::XmlMappingRule.new(
+            "new_element",
+            to: :new_element,
+            namespace: "http://example.com",
+            prefix: "test",
+          )
+
+          expect(sequence.attributes.map(&:name)).to include("new_element")
+        end
+
+        it "maintains original sequence elements in `Mfrac`" do
+          original_sequence = GroupSpec::Mfrac.mappings_for(:xml).element_sequence.first
+          expect(original_sequence.attributes.map(&:name)).not_to include("new_element")
+        end
+
+        it "maintains original sequence elements in `CommonAttributes`" do
+          original_sequence = GroupSpec::CommonAttributes.mappings_for(:xml).element_sequence.first
+          expect(original_sequence.attributes.map(&:name)).not_to include("new_element")
+        end
+
+        it "creates new sequence object with the new mapping object as model of sequence in `Mrow`" do
+          mrow_sequence_model = GroupSpec::Mrow.mappings_for(:xml).element_sequence[0].model
+          common_attributes_sequence_model = GroupSpec::CommonAttributes.mappings_for(:xml).element_sequence[0].model
+          expect(mrow_sequence_model).not_to be(common_attributes_sequence_model)
+        end
+      end
     end
 
     it "raises error if root is defined on imported class" do


### PR DESCRIPTION
This PR updates:
1. `import_model` is now supported for `key-value` formats.
2. Missing attribute methods with the `import_model_attributes` functionality.

This PR is also related to the **Schema** generator updates.
closes #310 
closes #321 
closes #340 