### PR TITLE
fix: deprecation warnings should display line of where the deprecated method is called

### DIFF
--- a/lib/lutaml/model/services/logger.rb
+++ b/lib/lutaml/model/services/logger.rb
@@ -12,7 +12,7 @@ module Lutaml
       #   Usage of `old` name is deprecated will be removed in the next major
       #   release. Please use the `replacement`` instead.
       def self.warn_future_deprecation(old:, replacement:)
-        trace = caller_locations[7] # first locations after the gem's internal files
+        trace = caller_locations(8..8).first # first locations after the gem's internal files
         warn("Usage of `#{old}` is deprecated and will be removed in the next major release. Please use `#{replacement}` instead.", "#{trace.path}:#{trace.lineno}:")
       end
 

--- a/lib/lutaml/model/services/logger.rb
+++ b/lib/lutaml/model/services/logger.rb
@@ -1,8 +1,8 @@
 module Lutaml
   module Model
     class Logger
-      def self.warn(message)
-        new.call(message, :warn)
+      def self.warn(message, path = nil)
+        new.call(message, :warn, path)
       end
 
       # @param [String] old: The name of the deprecated class or method
@@ -12,7 +12,8 @@ module Lutaml
       #   Usage of `old` name is deprecated will be removed in the next major
       #   release. Please use the `replacement`` instead.
       def self.warn_future_deprecation(old:, replacement:)
-        warn("Usage of `#{old}` is deprecated and will be removed in the next major release. Please use `#{replacement}` instead.")
+        trace = caller_locations[7] # first locations after the gem's internal files
+        warn("Usage of `#{old}` is deprecated and will be removed in the next major release. Please use `#{replacement}` instead.", "#{trace.path}:#{trace.lineno}:")
       end
 
       # @param [String] name
@@ -26,8 +27,8 @@ module Lutaml
         warn("`#{name}` is handled by default. No need to explicitly define at `#{caller_file}:#{caller_line}`")
       end
 
-      def call(message, type)
-        Warning.warn format_message(message, type)
+      def call(message, type, path = nil)
+        Warning.warn format_message(message, type, path)
       end
 
       private
@@ -46,8 +47,8 @@ module Lutaml
         "\e[#{color}m#{message}\e[0m"
       end
 
-      def format_message(message, type)
-        colorize("\n[Lutaml::Model] #{type.upcase}: #{message}\n", type)
+      def format_message(message, type, path = nil)
+        colorize("\n[Lutaml::Model] #{type.upcase}:#{path} #{message}\n", type)
       end
     end
   end

--- a/spec/lutaml/model/logger_spec.rb
+++ b/spec/lutaml/model/logger_spec.rb
@@ -1,0 +1,67 @@
+require "spec_helper"
+
+RSpec.describe Lutaml::Model::Logger do
+  describe ".warn" do
+    it "formats message with path when provided" do
+      message = "Test warning message"
+      path = "example.rb:123"
+
+      warning_output = capture_warning do
+        described_class.warn(message, path)
+      end
+
+      expect(warning_output).to include("[Lutaml::Model] WARN:example.rb:123 Test warning message")
+    end
+
+    it "formats message without path when not provided" do
+      message = "Test warning message"
+
+      warning_output = capture_warning do
+        described_class.warn(message)
+      end
+
+      expect(warning_output).to include("[Lutaml::Model] WARN: Test warning message")
+    end
+  end
+
+  describe ".warn_future_deprecation" do
+    it "shows deprecation warning with caller location" do
+      old_method = "old_method"
+      replacement = "new_method"
+
+      warning_output = capture_warning do
+        described_class.warn_future_deprecation(old: old_method, replacement: replacement)
+      end
+
+      expect(warning_output).to include("Usage of `old_method` is deprecated")
+      expect(warning_output).to include("Please use `new_method` instead")
+      expect(warning_output).to match(/:\d+:/) # Should include line number
+    end
+  end
+
+  describe "integration with existing methods" do
+    it "works with warn_auto_handling" do
+      expect do
+        described_class.warn_auto_handling(
+          name: "test_attribute",
+          caller_file: "test.rb",
+          caller_line: 42,
+        )
+      end.not_to raise_error
+    end
+  end
+
+  private
+
+  def capture_warning
+    # Capture stderr output
+    original_stderr = $stderr
+    $stderr = StringIO.new
+
+    yield
+
+    $stderr.string
+  ensure
+    $stderr = original_stderr
+  end
+end


### PR DESCRIPTION
fixes #453 

Added file path and line number where the deprecated method is called.