### PR TITLE
feat(collection): add index_by for O(1) collection lookups

### DIFF
--- a/docs/_pages/collections.adoc
+++ b/docs/_pages/collections.adoc
@@ -1416,6 +1416,92 @@ end
 ====
 
 
+==== Indexed lookups
+
+Collections can be indexed for O(1) lookups by one or more attributes.
+This is particularly useful for large collections where repeated lookups
+by key would otherwise be O(n).
+
+===== Single index
+
+Use `index_by` with a single field for simple indexed lookups:
+
+[source,ruby]
+----
+class Person < Lutaml::Model::Serializable
+  attribute :id, :string
+  attribute :name, :string
+end
+
+class PersonCollection < Lutaml::Model::Collection
+  instances :people, Person
+  index_by :id
+end
+
+people = PersonCollection.new([
+  { id: '001', name: 'Alice' },
+  { id: '002', name: 'Bob' }
+])
+
+# O(1) lookup by id
+people.fetch('001')              # => #<Person id='001' name='Alice'>
+people.find_by(:id, '002')       # => #<Person id='002' name='Bob'>
+people.find_by(:id, 'missing')   # => nil
+----
+
+===== Multiple indexes
+
+Use `index_by` with multiple fields for lookups by different keys:
+
+[source,ruby]
+----
+class PersonCollection < Lutaml::Model::Collection
+  instances :people, Person
+  index_by :id, :email, :slug
+end
+
+# O(1) lookup by any indexed field
+people.find_by(:id, '001')
+people.find_by(:email, 'alice@example.com')
+people.find_by(:slug, 'alice-smith')
+----
+
+===== Named indexes with custom key extraction
+
+Use `index` with a name and proc for custom key extraction:
+
+[source,ruby]
+----
+class PersonCollection < Lutaml::Model::Collection
+  instances :people, Person
+  index_by :id
+  index :email, by: ->(person) { person.email.downcase }
+end
+
+# Lookup with normalized key (proc stores lowercase)
+people.find_by(:email, 'alice@example.com')  # => finds Alice
+----
+
+===== Combined with sorting
+
+Indexes work alongside sorting:
+
+[source,ruby]
+----
+class PersonCollection < Lutaml::Model::Collection
+  instances :people, Person
+  index_by :id
+  sort by: :name, order: :asc
+end
+
+# Collection is sorted by name, indexed by id
+people.fetch('001')
+----
+
+NOTE: The index is rebuilt after any mutation (`<<`, `push`, `[]=`).
+For best performance with large collections, batch mutations before lookups.
+
+
 ==== Polymorphic collections
 
 Collections can contain instances of different model classes that share a common base class.

--- a/lib/lutaml/model/collection.rb
+++ b/lib/lutaml/model/collection.rb
@@ -9,6 +9,7 @@ module Lutaml
           instance_name
           sort_by_field
           sort_direction
+          indexes
         ].freeze
 
         ALLOWED_OPTIONS = %i[polymorphic].freeze
@@ -27,7 +28,8 @@ module Lutaml
         attr_reader :instance_type,
                     :instance_name,
                     :sort_by_field,
-                    :sort_direction
+                    :sort_direction,
+                    :indexes
 
         def instances(name, type, options = {}, &block)
           if (invalid_opts = options.keys - ALLOWED_OPTIONS).any?
@@ -56,6 +58,30 @@ module Lutaml
 
         def sort_configured?
           !!@sort_by_field
+        end
+
+        # Index by one or more fields for O(1) lookups
+        # Example: index_by :id, :email
+        def index_by(*fields)
+          @indexes ||= {}
+          fields.each do |field|
+            if field.is_a?(Proc)
+              raise ArgumentError,
+                    "Proc indexes require a name. Use: index :name, by: ->(item) { ... }"
+            end
+            @indexes[field.to_sym] = field.to_sym
+          end
+        end
+
+        # Named index with optional proc for custom key extraction
+        # Example: index :email, by: ->(item) { item.email.downcase }
+        def index(name, by:)
+          @indexes ||= {}
+          @indexes[name.to_sym] = by
+        end
+
+        def index_configured?
+          @indexes && !@indexes.empty?
         end
 
         def to(format, instance, options = {})
@@ -138,6 +164,7 @@ __register: Lutaml::Model::Config.default_register)
         end
 
         sort_items!
+        build_index_caches!
       end
 
       def to_format(format, options = {})
@@ -151,6 +178,7 @@ __register: Lutaml::Model::Config.default_register)
       def collection=(collection)
         instance_variable_set(:"@#{self.class.instance_name}", collection)
         sort_items!
+        build_index_caches!
       end
 
       def union(other)
@@ -188,6 +216,7 @@ __register: Lutaml::Model::Config.default_register)
       def push(item)
         collection.push(item)
         sort_items!
+        build_index_caches!
       end
 
       def [](index)
@@ -197,6 +226,7 @@ __register: Lutaml::Model::Config.default_register)
       def []=(index, value)
         collection[index] = value
         sort_items!
+        build_index_caches!
       end
 
       def empty?
@@ -214,6 +244,57 @@ __register: Lutaml::Model::Config.default_register)
 
         apply_sort!
         collection.reverse! if self.class.sort_direction == :desc
+      end
+
+      # Index methods for O(1) lookups
+
+      # @return [Hash, nil] Hash of { field_name => { key => item } } or nil
+      attr_reader :index_caches
+
+      # Build index caches for all configured indexes
+      def build_index_caches!
+        return unless self.class.index_configured?
+        return if collection.nil? || collection.empty?
+
+        @index_caches = {}
+
+        self.class.indexes.each do |name, field_or_proc|
+          @index_caches[name] = {}
+
+          collection.each do |item|
+            key = if field_or_proc.is_a?(Proc)
+                    field_or_proc.call(item)
+                  else
+                    item.send(field_or_proc)
+                  end
+            @index_caches[name][key] = item
+          end
+        end
+      end
+
+      # Find an item by index field and key
+      # @param field [Symbol] The index field name
+      # @param key [Object] The key to look up
+      # @return [Object, nil] The item or nil if not found
+      def find_by(field, key)
+        return nil unless @index_caches
+
+        cache = @index_caches[field.to_sym]
+        cache&.fetch(key, nil)
+      end
+
+      # Fetch an item by key (only for single-index collections)
+      # @param key [Object] The key to look up
+      # @return [Object, nil] The item or nil if not found
+      # @raise [ArgumentError] If multiple indexes are configured
+      def fetch(key)
+        unless self.class.indexes&.one?
+          raise ArgumentError,
+                "#fetch only works with single index. Use #find_by(field, key)"
+        end
+
+        field = self.class.indexes.keys.first
+        find_by(field, key)
       end
 
       def apply_sort!

--- a/spec/lutaml/model/collection_index_spec.rb
+++ b/spec/lutaml/model/collection_index_spec.rb
@@ -1,0 +1,338 @@
+require "spec_helper"
+require "lutaml/model"
+
+module CollectionIndexTests
+  class Person < Lutaml::Model::Serializable
+    attribute :id, :string
+    attribute :name, :string
+    attribute :email, :string
+    attribute :slug, :string
+  end
+end
+
+RSpec.describe "Collection index_by" do
+  describe "single index" do
+    let(:collection_class) do
+      Class.new(Lutaml::Model::Collection) do
+        instances :people, CollectionIndexTests::Person
+        index_by :id
+      end
+    end
+
+    let(:people_data) do
+      [
+        { id: "001", name: "Alice", email: "alice@example.com" },
+        { id: "002", name: "Bob", email: "bob@example.com" },
+        { id: "003", name: "Charlie", email: "charlie@example.com" },
+      ]
+    end
+
+    let(:collection) { collection_class.new(people_data) }
+
+    describe "#fetch" do
+      it "finds an item by key using O(1) lookup" do
+        person = collection.fetch("001")
+        expect(person).to be_a(CollectionIndexTests::Person)
+        expect(person.name).to eq("Alice")
+      end
+
+      it "returns nil for missing key" do
+        expect(collection.fetch("999")).to be_nil
+      end
+
+      it "returns nil for nil key" do
+        expect(collection.fetch(nil)).to be_nil
+      end
+    end
+
+    describe "#find_by" do
+      it "finds an item by field and key" do
+        person = collection.find_by(:id, "002")
+        expect(person).to be_a(CollectionIndexTests::Person)
+        expect(person.name).to eq("Bob")
+      end
+
+      it "returns nil for missing key" do
+        expect(collection.find_by(:id, "999")).to be_nil
+      end
+
+      it "returns nil for non-indexed field" do
+        expect(collection.find_by(:email, "alice@example.com")).to be_nil
+      end
+
+      it "accepts string field names" do
+        person = collection.find_by("id", "003")
+        expect(person.name).to eq("Charlie")
+      end
+    end
+
+    describe "#index_caches" do
+      it "returns the built index cache" do
+        expect(collection.index_caches).to be_a(Hash)
+        expect(collection.index_caches[:id]).to be_a(Hash)
+        expect(collection.index_caches[:id].keys).to contain_exactly("001", "002", "003")
+      end
+    end
+
+    describe "index updates on mutation" do
+      it "rebuilds index after #push" do
+        collection.push(CollectionIndexTests::Person.new(id: "004", name: "Diana"))
+
+        expect(collection.fetch("004")).not_to be_nil
+        expect(collection.fetch("004").name).to eq("Diana")
+      end
+
+      it "rebuilds index after #<<" do
+        collection << CollectionIndexTests::Person.new(id: "005", name: "Eve")
+
+        expect(collection.fetch("005")).not_to be_nil
+        expect(collection.fetch("005").name).to eq("Eve")
+      end
+
+      it "rebuilds index after #[]=" do
+        collection[0] = CollectionIndexTests::Person.new(id: "006", name: "Frank")
+
+        expect(collection.fetch("006")).not_to be_nil
+        expect(collection.fetch("006").name).to eq("Frank")
+      end
+
+      it "rebuilds index after #collection=" do
+        collection.collection = [
+          CollectionIndexTests::Person.new(id: "007", name: "Grace"),
+        ]
+
+        expect(collection.fetch("007")).not_to be_nil
+        expect(collection.fetch("001")).to be_nil
+      end
+    end
+  end
+
+  describe "multiple indexes" do
+    let(:collection_class) do
+      Class.new(Lutaml::Model::Collection) do
+        instances :people, CollectionIndexTests::Person
+        index_by :id, :email, :slug
+      end
+    end
+
+    let(:people_data) do
+      [
+        { id: "001", name: "Alice", email: "alice@example.com", slug: "alice" },
+        { id: "002", name: "Bob", email: "bob@example.com", slug: "bob" },
+        { id: "003", name: "Charlie", email: "charlie@example.com", slug: "charlie" },
+      ]
+    end
+
+    let(:collection) { collection_class.new(people_data) }
+
+    describe "#find_by" do
+      it "finds an item by id" do
+        person = collection.find_by(:id, "001")
+        expect(person.name).to eq("Alice")
+      end
+
+      it "finds an item by email" do
+        person = collection.find_by(:email, "bob@example.com")
+        expect(person.name).to eq("Bob")
+      end
+
+      it "finds an item by slug" do
+        person = collection.find_by(:slug, "charlie")
+        expect(person.name).to eq("Charlie")
+      end
+
+      it "returns nil for missing key on any index" do
+        expect(collection.find_by(:id, "999")).to be_nil
+        expect(collection.find_by(:email, "missing@example.com")).to be_nil
+        expect(collection.find_by(:slug, "missing")).to be_nil
+      end
+    end
+
+    describe "#fetch" do
+      it "raises ArgumentError when multiple indexes are configured" do
+        expect do
+          collection.fetch("001")
+        end.to raise_error(ArgumentError, /#fetch only works with single index/)
+      end
+    end
+
+    describe "#index_caches" do
+      it "builds separate caches for each index" do
+        expect(collection.index_caches.keys).to contain_exactly(:id, :email, :slug)
+      end
+    end
+  end
+
+  describe "named indexes with procs" do
+    let(:collection_class) do
+      Class.new(Lutaml::Model::Collection) do
+        instances :people, CollectionIndexTests::Person
+        index_by :id
+        index :email, by: ->(item) { item.email.downcase }
+      end
+    end
+
+    let(:people_data) do
+      [
+        { id: "001", name: "Alice", email: "ALICE@EXAMPLE.COM" },
+        { id: "002", name: "Bob", email: "BOB@EXAMPLE.COM" },
+      ]
+    end
+
+    let(:collection) { collection_class.new(people_data) }
+
+    describe "#find_by" do
+      it "finds item using proc-based index" do
+        person = collection.find_by(:email, "alice@example.com")
+        expect(person.name).to eq("Alice")
+      end
+
+      it "stores lowercase key via proc" do
+        # The proc lowercases the key, so lookup must use lowercase
+        person = collection.find_by(:email, "alice@example.com")
+        expect(person).not_to be_nil
+        expect(person.name).to eq("Alice")
+      end
+
+      it "still finds by regular index" do
+        person = collection.find_by(:id, "002")
+        expect(person.name).to eq("Bob")
+      end
+    end
+  end
+
+  describe "proc without name raises error" do
+    it "raises ArgumentError when proc is passed to index_by" do
+      expect do
+        Class.new(Lutaml::Model::Collection) do
+          instances :people, CollectionIndexTests::Person
+          index_by ->(item) { item.email.downcase }
+        end
+      end.to raise_error(ArgumentError, /Proc indexes require a name/)
+    end
+  end
+
+  describe "with sorting" do
+    let(:collection_class) do
+      Class.new(Lutaml::Model::Collection) do
+        instances :people, CollectionIndexTests::Person
+        index_by :id
+        sort by: :name, order: :asc
+      end
+    end
+
+    let(:people_data) do
+      [
+        { id: "001", name: "Charlie" },
+        { id: "002", name: "Alice" },
+        { id: "003", name: "Bob" },
+      ]
+    end
+
+    let(:collection) { collection_class.new(people_data) }
+
+    it "sorts items and indexes them" do
+      # Check sorting
+      expect(collection.map(&:name)).to eq(["Alice", "Bob", "Charlie"])
+
+      # Check indexing still works
+      expect(collection.fetch("001").name).to eq("Charlie")
+      expect(collection.fetch("002").name).to eq("Alice")
+      expect(collection.fetch("003").name).to eq("Bob")
+    end
+  end
+
+  describe "empty collection" do
+    let(:collection_class) do
+      Class.new(Lutaml::Model::Collection) do
+        instances :people, CollectionIndexTests::Person
+        index_by :id
+      end
+    end
+
+    let(:collection) { collection_class.new([]) }
+
+    it "returns nil from find_by on empty collection" do
+      expect(collection.find_by(:id, "001")).to be_nil
+    end
+
+    it "returns nil from fetch on empty collection" do
+      expect(collection.fetch("001")).to be_nil
+    end
+
+    it "returns nil index_caches for empty collection" do
+      expect(collection.index_caches).to be_nil
+    end
+  end
+
+  describe "collection without index" do
+    let(:collection_class) do
+      Class.new(Lutaml::Model::Collection) do
+        instances :people, CollectionIndexTests::Person
+      end
+    end
+
+    let(:collection) { collection_class.new([{ id: "001", name: "Alice" }]) }
+
+    it "returns nil from find_by when no indexes configured" do
+      expect(collection.find_by(:id, "001")).to be_nil
+    end
+
+    it "returns nil index_caches when no indexes configured" do
+      expect(collection.index_caches).to be_nil
+    end
+  end
+
+  describe "duplicate keys" do
+    let(:collection_class) do
+      Class.new(Lutaml::Model::Collection) do
+        instances :people, CollectionIndexTests::Person
+        index_by :id
+      end
+    end
+
+    let(:people_data) do
+      [
+        { id: "001", name: "Alice" },
+        { id: "001", name: "Alice Duplicate" }, # Same ID
+        { id: "002", name: "Bob" },
+      ]
+    end
+
+    let(:collection) { collection_class.new(people_data) }
+
+    it "last item with duplicate key wins" do
+      person = collection.fetch("001")
+      expect(person.name).to eq("Alice Duplicate")
+    end
+  end
+
+  describe "inheritance" do
+    let(:parent_class) do
+      Class.new(Lutaml::Model::Collection) do
+        instances :people, CollectionIndexTests::Person
+        index_by :id
+      end
+    end
+
+    let(:child_class) do
+      Class.new(parent_class) do
+        index_by :email
+      end
+    end
+
+    let(:collection) { child_class.new([{ id: "001", name: "Alice", email: "alice@example.com" }]) }
+
+    it "child class has its own indexes" do
+      # Child should have :email index (overwrites parent's :id)
+      person = collection.find_by(:email, "alice@example.com")
+      expect(person.name).to eq("Alice")
+    end
+
+    it "parent class retains its indexes" do
+      parent_collection = parent_class.new([{ id: "001", name: "Alice", email: "alice@example.com" }])
+      person = parent_collection.fetch("001")
+      expect(person.name).to eq("Alice")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

This PR adds the `index_by` directive to `Lutaml::Model::Collection` for O(1) lookups by one or more attributes. This addresses performance issues when repeatedly searching for items by key attributes (reported by the fontist project).

## Changes

- **`lib/lutaml/model/collection.rb`**: Added `index_by` and `index` directives, index cache management, and `find_by`/`fetch` methods
- **`spec/lutaml/model/collection_index_spec.rb`**: New test file with 31 tests covering all functionality
- **`docs/_pages/collections.adoc`**: Documentation for the new feature

## API

### Single index
```ruby
class PersonCollection < Lutaml::Model::Collection
  instances :people, Person
  index_by :id
end

collection.fetch('123')           # O(1)
collection.find_by(:id, '123')    # O(1)
```

### Multiple indexes
```ruby
class PersonCollection < Lutaml::Model::Collection
  instances :people, Person
  index_by :id, :email, :slug
end

collection.find_by(:email, 'a@b.com')  # O(1)
```

### Named indexes with custom key extraction
```ruby
class PersonCollection < Lutaml::Model::Collection
  instances :people, Person
  index :email, by: ->(person) { person.email.downcase }
end

collection.find_by(:email, 'alice@example.com')  # O(1)
```

## Test plan

- [x] All 31 new tests pass
- [x] All 3072 existing tests pass (no regressions)
- [x] Rubocop passes with no offenses