### PR TITLE
fix: missing 'root_mappings' and Collection inheritance

### DIFF
--- a/lib/lutaml/model/collection.rb
+++ b/lib/lutaml/model/collection.rb
@@ -4,6 +4,24 @@ module Lutaml
       include Enumerable
 
       class << self
+        INHERITED_ATTRIBUTES = %i[
+          instance_type
+          instance_name
+          order_by_field
+          order_direction
+        ].freeze
+
+        def inherited(subclass)
+          super
+
+          INHERITED_ATTRIBUTES.each do |var|
+            subclass.instance_variable_set(
+              :"@#{var}",
+              instance_variable_get(:"@#{var}"),
+            )
+          end
+        end
+
         attr_reader :instance_type,
                     :instance_name,
                     :order_by_field,

--- a/lib/lutaml/model/mapping/key_value_mapping.rb
+++ b/lib/lutaml/model/mapping/key_value_mapping.rb
@@ -206,7 +206,7 @@ module Lutaml
       end
 
       def find_by_name(name)
-        @mappings[m.name.to_s] == name.to_s
+        @mappings.find { |m| m.name.to_s == name.to_s }
       end
 
       def polymorphic_mapping

--- a/lib/lutaml/model/mapping/key_value_mapping.rb
+++ b/lib/lutaml/model/mapping/key_value_mapping.rb
@@ -48,6 +48,7 @@ module Lutaml
       )
         mapping_name = name_for_mapping(root_mappings, name)
         validate!(mapping_name, to, with, render_nil, render_empty)
+        remove_existing_mapping_with(mapping_name)
 
         @mappings << KeyValueMappingRule.new(
           mapping_name,
@@ -207,6 +208,10 @@ module Lutaml
 
       def root_mapping
         @mappings.find(&:root_mapping?)
+      end
+
+      def remove_existing_mapping_with(name)
+        @mappings.delete_if { |m| m.name.to_s == name.to_s }
       end
 
       Lutaml::Model::Config::KEY_VALUE_FORMATS.each do |format|

--- a/lib/lutaml/model/mapping/key_value_mapping_rule.rb
+++ b/lib/lutaml/model/mapping/key_value_mapping_rule.rb
@@ -64,6 +64,7 @@ module Lutaml
           with: Utils.deep_dup(custom_methods),
           delegate: delegate,
           child_mappings: Utils.deep_dup(child_mappings),
+          root_mappings: Utils.deep_dup(root_mappings),
           value_map: Utils.deep_dup(@value_map),
         )
       end

--- a/lib/lutaml/model/serialize.rb
+++ b/lib/lutaml/model/serialize.rb
@@ -211,14 +211,14 @@ module Lutaml
               @mappings[format].merge_mapping_elements(mapping)
               @mappings[format].merge_elements_sequence(mapping)
             else
-              @mappings[format].mappings.concat(mapping.mappings)
+              @mappings[format].mappings_hash.merge!(mapping.mappings_hash)
             end
           end
         end
 
         def handle_key_value_mappings(mapping, format)
           @mappings[format] ||= KeyValueMapping.new
-          @mappings[format].mappings.concat(mapping.mappings)
+          @mappings[format].mappings_hash.merge!(mapping.mappings_hash)
         end
 
         def import_model(model)

--- a/spec/lutaml/model/xml/root_mappings/nested_child_mappings_spec.rb
+++ b/spec/lutaml/model/xml/root_mappings/nested_child_mappings_spec.rb
@@ -47,6 +47,10 @@ module NestedChildMappingsSpec
       }
     end
   end
+
+  class ManifestResponseWrap < ManifestResponse
+    # This class confirms the successful inhertiance of the `Collection` attribute.
+  end
 end
 
 RSpec.describe "NestedChildMappingsSpec" do
@@ -90,8 +94,52 @@ RSpec.describe "NestedChildMappingsSpec" do
     YAML
   end
 
+  let(:wrapped_yaml) do
+    <<~YAML
+      ---
+      Yu Gothic:
+        Bold:
+          full_name: Yu Gothic Bold
+          paths:
+          - "/Applications/Microsoft Excel.app/Contents/Resources/DFonts/YuGothB.ttc"
+          - "/Applications/Microsoft OneNote.app/Contents/Resources/DFonts/YuGothB.ttc"
+          - "/Applications/Microsoft Outlook.app/Contents/Resources/DFonts/YuGothB.ttc"
+          - "/Applications/Microsoft PowerPoint.app/Contents/Resources/DFonts/YuGothB.ttc"
+          - "/Applications/Microsoft Word.app/Contents/Resources/DFonts/YuGothB.ttc"
+        Regular:
+          full_name: Yu Gothic Regular
+          paths:
+          - "/Applications/Microsoft Excel.app/Contents/Resources/DFonts/YuGothR.ttc"
+          - "/Applications/Microsoft OneNote.app/Contents/Resources/DFonts/YuGothR.ttc"
+          - "/Applications/Microsoft Outlook.app/Contents/Resources/DFonts/YuGothR.ttc"
+          - "/Applications/Microsoft PowerPoint.app/Contents/Resources/DFonts/YuGothR.ttc"
+          - "/Applications/Microsoft Word.app/Contents/Resources/DFonts/YuGothR.ttc"
+      Noto Sans Condensed:
+        Regular:
+          full_name: Noto Sans Condensed
+          paths:
+          - "/Users/foo/.fontist/fonts/NotoSans-Condensed.ttf"
+        Bold:
+          full_name: Noto Sans Condensed Bold
+          paths:
+          - "/Users/foo/.fontist/fonts/NotoSans-CondensedBold.ttf"
+        Bold Italic:
+          full_name: Noto Sans Condensed Bold Italic
+          paths:
+          - "/Users/foo/.fontist/fonts/NotoSans-CondensedBoldItalic.ttf"
+        Italic:
+          full_name: Noto Sans Condensed Italic
+          paths:
+          - "/Users/foo/.fontist/fonts/NotoSans-CondensedItalic.ttf"
+    YAML
+  end
+
   let(:parsed_yaml) do
     NestedChildMappingsSpec::ManifestResponse.from_yaml(yaml)
+  end
+
+  let(:wrap_parsed_yaml) do
+    NestedChildMappingsSpec::ManifestResponseWrap.from_yaml(wrapped_yaml)
   end
 
   let(:expected_fonts) do
@@ -159,6 +207,11 @@ RSpec.describe "NestedChildMappingsSpec" do
 
   it "rounds trip correctly" do
     expected_yaml = parsed_yaml.to_yaml
+    expect(expected_yaml).to eq(yaml)
+  end
+
+  it "round trips nested child mappings correctly with Wrap class" do
+    expected_yaml = wrap_parsed_yaml.to_yaml
     expect(expected_yaml).to eq(yaml)
   end
 end


### PR DESCRIPTION
Added the missing `Collection` attributes when inherited and included the `root_mappings` in the `key_value_mapping`'s `deep_dup` method.

closes #449