### PR TITLE
fix: rubocop issues

### DIFF
--- a/spec/lutaml/model/type/integer_spec.rb
+++ b/spec/lutaml/model/type/integer_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe Lutaml::Model::Type::Integer do
     end
 
     context "with very large integer" do
-      let(:max_value) { ((2**((0.size * 8) - 2))) }
+      let(:max_value) { (2**((0.size * 8) - 2)) }
       let(:value) { max_value.to_s }
 
       it { is_expected.to eq(max_value) }


### PR DESCRIPTION
integer_spec was failing rubocop check due to rubocop version update. 1.80.1 -> 1.80.2

changed the integer_spec.rb file to pass the check.