### PR TITLE
`register` argument for Collection instances

### DIFF
--- a/lib/lutaml/model/collection.rb
+++ b/lib/lutaml/model/collection.rb
@@ -96,14 +96,13 @@ module Lutaml
         items = [items].compact unless items.is_a?(Array)
 
         register_object = Lutaml::Model::GlobalRegister.lookup(@__register)
-        type = register_object.get_class_without_register(self.class.instance_type)
+        type = register_object.get_class(self.class.instance_type)
         self.collection = items.map do |item|
           if item.is_a?(type)
             item
           elsif type <= Lutaml::Model::Type::Value
             type.cast(item)
           else
-            item[:__register] = __register
             type.new(item)
           end
         end

--- a/lib/lutaml/model/register.rb
+++ b/lib/lutaml/model/register.rb
@@ -28,7 +28,7 @@ module Lutaml
       def get_class(klass_name)
         expected_class = get_class_without_register(klass_name)
         if !(expected_class < Lutaml::Model::Type::Value)
-          expected_class.class_variable_set(:@@register, id)
+          expected_class.class_variable_set(:@@__register, id)
         end
         expected_class
       end

--- a/lib/lutaml/model/schema/shared_methods.rb
+++ b/lib/lutaml/model/schema/shared_methods.rb
@@ -5,8 +5,8 @@ module Lutaml
     module Schema
       module SharedMethods
         def extract_register_from(klass)
-          register = if klass.class_variable_defined?(:@@register)
-                       klass.class_variable_get(:@@register)
+          register = if klass.class_variable_defined?(:@@__register)
+                       klass.class_variable_get(:@@__register)
                      end
 
           case register

--- a/lib/lutaml/model/serialize.rb
+++ b/lib/lutaml/model/serialize.rb
@@ -497,8 +497,8 @@ module Lutaml
         def extract_register_id(register)
           if register
             register.is_a?(Lutaml::Model::Register) ? register.id : register
-          elsif class_variable_defined?(:@@register)
-            class_variable_get(:@@register)
+          elsif class_variable_defined?(:@@__register)
+            class_variable_get(:@@__register)
           else
             Lutaml::Model::Config.default_register
           end


### PR DESCRIPTION
This PR updates the `register` class variables and updates the `Collection`'s `initialize` function.

closes #450