### PR TITLE
Accumulate schemas across parse() calls to support multiple entrypoints

### DIFF
--- a/lib/lutaml/xml/schema/xsd.rb
+++ b/lib/lutaml/xml/schema/xsd.rb
@@ -55,7 +55,10 @@ module Lutaml
           end
 
           register ||= self.register
-          Schema.reset_processed_schemas unless nested_schema
+          # Accumulate schemas across parse() calls. When parsing multiple
+          # entrypoints (e.g., urbanFunction.xsd, urbanObject.xsd), each may
+          # import shared schemas. The schema_by_location_or_instance method
+          # checks processed_schemas first, so duplicates are avoided by reuse.
 
           Glob.schema_mappings = schema_mappings
           Glob.path_or_url(location)


### PR DESCRIPTION
When parsing multiple XSD entrypoints (e.g., urbanFunction.xsd, urbanObject.xsd, FGD_GMLSchema.xsd), each may import shared schemas like GML.

This change removes the reset of processed_schemas between parse() calls. The schema_by_location_or_instance method checks processed_schemas first during import resolution, so duplicate parsing is avoided by returning the cached schema.

Result: All types from all entrypoints are properly indexed without duplicate work.

Fixes: parsing multiple entrypoints loses schemas from earlier entrypoints