### PR TITLE
Make liquid dependency optional

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,10 @@ gemspec
 gem "benchmark-ips"
 gem "bigdecimal"
 gem "equivalent-xml"
-gem "liquid"
+# TODO: remove once https://github.com/Shopify/liquid/issues/1772 is fixed
+# needed for liquid with ruby 3.4
+gem "base64"
+gem "liquid", "~> 5"
 gem "lutaml-xsd"
 gem "multi_json"
 gem "nokogiri"

--- a/lutaml-model.gemspec
+++ b/lutaml-model.gemspec
@@ -30,10 +30,6 @@ Gem::Specification.new do |spec|
   end
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
 
-  # TODO: remove once https://github.com/Shopify/liquid/issues/1772 is fixed
-  # needed for liquid with ruby 3.4
-  spec.add_dependency "base64"
-  spec.add_dependency "liquid", "~> 5"
   spec.add_dependency "moxml", ">= 0.1.2"
   spec.add_dependency "thor"
   spec.metadata["rubygems_mfa_required"] = "true"


### PR DESCRIPTION
This PR moves the `liquid` gem (with its dependency) from gemspec to the Gemfile since this is an optional feature.

related to => plurimath/plurimath.org#65