### PR TITLE
fix: preserve unused namespace declarations with prefix: true

### DIFF
--- a/lib/lutaml/xml/declaration_planner.rb
+++ b/lib/lutaml/xml/declaration_planner.rb
@@ -1553,11 +1553,11 @@ module Lutaml
         #
         # CRITICAL: Only preserve namespaces that were ORIGINALLY declared at root.
         # Namespaces declared on child elements in the input should remain on children.
-        # NOTE: Skip PRESERVATION when explicit format preference is set.
-        # When user specifies prefix: true/false, that overrides input format.
-        has_explicit_pref = options.key?(:prefix) || options.key?(:use_prefix)
-        if is_root && !has_explicit_pref
-          stored_plan = options[:stored_xml_declaration_plan]
+        # NOTE: PRESERVATION should always run when we have a stored plan, because
+        # unused namespaces (like xmlns:xsi for schemaLocation) should be preserved
+        # for round-trip fidelity regardless of prefix formatting options.
+        stored_plan = options[:stored_xml_declaration_plan]
+        if is_root && stored_plan
 
           # Get root-level namespaces from location tracking.
           # This properly distinguishes namespaces declared at root vs hoisted there.

--- a/spec/lutaml/xml/namespace_preservation_spec.rb
+++ b/spec/lutaml/xml/namespace_preservation_spec.rb
@@ -328,6 +328,49 @@ RSpec.describe "Namespace Preservation Issue #3" do
       expect(output).to include('xmlns:mml="http://www.w3.org/1998/Math/MathML"')
     end
 
+    it "preserves unused namespace declarations with prefix: true" do
+      # Define namespace class
+      gml_ns = Class.new(Lutaml::Xml::W3c::XmlNamespace) do
+        uri "http://www.opengis.net/gml/3.2"
+        prefix_default "gml"
+      end
+
+      # Define model class (similar to ogc-gml Polygon pattern)
+      polygon_class = Class.new(Lutaml::Model::Serializable) do
+        attribute :exterior, :string
+
+        xml do
+          root "Polygon"
+          namespace gml_ns
+          map_element "exterior", to: :exterior
+        end
+
+        def self.name
+          "Polygon"
+        end
+      end
+
+      # Input XML has xmlns:xsi but no attributes using it (schemaLocation stripped),
+      # so xsi namespace is truly unused by any mapped content.
+      # This mirrors the ogc-gml gmlring2.xml scenario.
+      xml_input = <<~XML
+        <?xml version="1.0"?>
+        <gml:Polygon xmlns:gml="http://www.opengis.net/gml/3.2"
+                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+          <gml:exterior>outer</gml:exterior>
+        </gml:Polygon>
+      XML
+
+      polygon = polygon_class.from_xml(xml_input)
+      expect(polygon.exterior).to eq("outer")
+
+      # Round-trip with prefix: true — xmlns:xsi must still be preserved
+      output = polygon.to_xml(prefix: true)
+
+      expect(output).to include('xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"')
+      expect(output).to include('xmlns:gml="http://www.opengis.net/gml/3.2"')
+    end
+
     it "does not hoist child-declared namespaces to root" do
       # Define namespace classes
       child_ns = Class.new(Lutaml::Xml::W3c::XmlNamespace) do


### PR DESCRIPTION
## Summary
- The PRESERVATION section in `determine_hoisted_declarations` was guarded by `has_explicit_pref`, causing unused namespace declarations (like `xmlns:xsi`) to be dropped when `prefix: true` was passed to `to_xml`
- Element format and namespace declaration preservation are orthogonal concerns. The `has_explicit_pref` guard is correct in `format_chooser.rb` (controls element rendering), but was incorrectly duplicated into the PRESERVATION section (controls which xmlns declarations survive round-tripping)
- Added a round-trip spec that reproduces the exact ogc-gml `gmlring2.xml` scenario

## Root cause
`declaration_planner.rb:1556` checked `options.key?(:prefix) || options.key?(:use_prefix)` before running the PRESERVATION section. When `prefix: true` was passed, the PRESERVATION section was skipped entirely, so `xmlns:xsi` (unused by any mapped element) was dropped from the output.

## Fix
Changed the guard to simply `if is_root && stored_plan` — PRESERVATION always runs when a stored plan exists, regardless of prefix formatting options.

## Test plan
- [x] New spec `preserves unused namespace declarations with prefix: true` fails without the fix, passes with it
- [x] All 3935 existing specs pass
- [x] Rubocop clean