### PR TITLE
Fix retained original `model` reference in imported `choice` attributes

### DIFF
--- a/lib/lutaml/model/choice.rb
+++ b/lib/lutaml/model/choice.rb
@@ -69,6 +69,20 @@ module Lutaml
         @model.attributes.merge!(attrs_hash)
       end
 
+      def deep_duplicate(new_model)
+        choice = self.class.new(new_model, @min, @max)
+        @attributes.map do |attr|
+          choice.attributes << if attr.is_a?(Choice)
+                                 attr.deep_duplicate(new_model)
+                               else
+                                 choice_attr = new_model.instance_variable_get(:@attributes)[attr.name]
+                                 choice_attr.options[:choice] = choice
+                                 choice_attr
+                               end
+        end
+        choice
+      end
+
       def validate_count_errors!(count, attributes)
         return if count.between?(@min, @max)
         return if optional_empty_choice?(count)

--- a/lib/lutaml/model/serialize.rb
+++ b/lib/lutaml/model/serialize.rb
@@ -49,8 +49,13 @@ module Lutaml
         def initialize_attrs(source_class)
           @mappings = Utils.deep_dup(source_class.instance_variable_get(:@mappings)) || {}
           @attributes = Utils.deep_dup(source_class.instance_variable_get(:@attributes)) || {}
-          @choice_attributes = Utils.deep_dup(source_class.instance_variable_get(:@choice_attributes)) || []
+          @choice_attributes = deep_duplicate_choice_attributes(source_class)
           instance_variable_set(:@model, self)
+        end
+
+        def deep_duplicate_choice_attributes(source_class)
+          choice_attrs = Array(source_class.instance_variable_get(:@choice_attributes))
+          choice_attrs.map { |choice_attr| choice_attr.deep_duplicate(self) }
         end
 
         def attributes(register = nil)
@@ -235,8 +240,8 @@ module Lutaml
             define_attribute_methods(attr)
           end
 
-          @choice_attributes.concat(Utils.deep_dup(model.choice_attributes))
           @attributes.merge!(Utils.deep_dup(model.attributes))
+          @choice_attributes.concat(deep_duplicate_choice_attributes(model))
         end
 
         def import_model_mappings(model)

--- a/spec/lutaml/model/group_spec.rb
+++ b/spec/lutaml/model/group_spec.rb
@@ -276,7 +276,17 @@ RSpec.describe "Group" do
         source_attributes.each do |name, attr|
           expect(target_attributes[name].name).to eq(attr.name)
           expect(target_attributes[name].type).to eq(attr.type)
-          expect(target_attributes[name].options).to eq(attr.options)
+          # can't compare the 'choice' directly as their 'model' will be different
+          expect(target_attributes[name].options.except(:choice)).to eq(attr.options.except(:choice))
+          if target_attributes[name].options.key?(:choice)
+            target_choice = target_attributes[name].options[:choice]
+            source_choice = attr.options[:choice]
+            expect(target_choice.min).to eql(source_choice.min)
+            expect(target_choice.max).to eql(source_choice.max)
+            expect(target_choice.model).not_to be(source_choice.model)
+            # can't compare the attributes directly as 'model' of their 'choice' will be different
+            expect(target_choice.attributes).not_to be(source_choice.attributes)
+          end
         end
       end
     end


### PR DESCRIPTION
This PR ensure imported `choice` attributes rebind to the importing class, updating `@model` and `:choice` references accordingly.

closes #500 