### PR TITLE
fix: missing element prefixes for Ox and Oga adapters

### DIFF
--- a/lib/lutaml/model/xml/oga_adapter.rb
+++ b/lib/lutaml/model/xml/oga_adapter.rb
@@ -124,7 +124,7 @@ module Lutaml
 
           tag_name = options[:tag_name] || xml_mapping.root_element
 
-          prefixed_xml.create_and_add_element(tag_name, attributes: attributes) do |el|
+          prefixed_xml.create_and_add_element(tag_name, prefix: prefix, attributes: attributes) do |el|
             index_hash = {}
             content = []
 

--- a/lib/lutaml/model/xml/ox_adapter.rb
+++ b/lib/lutaml/model/xml/ox_adapter.rb
@@ -56,7 +56,7 @@ module Lutaml
           prefixed_xml = builder.add_namespace_prefix(prefix)
 
           tag_name = options[:tag_name] || xml_mapping.root_element
-          prefixed_xml.create_and_add_element(tag_name, attributes: attributes) do |el|
+          prefixed_xml.create_and_add_element(tag_name, prefix: prefix, attributes: attributes) do |el|
             if options.key?(:namespace_prefix) && !options[:namespace_prefix]
               prefixed_xml.add_namespace_prefix(nil)
             end

--- a/spec/lutaml/model/mixed_content_spec.rb
+++ b/spec/lutaml/model/mixed_content_spec.rb
@@ -201,6 +201,46 @@ module MixedContentSpec
       map_content to: :content
     end
   end
+
+  module PrefixedElements
+    class Annotation < Lutaml::Model::Serializable
+      attribute :content, :string
+
+      xml do
+        root "annotation"
+        namespace "http://example.com/schema", "xsd"
+
+        map_content to: :content
+      end
+    end
+
+    class Element < Lutaml::Model::Serializable
+      attribute :name, :string
+      attribute :status, :string
+      attribute :annotation, Annotation
+
+      xml do
+        root "element", mixed: true
+
+        namespace "http://example.com/schema", "xsd"
+
+        map_attribute :name, to: :name
+        map_attribute :status, to: :status
+        map_element :annotation, to: :annotation
+      end
+    end
+
+    class Schema < Lutaml::Model::Serializable
+      attribute :element, Element, collection: true
+
+      xml do
+        root "schema"
+        namespace "http://example.com/schema", "xsd"
+
+        map_element :element, to: :element
+      end
+    end
+  end
 end
 
 RSpec.describe "MixedContent" do
@@ -906,6 +946,24 @@ RSpec.describe "MixedContent" do
             expect(serialized.strip).to eq(expected_xml.force_encoding("ISO-8859-1"))
           end
         end
+      end
+    end
+
+    context "when mixed: true is set for prefixed elements" do
+      let(:xml) do
+        <<~XML
+          <xsd:schema xmlns:xsd="http://example.com/schema">
+            <xsd:element>
+              <xsd:annotation>Testing annotation</xsd:annotation>
+            </xsd:element>
+          </xsd:schema>
+        XML
+      end
+
+      let(:serialized) { MixedContentSpec::PrefixedElements::Schema.from_xml(xml).to_xml }
+
+      it "deserializes and serializes mixed prefixed elements correctly for prefixed elements" do
+        expect(serialized).to be_equivalent_to(xml)
       end
     end
   end


### PR DESCRIPTION
This PR fixes the issue of missing prefixes in the **Ox** and **Oga** adapters.

closes #477 