### PR TITLE
fix: `except` option support

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -4754,7 +4754,7 @@ class JapaneseCeramic < Lutaml::Model::Serializable
   xml do
     root 'JapaneseCeramic'
     map_attribute 'glazeType', to: :glaze_type
-    map_element 'description' to: :description
+    map_element 'description', to: :description
   end
 end
 ----
@@ -4866,7 +4866,7 @@ class JapaneseCeramic < Lutaml::Model::Serializable
   xml do
     root 'JapaneseCeramic'
     map_attribute 'glazeType', to: :glaze_type
-    map_element 'description' to: :description
+    map_element 'description', to: :description
   end
 end
 ----
@@ -4891,6 +4891,52 @@ end
 ----
 ====
 
+
+===== Skip Model attribute rendering (exporting)
+
+In `to_xml`, the `except` option allows you to exclude certain model attributes from being included in the XML output.
+
+`except`:: An array of attribute names.
+
+[example]
+====
+[source, ruby]
+----
+class JapaneseCeramic < Lutaml::Model::Serializable
+  attribute :glaze_type, :string
+  attribute :description, :string
+
+  xml do
+    root 'JapaneseCeramic'
+    map_attribute 'glazeType', to: :glaze_type
+    map_element 'description', to: :description
+  end
+end
+----
+
+[source,ruby]
+----
+# Create a new instance
+> instance = JapaneseCeramic.new(glaze_type: "Clear", description: "Porcelain")
+#=> #<JapaneseCeramic:0x00000002e5625650 @description="Porcelain", @glaze_type="Clear">
+
+# Serialize the instance to XML without glaze_type
+> instance.to_xml(except: [:glaze_type])
+#=> "<JapaneseCeramic>\n  <description>Porcelain</description>\n</JapaneseCeramic>"
+
+# Serialize the instance to XML without glaze_type and description
+> instance.to_xml(except: [:glaze_type, :description])
+#=> "<JapaneseCeramic/>"
+
+# Serialize the instance to YAML without glaze_type
+> instance.to_yaml(except: [:glaze_type])
+#=> "---\ndescription: Porcelain\n"
+
+# Serialize the instance to YAML without glaze_type and description
+> instance.to_yaml(except: [:glaze_type, :description])
+#=> "--- {}\n"
+----
+====
 
 ===== Deserialization character encoding (parsing)
 

--- a/lib/lutaml/model/xml/document.rb
+++ b/lib/lutaml/model/xml/document.rb
@@ -221,6 +221,8 @@ module Lutaml
           prefixed_xml = xml.add_namespace_prefix(prefix)
           tag_name = options[:tag_name] || xml_mapping.root_element
 
+          return if options[:except]&.include?(tag_name)
+
           prefixed_xml.create_and_add_element(tag_name, prefix: prefix,
                                                         attributes: attributes) do
             if options.key?(:namespace_prefix) && !options[:namespace_prefix]
@@ -236,6 +238,8 @@ module Lutaml
             mappings.each do |element_rule|
               attribute_def = attribute_definition_for(element, element_rule,
                                                        mapper_class: mapper_class)
+
+              next if options[:except]&.include?(element_rule.to)
 
               if attribute_def
                 value = attribute_value_for(element, element_rule)
@@ -357,8 +361,7 @@ module Lutaml
           end
 
           xml_mapping.attributes.each_with_object(attrs) do |mapping_rule, hash|
-            next if options[:except]&.include?(mapping_rule.to)
-            next if mapping_rule.custom_methods[:to]
+            next if mapping_rule.custom_methods[:to] || options[:except]&.include?(mapping_rule.to)
 
             mapping_rule_name = mapping_rule.multiple_mappings? ? mapping_rule.name.first : mapping_rule.name
 

--- a/lib/lutaml/model/xml/oga_adapter.rb
+++ b/lib/lutaml/model/xml/oga_adapter.rb
@@ -115,13 +115,16 @@ module Lutaml
         def build_ordered_element(builder, element, options = {})
           mapper_class = determine_mapper_class(element, options)
           xml_mapping = mapper_class.mappings_for(:xml)
-          return xml unless xml_mapping
+          return builder unless xml_mapping
 
-          attributes = build_attributes(element, xml_mapping).compact
+          attributes = build_attributes(element, xml_mapping, options).compact
+
+          prefix = determine_namespace_prefix(options, xml_mapping)
+          prefixed_xml = builder.add_namespace_prefix(prefix)
 
           tag_name = options[:tag_name] || xml_mapping.root_element
-          builder.create_and_add_element(tag_name,
-                                         attributes: attributes) do |el|
+
+          prefixed_xml.create_and_add_element(tag_name, attributes: attributes) do |el|
             index_hash = {}
             content = []
 
@@ -131,7 +134,7 @@ module Lutaml
               curr_index = index_hash[object_key] += 1
 
               element_rule = xml_mapping.find_by_name(object.name, type: object.type)
-              next if element_rule.nil?
+              next if element_rule.nil? || options[:except]&.include?(element_rule.to)
 
               attribute_def = attribute_definition_for(element, element_rule,
                                                        mapper_class: mapper_class)

--- a/spec/lutaml/model/except_spec.rb
+++ b/spec/lutaml/model/except_spec.rb
@@ -1,0 +1,217 @@
+require "spec_helper"
+require "lutaml/model"
+require "lutaml/model/xml/ox_adapter"
+require "lutaml/model/xml/oga_adapter"
+
+module ExceptSpecs
+  class Annotation < Lutaml::Model::Serializable
+    attribute :id, :string
+    attribute :appinfo, :string
+    attribute :documentation, :string
+
+    xml do
+      root "annotation", mixed: true
+      namespace "http://www.w3.org/2001/XMLSchema", "xsd"
+
+      map_element :documentation, to: :documentation
+      map_element :appinfo, to: :appinfo
+      map_attribute :id, to: :id
+    end
+  end
+
+  class Attribute < Lutaml::Model::Serializable
+    attribute :id, :string
+    attribute :ref, :string
+    attribute :name, :string
+    attribute :annotation, Annotation
+
+    xml do
+      root "attribute", mixed: true
+      namespace "http://www.w3.org/2001/XMLSchema", "xsd"
+
+      map_attribute :id, to: :id
+      map_attribute :ref, to: :ref
+      map_attribute :name, to: :name
+      map_element :annotation, to: :annotation
+    end
+  end
+
+  class AttributeGroup < Lutaml::Model::Serializable
+    attribute :id, :string
+    attribute :ref, :string
+    attribute :name, :string
+    attribute :annotation, Annotation
+    attribute :attribute, Attribute
+
+    xml do
+      root "attributeGroup", mixed: true
+      namespace "http://www.w3.org/2001/XMLSchema", "xsd"
+
+      map_attribute :id, to: :id
+      map_attribute :ref, to: :ref
+      map_attribute :name, to: :name
+      map_element :attribute, to: :attribute
+      map_element :annotation, to: :annotation
+    end
+  end
+
+  class Schema < Lutaml::Model::Serializable
+    attribute :id, :string
+    attribute :attribute, Attribute
+    attribute :attribute_group, AttributeGroup
+
+    xml do
+      root "schema", mixed: true
+      namespace "http://www.w3.org/2001/XMLSchema", "xsd"
+
+      map_attribute :id, to: :id
+      map_element :attribute, to: :attribute
+      map_element :attributeGroup, to: :attribute_group
+    end
+  end
+end
+
+RSpec.describe "Except" do
+  shared_examples "xml" do |adapter_class|
+    around do |example|
+      old_adapter = Lutaml::Model::Config.xml_adapter
+      Lutaml::Model::Config.xml_adapter = adapter_class
+      example.run
+    ensure
+      Lutaml::Model::Config.xml_adapter = old_adapter
+    end
+
+    context "when :except option is used for XML conversion" do
+      let(:xml) do
+        <<~XML
+          <xsd:schema id="testing" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+            <xsd:attribute id="attr1" name="test">
+              <xsd:annotation>
+                <xsd:documentation>A test model</xsd:documentation>
+              </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attributeGroup id="attr2">
+              <xsd:annotation>
+                <xsd:documentation>Another test model</xsd:documentation>
+              </xsd:annotation>
+              <xsd:attribute id="nested_attr" name="nested">
+                <xsd:annotation>
+                  <xsd:documentation>Nested attribute</xsd:documentation>
+                </xsd:annotation>
+              </xsd:attribute>
+            </xsd:attributeGroup>
+          </xsd:schema>
+        XML
+      end
+
+      let(:xml_without_annotations) do
+        <<~XML
+          <xsd:schema id="testing" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+            <xsd:attribute id="attr1" name="test"/>
+            <xsd:attributeGroup id="attr2">
+              <xsd:attribute id="nested_attr" name="nested"/>
+            </xsd:attributeGroup>
+          </xsd:schema>
+        XML
+      end
+
+      let(:xml_without_annotations_and_ids) do
+        <<~XML
+          <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+            <xsd:attribute name="test"/>
+            <xsd:attributeGroup>
+              <xsd:attribute name="nested"/>
+            </xsd:attributeGroup>
+          </xsd:schema>
+        XML
+      end
+
+      let(:parsed_instances) { ExceptSpecs::Schema.from_xml(xml) }
+
+      it "excludes specified elements from the XML output" do
+        parsed_xml = parsed_instances.to_xml(except: %i[annotation])
+        expect(parsed_xml).to be_equivalent_to(xml_without_annotations)
+      end
+
+      it "excludes specified attributes and elements from the XML output" do
+        parsed_xml = parsed_instances.to_xml(except: %i[annotation id])
+        expect(parsed_xml).to be_equivalent_to(xml_without_annotations_and_ids)
+      end
+    end
+  end
+
+  describe "yaml" do
+    context "when :except option is used for YAML (key-value) conversion" do
+      let(:yaml) do
+        <<~YAML
+          ---
+          id: testing
+          attribute:
+            id: attr1
+            name: test
+            annotation:
+              documentation: A test model
+          attribute_group:
+            id: attr2
+            annotation:
+              documentation: Another test model
+            attribute:
+              id: nested_attr
+              name: nested
+              annotation:
+                documentation: Nested attribute
+        YAML
+      end
+
+      let(:yaml_without_annotations) do
+        <<~YAML
+          ---
+          id: testing
+          attribute:
+            id: attr1
+            name: test
+          attribute_group:
+            id: attr2
+            attribute:
+              id: nested_attr
+              name: nested
+        YAML
+      end
+
+      let(:yaml_without_annotations_and_ids) do
+        <<~YAML
+          ---
+          attribute:
+            name: test
+          attribute_group:
+            attribute:
+              name: nested
+        YAML
+      end
+
+      let(:parsed_instances) { ExceptSpecs::Schema.from_yaml(yaml) }
+
+      it "excludes 'annotation' keys from the YAML output" do
+        parsed_yaml = parsed_instances.to_yaml(except: %i[annotation])
+        expect(parsed_yaml).to be_equivalent_to(yaml_without_annotations)
+      end
+
+      it "excludes 'annotation' and 'id' from the YAML output" do
+        parsed_yaml = parsed_instances.to_yaml(except: %i[annotation id])
+        expect(parsed_yaml).to be_equivalent_to(yaml_without_annotations_and_ids)
+      end
+    end
+  end
+
+  describe Lutaml::Model::Xml::NokogiriAdapter do
+    it_behaves_like "xml", described_class
+  end
+
+  describe Lutaml::Model::Xml::OgaAdapter do
+    it_behaves_like "xml", described_class
+  end
+
+  describe Lutaml::Model::Xml::OxAdapter do
+    it_behaves_like "xml", described_class
+  end
+end

--- a/spec/lutaml/model/included_spec.rb
+++ b/spec/lutaml/model/included_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe "Included" do
   end
 
   it "uses included module attributes" do
-    expect(impl_object.to_xml(pretty: true)).to eq(expected_xml)
+    expect(impl_object.to_xml(pretty: true)).to be_equivalent_to(expected_xml)
   end
 
   context "with multiple implementing classes" do

--- a/spec/lutaml/model/inheritance_spec.rb
+++ b/spec/lutaml/model/inheritance_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe "Inheritance" do
   end
 
   it "uses parent attributes" do
-    expect(child_object.to_xml(pretty: true)).to eq(expected_xml)
+    expect(child_object.to_xml(pretty: true)).to be_equivalent_to(expected_xml)
   end
 
   context "with multiple child classes" do
@@ -176,7 +176,7 @@ RSpec.describe "Inheritance" do
 
     it "round trip correctly" do
       parsed = InheritanceSpec::Child.from_xml(xml)
-      expect(parsed.to_xml).to eq(xml)
+      expect(parsed.to_xml).to be_equivalent_to(xml)
     end
   end
 

--- a/spec/lutaml/model/mixed_content_spec.rb
+++ b/spec/lutaml/model/mixed_content_spec.rb
@@ -250,7 +250,7 @@ RSpec.describe "MixedContent" do
             expected_output = expected_output.gsub(/\n\s*/, " ")
           end
 
-          expect(content).to eq(expected_output)
+          expect(content).to be_equivalent_to(expected_output)
         end
 
         serialized = parsed.to_xml


### PR DESCRIPTION
This PR adds support for the `except` argument to `elements`.
Added support for `except` and fixed the serialization of namespaced elements for **Oga** and **Ox** adapters.

Added a section in the documentation section for the `except` option.

closes #469 