### PR TITLE
Updated `Xml::Element` to support `to_liquid` method

### DIFF
--- a/lib/lutaml/model/liquefiable.rb
+++ b/lib/lutaml/model/liquefiable.rb
@@ -72,6 +72,8 @@ module Lutaml
               register_drop_method(attr_name)
             end
 
+            register_drop_method(:element_order)
+
             generate_mapping_methods
           end
         end

--- a/lib/lutaml/model/xml/element.rb
+++ b/lib/lutaml/model/xml/element.rb
@@ -2,6 +2,8 @@ module Lutaml
   module Model
     module Xml
       class Element
+        include Lutaml::Model::Liquefiable
+
         attr_reader :type, :name
 
         def initialize(type, name)
@@ -25,7 +27,31 @@ module Lutaml
           end
         end
 
+        def to_liquid
+          self.class.validate_liquid!
+          self.class.register_liquid_drop_class unless self.class.drop_class
+
+          register_liquid_methods
+          self.class.drop_class.new(self)
+        end
+
         alias == eql?
+
+        private
+
+        def register_liquid_methods
+          %i[text? element_tag type name].each do |attr_name|
+            self.class.register_drop_method(attr_name)
+          end
+
+          self.class.drop_class.define_method(:==) do |other|
+            return false unless other.is_a?(self.class)
+
+            instance_variables.all? do |var|
+              instance_variable_get(var) == other.instance_variable_get(var)
+            end
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
This PR updates the `Xml::Element` class to support the `to_liquid` method.

related to metanorma/metanorma-plugin-lutaml#177