### PR TITLE
feat: add consolidation mapping for grouping sibling XML elements

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,7 @@ AllCops:
   NewCops: enable
   Exclude:
     - 'vendor/**/*'
+    - 'tmp/**/*'
     - '**/*.adoc'
     - '**/*.md'
 

--- a/README.adoc
+++ b/README.adoc
@@ -65,6 +65,7 @@ link:docs/migration-guides/0-1-0-migrate-from-shale.adoc[Migrating from Shale to
 * Symmetric OOP architecture for all formats with KeyValueDataModel (see <<keyvaluedatamodel-architecture>>)
 * Parse XSD schemas into Ruby objects for inspection and manipulation (see <<xsd-schema-parsing>>)
 * Reusable XML mapping classes for sharing mappings across models
+* Consolidation mapping: group sibling XML elements into structured model instances (see <<consolidation-mapping>>)
 
 
 == Data modeling in a nutshell
@@ -15577,7 +15578,15 @@ and examples.
 [[schema-import]]
 == Schema import
 
-Lutaml::Model provides functionality to import schema definitions into LutaML
+[[consolidation-mapping]]
+== Consolidation mapping
+
+Consolidation mapping groups flat sibling XML elements into structured model
+instances based on attribute values. See
+link:docs/_pages/consolidation-mapping.html[Consolidation Mapping guide] for
+full documentation.
+
+.Lutaml::Model provides functionality to import schema definitions into LutaML
 models. This allows you to create models from existing schema definitions.
 
 Currently, the following schema formats are supported:

--- a/docs/_guides/index.adoc
+++ b/docs/_guides/index.adoc
@@ -32,6 +32,7 @@ Task-oriented guides for accomplishing specific goals with Lutaml::Model.
 * link:../schema-import[Schema Import] - Import schemas to create models
 * link:../liquid-templates[Liquid Templates] - Template integration
 * link:../ooxml-examples[OOXML Examples] - Real-world Office Open XML
+* link:../consolidation-mapping[Consolidation Mapping] - Group sibling elements into structured models
 
 == By task
 
@@ -51,6 +52,7 @@ Task-oriented guides for accomplishing specific goals with Lutaml::Model.
 
 . link:../collection-serialization[Collection Serialization]
 . link:../../collections[Collections reference]
+. link:../consolidation-mapping[Consolidation Mapping] - Group elements into structured models
 
 === I want to transform data
 

--- a/docs/_pages/collections.adoc
+++ b/docs/_pages/collections.adoc
@@ -768,6 +768,12 @@ end
 ====
 
 
+=== Consolidation mapping
+
+Collections can consolidate flat sibling elements into structured group instances.
+See link:../_guides/consolidation-mapping[Consolidation Mapping] for the full guide.
+
+
 
 === Nested collections
 

--- a/docs/_pages/consolidation-mapping.adoc
+++ b/docs/_pages/consolidation-mapping.adoc
@@ -1,0 +1,252 @@
+---
+title: Consolidation Mapping
+parent: Guides
+nav_order: 95
+---
+
+= Consolidation Mapping
+
+Consolidation mapping groups sibling XML elements into structured model instances.
+It solves the problem where multiple elements of the same name need to be
+organized by an attribute value and distributed into typed attributes on a
+group model.
+
+== The Problem
+
+ISO and other standards documents contain XML structures where multiple sibling
+elements share the same name but are distinguished by attribute values:
+
+[source,xml]
+----
+<bibdata>
+  <title lang="en" type="main">Cereals and pulses</title>
+  <title lang="en" type="title-intro">Cereals and pulses</title>
+  <title lang="en" type="title-main">Specifications</title>
+  <title lang="en" type="title-part">Rice</title>
+  <title lang="fr" type="main">Céréales et légumineuses</title>
+  <title lang="fr" type="title-intro">Céréales</title>
+  <title lang="fr" type="title-part">Riz</title>
+</bibdata>
+----
+
+You want to access these as grouped, structured objects:
+
+[source,ruby]
+----
+bibdata.titles.per_lang.find { |g| g.lang == "en" }.main_title.content
+#=> "Cereals and pulses"
+
+bibdata.titles.per_lang.find { |g| g.lang == "fr" }.title_part.content
+#=> "Riz"
+----
+
+== Concepts
+
+Consolidation mapping uses three components:
+
+[cols="1,4"]
+|===
+| Component | Purpose
+
+| `instances` | Declares the raw item type (existing Collection feature)
+| `organizes` | Declares the output group model type
+| `consolidate_map` | Declares how to group and distribute items (in format block)
+|===
+
+=== Model-level declaration
+
+On your Collection class, declare both the raw item type and the organized output:
+
+[source,ruby]
+----
+class TitleCollection < Lutaml::Model::Collection
+  instances :items, IndividualTitle        # raw parsed items
+  organizes :per_lang, PerLangTitleGroup   # organized output
+end
+----
+
+=== Format-level declaration
+
+In the Collection's format block, declare the consolidation rules:
+
+[source,ruby]
+----
+class TitleCollection < Lutaml::Model::Collection
+  instances :items, IndividualTitle
+  organizes :per_lang, PerLangTitleGroup
+
+  xml do
+    root "titles"
+    map_instances to: :items
+
+    consolidate_map by: :lang, to: :per_lang do
+      gather :lang, to: :lang
+      dispatch_by :type_of_title do
+        route "main" => :main_title
+        route "title-intro" => :title_intro
+        route "title-main" => :title_main
+        route "title-part" => :title_part
+      end
+    end
+  end
+end
+----
+
+== Complete Example
+
+=== Define the models
+
+[source,ruby]
+----
+# Raw parsed element
+class IndividualTitle < Lutaml::Model::Serializable
+  attribute :lang, :string
+  attribute :type_of_title, :string
+  attribute :content, :string
+
+  xml do
+    root "title"
+    map_attribute "lang", to: :lang
+    map_attribute "type", to: :type_of_title
+    map_content to: :content
+  end
+end
+
+# Grouped result model (plain model, no format knowledge)
+class PerLangTitleGroup < Lutaml::Model::Serializable
+  attribute :lang, :string
+  attribute :main_title, IndividualTitle
+  attribute :title_intro, IndividualTitle
+  attribute :title_main, IndividualTitle
+  attribute :title_part, IndividualTitle
+end
+
+# Collection that orchestrates consolidation
+class TitleCollection < Lutaml::Model::Collection
+  instances :items, IndividualTitle
+  organizes :per_lang, PerLangTitleGroup
+
+  xml do
+    root "titles"
+    map_instances to: :items
+
+    consolidate_map by: :lang, to: :per_lang do
+      gather :lang, to: :lang
+      dispatch_by :type_of_title do
+        route "main" => :main_title
+        route "title-intro" => :title_intro
+        route "title-main" => :title_main
+        route "title-part" => :title_part
+      end
+    end
+  end
+end
+
+# Parent model
+class Bibdata < Lutaml::Model::Serializable
+  attribute :titles, IndividualTitle, collection: TitleCollection
+
+  xml do
+    root "bibdata"
+    map_element "title", to: :titles
+  end
+end
+----
+
+=== Parse and access grouped data
+
+[source,ruby]
+----
+bibdata = Bibdata.from_xml(xml)
+
+# Access raw items
+bibdata.titles.items.size  #=> 7
+
+# Access organized groups
+bibdata.titles.per_lang.size  #=> 2
+
+en = bibdata.titles.per_lang.find { |g| g.lang == "en" }
+en.main_title.content   #=> "Cereals and pulses"
+en.title_part.content   #=> "Rice"
+
+fr = bibdata.titles.per_lang.find { |g| g.lang == "fr" }
+fr.main_title.content   #=> "Céréales et légumineuses"
+fr.title_main           #=> nil (no title-main for French)
+----
+
+=== Serialize back to XML
+
+Serialization uses the raw items to produce the original XML structure:
+
+[source,ruby]
+----
+bibdata.to_xml
+#=>
+# <bibdata>
+#   <title lang="en" type="main">Cereals and pulses</title>
+#   <title lang="en" type="title-intro">Cereals and pulses</title>
+#   ...
+# </bibdata>
+----
+
+== DSL Reference
+
+=== `organizes`
+
+Declares that a Collection produces organized instances of a GroupClass.
+
+[source,ruby]
+----
+organizes :name, GroupClass
+----
+
+Creates a collection attribute on the Collection class and stores the
+organization metadata.
+
+=== `consolidate_map`
+
+Declared inside a format block (`xml do`, `json do`). Defines how raw items
+are grouped and distributed.
+
+[source,ruby]
+----
+consolidate_map by: :attribute_name, to: :target_attribute do
+  gather :source_attr, to: :target_attr
+  dispatch_by :discriminator_attr do
+    route "value1" => :target_attr1
+    route "value2" => :target_attr2
+  end
+end
+----
+
+Parameters:
+
+[cols="1,4"]
+|===
+| Parameter | Description
+
+| `by:` | The attribute name to group by (Symbol)
+| `to:` | The target attribute on the Collection for organized output
+|===
+
+Block methods:
+
+[cols="1,4"]
+|===
+| Method | Description
+
+| `gather :source, to: :target` | Copy a shared attribute from items to the group
+| `dispatch_by :attr` | Declare which attribute discriminates items within a group
+| `route "value" => :target` | Map a discriminator value to a group attribute
+|===
+
+== Design Principles
+
+1. **Model-centric**: GroupClasses are plain models with attributes only.
+   No format-specific consolidation knowledge lives on the GroupClass.
+2. **Collection orchestrates**: All consolidation logic lives on the
+   Collection's format mapping block.
+3. **Format-agnostic model level**: `organizes` works for any format.
+   `consolidate_map` is format-specific.
+4. **Round-trip safe**: Raw items are preserved for exact XML round-tripping.
+   Organized groups are a derived view.

--- a/lib/lutaml/model.rb
+++ b/lib/lutaml/model.rb
@@ -58,6 +58,19 @@ module Lutaml
     autoload :Validation, "#{__dir__}/model/validation"
     autoload :Choice, "#{__dir__}/model/choice"
     autoload :Sequence, "#{__dir__}/model/sequence"
+    autoload :Organization, "#{__dir__}/model/organization"
+    autoload :ConsolidationRule, "#{__dir__}/model/consolidation_rule"
+    autoload :ConsolidationMap, "#{__dir__}/model/consolidation_map"
+    autoload :GatherRule, "#{__dir__}/model/consolidation_rule/gather_rule"
+    autoload :DispatchBlock,
+             "#{__dir__}/model/consolidation_rule/dispatch_block"
+    autoload :DispatchBuilder,
+             "#{__dir__}/model/consolidation_rule/dispatch_block"
+    autoload :PatternElementRule,
+             "#{__dir__}/model/consolidation_rule/pattern_element_rule"
+    autoload :PatternContentRule,
+             "#{__dir__}/model/consolidation_rule/pattern_content_rule"
+    autoload :Consolidation, "#{__dir__}/model/consolidation/engine"
     autoload :ValueTransformer, "#{__dir__}/model/value_transformer"
     autoload :Registrable, "#{__dir__}/model/registrable"
 

--- a/lib/lutaml/model/collection.rb
+++ b/lib/lutaml/model/collection.rb
@@ -59,6 +59,7 @@ module Lutaml
           sort_direction
           indexes
           collection_validations
+          organization
         ].freeze
 
         ALLOWED_OPTIONS = %i[polymorphic].freeze
@@ -79,7 +80,8 @@ module Lutaml
                     :sort_by_field,
                     :sort_direction,
                     :indexes,
-                    :collection_validations
+                    :collection_validations,
+                    :organization
 
         def instances(name, type, options = {}, &block)
           if (invalid_opts = options.keys - ALLOWED_OPTIONS).any?
@@ -95,6 +97,15 @@ module Lutaml
           define_method(:"#{name}=") do |collection|
             self.collection = collection
           end
+        end
+
+        # Declare that this Collection produces organized instances of a GroupClass.
+        #
+        # @param name [Symbol] attribute name on the Collection
+        # @param group_class [Class] the GroupClass type
+        def organizes(name, group_class)
+          attribute(name, group_class, collection: true)
+          @organization = Organization.new(name, group_class)
         end
 
         def sort(by:, order: :asc)

--- a/lib/lutaml/model/consolidation/attribute_grouper.rb
+++ b/lib/lutaml/model/consolidation/attribute_grouper.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Lutaml
+  module Model
+    module Consolidation
+      class AttributeGrouper
+        # @param collection [Collection] the collection instance
+        # @param map [ConsolidationMap] consolidation configuration
+        # @param raw_items [Array] raw parsed instances
+        def process(collection, map, raw_items)
+          gather_rule = map.rules.find { |r| r.is_a?(GatherRule) }
+          dispatch_block = map.rules.find { |r| r.is_a?(DispatchBlock) }
+
+          # Group by the attribute declared in map.by
+          grouped = raw_items.group_by { |item| item.public_send(map.by) }
+
+          organized = grouped.map do |_key, items|
+            build_group(map.group_class, items, gather_rule, dispatch_block)
+          end
+
+          collection.public_send(:"#{map.to}=", organized)
+        end
+
+        private
+
+        def build_group(group_class, items, gather_rule, dispatch_block)
+          instance = group_class.new
+
+          if gather_rule && items.any?
+            value = items.first.public_send(gather_rule.source)
+            instance.public_send(:"#{gather_rule.target}=", value)
+          end
+
+          if dispatch_block
+            Dispatcher.new(dispatch_block).dispatch(instance,
+                                                    items)
+          end
+
+          instance
+        end
+      end
+    end
+  end
+end

--- a/lib/lutaml/model/consolidation/dispatcher.rb
+++ b/lib/lutaml/model/consolidation/dispatcher.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Lutaml
+  module Model
+    module Consolidation
+      class Dispatcher
+        def initialize(dispatch_block)
+          @dispatch_block = dispatch_block
+        end
+
+        # @param group_instance [Serializable] the GroupClass instance
+        # @param items [Array] raw items to route
+        def dispatch(group_instance, items)
+          items.each do |item|
+            value = item.public_send(@dispatch_block.discriminator)
+            target_attr = @dispatch_block.route_for(value)
+            next unless target_attr
+
+            assign(group_instance, target_attr, item)
+          end
+
+          group_instance
+        end
+
+        private
+
+        def assign(group_instance, target_attr, item)
+          # Determine whether to assign whole instance or extract value
+          attr_def = group_instance.class.attributes[target_attr.to_sym]
+          target_type = attr_def&.type
+
+          value = if target_type == item.class
+                    item
+                  elsif item.respond_to?(:value)
+                    item.value
+                  else
+                    item
+                  end
+
+          group_instance.public_send(:"#{target_attr}=", value)
+        end
+      end
+    end
+  end
+end

--- a/lib/lutaml/model/consolidation/engine.rb
+++ b/lib/lutaml/model/consolidation/engine.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require_relative "attribute_grouper"
+require_relative "dispatcher"
+require_relative "pattern_chunker"
+
+module Lutaml
+  module Model
+    module Consolidation
+      class Engine
+        # @param collection [Collection] the collection instance
+        # @param consolidation_map [ConsolidationMap] the format-level config
+        # @param raw_data [Array] raw items (Pattern A) or mixed content tokens (Pattern B)
+        def self.run(collection, consolidation_map, raw_data)
+          strategy = strategy_for(consolidation_map)
+          strategy.process(collection, consolidation_map, raw_data)
+        end
+
+        class << self
+          private
+
+          def strategy_for(consolidation_map)
+            if consolidation_map.pattern?
+              PatternChunker.new
+            else
+              AttributeGrouper.new
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/lutaml/model/consolidation/pattern_chunker.rb
+++ b/lib/lutaml/model/consolidation/pattern_chunker.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+module Lutaml
+  module Model
+    module Consolidation
+      class PatternChunker
+        # @param collection [Collection] the collection instance
+        # @param map [ConsolidationMap] consolidation configuration
+        # @param tokens [Array] mixed content tokens from parent
+        def process(collection, map, tokens)
+          rules = map.rules
+          element_rules = rules.grep(PatternElementRule)
+          trigger_rule = element_rules.first
+          content_rule = rules.find { |r| r.is_a?(PatternContentRule) }
+
+          entries = []
+          current = nil
+
+          tokens.each do |token|
+            case token_type(token)
+            when :element
+              rule = element_rules.find do |r|
+                r.element_name == token_name(token)
+              end
+              next unless rule
+
+              if rule == trigger_rule && current
+                entries << current
+                current = nil
+              end
+
+              current ||= map.group_class.new
+              current.public_send(:"#{rule.target}=", token_text(token))
+            when :text
+              next unless content_rule && current
+
+              text = token_text(token)
+              next if text.strip.empty?
+
+              current.public_send(:"#{content_rule.target}=", text)
+            end
+          end
+
+          entries << current if current
+          collection.public_send(:"#{map.to}=", entries)
+        end
+
+        private
+
+        # Token interface — adapted to parent's mixed content representation.
+        # Subclasses or runtime adapters override these for format-specific tokens.
+
+        # @param token [Object] a mixed content token
+        # @return [Symbol] :element or :text
+        def token_type(token)
+          if token.respond_to?(:node_type)
+            token.node_type == :element ? :element : :text
+          elsif token.is_a?(Hash)
+            token[:type] || (token.key?(:text) ? :text : :element)
+          else
+            :text
+          end
+        end
+
+        # @param token [Object] a mixed content token
+        # @return [String, nil] the element name
+        def token_name(token)
+          if token.respond_to?(:name)
+            token.name
+          elsif token.is_a?(Hash)
+            token[:name]
+          end
+        end
+
+        # @param token [Object] a mixed content token
+        # @return [String, nil] the text content
+        def token_text(token)
+          if token.respond_to?(:text)
+            token.text
+          elsif token.is_a?(Hash)
+            token[:text]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/lutaml/model/consolidation_map.rb
+++ b/lib/lutaml/model/consolidation_map.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module Lutaml
+  module Model
+    class ConsolidationMap
+      attr_reader :by, :to, :group_class, :rules
+
+      # @param by [Symbol] grouping criterion (:attr_name or :pattern)
+      # @param to [Symbol] target attribute name on Collection
+      # @param group_class [Class] resolved from Collection's Organization
+      # @param rules [Array<ConsolidationRule>] consolidation rules
+      def initialize(by:, to:, group_class:, rules:)
+        @by = by
+        @to = to
+        @group_class = group_class
+        @rules = rules
+      end
+
+      def pattern?
+        @by == :pattern
+      end
+
+      def attribute_based?
+        !pattern?
+      end
+
+      # Builder evaluates the consolidate_map block
+      class Builder
+        def initialize(by, to, group_class)
+          @by = by
+          @to = to
+          @group_class = group_class
+          @rules = []
+        end
+
+        # Pattern A: gather a shared attribute from grouped instances
+        def gather(source, to:)
+          @rules << GatherRule.new(source, to)
+        end
+
+        # Pattern A: declare discriminator routing
+        def dispatch_by(discriminator, &)
+          routes = DispatchBuilder.new.evaluate(&)
+          @rules << DispatchBlock.new(discriminator, routes)
+        end
+
+        # Pattern B: map an element name to an attribute
+        def map_element(element_name, to:)
+          @rules << PatternElementRule.new(element_name, to)
+        end
+
+        # Pattern B: map text content to an attribute
+        def map_content(to:)
+          @rules << PatternContentRule.new(to)
+        end
+
+        def build
+          ConsolidationMap.new(
+            by: @by,
+            to: @to,
+            group_class: @group_class,
+            rules: @rules,
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/lutaml/model/consolidation_rule.rb
+++ b/lib/lutaml/model/consolidation_rule.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Lutaml
+  module Model
+    # Base class for all rules within a ConsolidationMap.
+    #
+    # Subclasses define specific rule types:
+    # - GatherRule: collect a shared attribute from grouped instances
+    # - DispatchBlock: discriminator routing configuration
+    # - PatternElementRule: map an element name to an attribute
+    # - PatternContentRule: map text content to an attribute
+    class ConsolidationRule
+      # Marker base class for consolidation rules.
+      # Subclasses: GatherRule, DispatchBlock, PatternElementRule, PatternContentRule
+
+      # Base initialize - subclasses should call super
+      def initialize(*_args); end
+
+      private
+
+      # Override in subclasses to provide rule-specific data
+      def rule_data
+        {}
+      end
+    end
+  end
+end

--- a/lib/lutaml/model/consolidation_rule/dispatch_block.rb
+++ b/lib/lutaml/model/consolidation_rule/dispatch_block.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Lutaml
+  module Model
+    class DispatchBlock < ConsolidationRule
+      attr_reader :discriminator, :routes
+
+      # @param discriminator [Symbol] attribute name to discriminate by
+      # @param routes [Hash{String => Symbol}] value -> target attribute
+      def initialize(discriminator, routes)
+        super
+        @discriminator = discriminator
+        @routes = routes
+      end
+
+      def route_for(value)
+        @routes[value]
+      end
+    end
+
+    # Helper builder for the dispatch_by block
+    class DispatchBuilder
+      def evaluate(&)
+        @routes = {}
+        instance_eval(&)
+        @routes
+      end
+
+      def route(mapping)
+        @routes.merge!(mapping)
+      end
+    end
+  end
+end

--- a/lib/lutaml/model/consolidation_rule/gather_rule.rb
+++ b/lib/lutaml/model/consolidation_rule/gather_rule.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Lutaml
+  module Model
+    class GatherRule < ConsolidationRule
+      attr_reader :source, :target
+
+      # @param source [Symbol] attribute name on raw items
+      # @param target [Symbol] attribute name on GroupClass
+      def initialize(source, target)
+        super
+        @source = source
+        @target = target
+      end
+    end
+  end
+end

--- a/lib/lutaml/model/consolidation_rule/pattern_content_rule.rb
+++ b/lib/lutaml/model/consolidation_rule/pattern_content_rule.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Lutaml
+  module Model
+    class PatternContentRule < ConsolidationRule
+      attr_reader :target
+
+      # @param target [Symbol] attribute name on GroupClass
+      def initialize(target)
+        super
+        @target = target
+      end
+    end
+  end
+end

--- a/lib/lutaml/model/consolidation_rule/pattern_element_rule.rb
+++ b/lib/lutaml/model/consolidation_rule/pattern_element_rule.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Lutaml
+  module Model
+    class PatternElementRule < ConsolidationRule
+      attr_reader :element_name, :target
+
+      # @param element_name [String] XML element name
+      # @param target [Symbol] attribute name on GroupClass
+      def initialize(element_name, target)
+        super
+        @element_name = element_name
+        @target = target
+      end
+    end
+  end
+end

--- a/lib/lutaml/model/organization.rb
+++ b/lib/lutaml/model/organization.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Lutaml
+  module Model
+    # Stores the format-agnostic declaration that a Collection
+    # produces organized instances of a GroupClass.
+    #
+    # Created by Collection.organizes(:name, GroupClass).
+    # Stored as class-level metadata on the Collection subclass.
+    #
+    # @example
+    #   class TitleCollection < Lutaml::Model::Collection
+    #     organizes :per_lang, PerLangTitleGroup
+    #   end
+    #
+    #   TitleCollection.organization
+    #   #=> #<Organization @name=:per_lang, @group_class=PerLangTitleGroup>
+    class Organization
+      attr_reader :name, :group_class
+
+      # @param name [Symbol] attribute name on the Collection
+      # @param group_class [Class] the GroupClass type
+      def initialize(name, group_class)
+        @name = name
+        @group_class = group_class
+      end
+    end
+  end
+end

--- a/lib/lutaml/xml/mapping.rb
+++ b/lib/lutaml/xml/mapping.rb
@@ -50,7 +50,8 @@ module Lutaml
                   :namespace_scope,
                   :namespace_scope_config,
                   :mapper_class,
-                  :xml_space
+                  :xml_space,
+                  :consolidation_maps
 
       def initialize
         super
@@ -66,6 +67,7 @@ module Lutaml
         @register_elements = ::Hash.new { |h, k| h[k] = {} }
         @register_attributes = ::Hash.new { |h, k| h[k] = {} }
         @register_element_sequences = ::Hash.new { |h, k| h[k] = [] }
+        @consolidation_maps = []
         @finalized = false
         @element_name = nil
         @namespace_class = nil
@@ -718,6 +720,23 @@ module Lutaml
         end
       end
 
+      # Declare consolidation rules for this mapping.
+      #
+      # Creates a ConsolidationMap that describes how sibling elements
+      # are grouped into structured model instances.
+      #
+      # @param by [Symbol] grouping criterion (:attr_name or :pattern)
+      # @param to [Symbol] target attribute name on the Collection
+      # @param group_class [Class] the GroupClass to instantiate (optional, resolved from Organization)
+      # @yield Builder block with gather/dispatch_by or map_element/map_content
+      # @return [ConsolidationMap]
+      def consolidate_map(by:, to:, group_class: nil, &)
+        builder = ::Lutaml::Model::ConsolidationMap::Builder.new(by, to,
+                                                                 group_class)
+        builder.instance_eval(&)
+        @consolidation_maps << builder.build
+      end
+
       # Import mappings from another model.
       # For default register: imports BOTH attributes (into @mapper_class) AND mappings.
       # For non-default register: stores mappings in register-specific storage
@@ -1184,6 +1203,7 @@ module Lutaml
           @register_element_sequences
           @mappings_imported
           @sequence_importable_mappings
+          @consolidation_maps
         ]
       end
 

--- a/lib/lutaml/xml/model_transform.rb
+++ b/lib/lutaml/xml/model_transform.rb
@@ -277,6 +277,8 @@ visited = Set.new)
           instance.using_default_for(attr_name)
         end
 
+        run_consolidation(instance, effective_register)
+
         instance
       end
 
@@ -759,6 +761,45 @@ effective_register = lutaml_register)
       def attr_type_is_serializable(attr, effective_register)
         attr_type = attr&.type(effective_register)
         attr_type.is_a?(Class) && attr_type.include?(::Lutaml::Model::Serialize)
+      end
+
+      # Run consolidation on any Collection attributes that have organization.
+      # This is called as a post-processing step after all mappings are applied.
+      #
+      # @param instance [Serializable] the deserialized model instance
+      # @param register [Symbol] the register id
+      def run_consolidation(instance, register)
+        return unless instance.is_a?(::Lutaml::Model::Serialize)
+
+        instance.class.attributes.each_value do |attr|
+          next unless attr.collection?
+          next unless attr.custom_collection?
+
+          collection = instance.public_send(attr.name)
+          next unless collection.is_a?(::Lutaml::Model::Collection)
+          next unless collection.class.organization
+
+          mappings = collection.class.mappings_for(:xml, register)
+          next unless mappings.respond_to?(:consolidation_maps)
+          next if mappings.consolidation_maps.empty?
+
+          mappings.consolidation_maps.each do |map|
+            org = collection.class.organization
+            resolved_map = if map.group_class
+                             map
+                           else
+                             ::Lutaml::Model::ConsolidationMap.new(
+                               by: map.by,
+                               to: map.to,
+                               group_class: org.group_class,
+                               rules: map.rules,
+                             )
+                           end
+            ::Lutaml::Model::Consolidation::Engine.run(
+              collection, resolved_map, collection.collection
+            )
+          end
+        end
       end
     end
   end

--- a/spec/lutaml/model/consolidation_spec.rb
+++ b/spec/lutaml/model/consolidation_spec.rb
@@ -1,0 +1,295 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Consolidation Mapping" do
+  before do
+    Lutaml::Model::GlobalContext.clear_caches
+    Lutaml::Model::TransformationRegistry.instance.clear
+    Lutaml::Model::GlobalRegister.instance.reset
+  end
+
+  describe "Pattern A: Attribute-based consolidation" do
+    before do
+      # Individual title model
+      stub_const("ConTitle", Class.new(Lutaml::Model::Serializable) do
+        attribute :lang, :string
+        attribute :type_of_title, :string
+        attribute :content, :string
+
+        xml do
+          root "title"
+          map_attribute "lang", to: :lang
+          map_attribute "type", to: :type_of_title
+          map_content to: :content
+        end
+      end)
+
+      # Per-language group model
+      stub_const("ConPerLangGroup", Class.new(Lutaml::Model::Serializable) do
+        attribute :lang, :string
+        attribute :main_title, ConTitle
+        attribute :title_intro, ConTitle
+        attribute :title_main, ConTitle
+        attribute :title_part, ConTitle
+      end)
+
+      # Title collection with consolidation
+      stub_const("ConTitleCollection", Class.new(Lutaml::Model::Collection) do
+        instances :items, ConTitle
+        organizes :per_lang, ConPerLangGroup
+
+        xml do
+          root "titles"
+          map_instances to: :items
+          consolidate_map by: :lang, to: :per_lang do
+            gather :lang, to: :lang
+            dispatch_by :type_of_title do
+              route "main" => :main_title
+              route "title-intro" => :title_intro
+              route "title-main" => :title_main
+              route "title-part" => :title_part
+            end
+          end
+        end
+      end)
+
+      # Parent model
+      stub_const("ConBibdata", Class.new(Lutaml::Model::Serializable) do
+        attribute :titles, ConTitle, collection: ConTitleCollection
+
+        xml do
+          root "bibdata"
+          map_element "title", to: :titles
+        end
+      end)
+    end
+
+    let(:xml) do
+      <<~XML
+        <bibdata>
+          <title lang="en" type="main">Cereals and pulses</title>
+          <title lang="en" type="title-intro">Cereals and pulses</title>
+          <title lang="en" type="title-main">Specifications</title>
+          <title lang="en" type="title-part">Rice</title>
+          <title lang="fr" type="main">Céréales et légumineuses</title>
+          <title lang="fr" type="title-intro">Céréales</title>
+          <title lang="fr" type="title-part">Riz</title>
+        </bibdata>
+      XML
+    end
+
+    it "groups titles by language" do
+      bibdata = ConBibdata.from_xml(xml)
+      collection = bibdata.titles
+
+      expect(collection).to be_a(ConTitleCollection)
+      expect(collection.per_lang.size).to eq(2)
+    end
+
+    it "assigns language to each group" do
+      bibdata = ConBibdata.from_xml(xml)
+      langs = bibdata.titles.per_lang.map(&:lang)
+
+      expect(langs).to contain_exactly("en", "fr")
+    end
+
+    it "dispatches titles to correct attributes within each group" do
+      bibdata = ConBibdata.from_xml(xml)
+      en_group = bibdata.titles.per_lang.find { |g| g.lang == "en" }
+
+      expect(en_group.main_title.content).to eq("Cereals and pulses")
+      expect(en_group.title_intro.content).to eq("Cereals and pulses")
+      expect(en_group.title_main.content).to eq("Specifications")
+      expect(en_group.title_part.content).to eq("Rice")
+    end
+
+    it "handles groups with different attribute counts" do
+      bibdata = ConBibdata.from_xml(xml)
+      fr_group = bibdata.titles.per_lang.find { |g| g.lang == "fr" }
+
+      expect(fr_group.main_title.content).to eq("Céréales et légumineuses")
+      expect(fr_group.title_intro.content).to eq("Céréales")
+      expect(fr_group.title_part.content).to eq("Riz")
+      # fr has no title-main
+      expect(fr_group.title_main).to be_nil
+    end
+
+    it "preserves raw items" do
+      bibdata = ConBibdata.from_xml(xml)
+
+      expect(bibdata.titles.items.size).to eq(7)
+    end
+
+    it "round-trips through XML serialization" do
+      bibdata = ConBibdata.from_xml(xml)
+      result = bibdata.to_xml
+
+      reparsed = ConBibdata.from_xml(result)
+      en_group = reparsed.titles.per_lang.find { |g| g.lang == "en" }
+
+      expect(en_group.main_title.content).to eq("Cereals and pulses")
+      expect(en_group.title_part.content).to eq("Rice")
+    end
+  end
+
+  describe "Pattern A: Group by type, distribute by language" do
+    before do
+      stub_const("ConTitle2", Class.new(Lutaml::Model::Serializable) do
+        attribute :lang, :string
+        attribute :type_of_title, :string
+        attribute :content, :string
+
+        xml do
+          root "title"
+          map_attribute "lang", to: :lang
+          map_attribute "type", to: :type_of_title
+          map_content to: :content
+        end
+      end)
+
+      stub_const("ConPerTypeGroup", Class.new(Lutaml::Model::Serializable) do
+        attribute :type_of_title, :string
+        attribute :en, ConTitle2
+        attribute :fr, ConTitle2
+      end)
+
+      stub_const("ConTitleCollection2", Class.new(Lutaml::Model::Collection) do
+        instances :items, ConTitle2
+        organizes :per_type, ConPerTypeGroup
+
+        xml do
+          root "titles"
+          map_instances to: :items
+          consolidate_map by: :type_of_title, to: :per_type do
+            gather :type_of_title, to: :type_of_title
+            dispatch_by :lang do
+              route "en" => :en
+              route "fr" => :fr
+            end
+          end
+        end
+      end)
+
+      stub_const("ConBibdata2", Class.new(Lutaml::Model::Serializable) do
+        attribute :titles, ConTitle2, collection: ConTitleCollection2
+
+        xml do
+          root "bibdata"
+          map_element "title", to: :titles
+        end
+      end)
+    end
+
+    let(:xml) do
+      <<~XML
+        <bibdata>
+          <title lang="en" type="main">Cereals and pulses</title>
+          <title lang="fr" type="main">Céréales et légumineuses</title>
+          <title lang="en" type="title-part">Rice</title>
+          <title lang="fr" type="title-part">Riz</title>
+        </bibdata>
+      XML
+    end
+
+    it "groups titles by type" do
+      bibdata = ConBibdata2.from_xml(xml)
+      types = bibdata.titles.per_type.map(&:type_of_title)
+
+      expect(types).to contain_exactly("main", "title-part")
+    end
+
+    it "dispatches languages to correct attributes" do
+      bibdata = ConBibdata2.from_xml(xml)
+      main_group = bibdata.titles.per_type.find do |g|
+        g.type_of_title == "main"
+      end
+
+      expect(main_group.en.content).to eq("Cereals and pulses")
+      expect(main_group.fr.content).to eq("Céréales et légumineuses")
+    end
+  end
+
+  describe "DSL structure" do
+    it "stores organization on Collection class" do
+      klass = Class.new(Lutaml::Model::Serializable) do
+        attribute :name, :string
+      end
+
+      collection_class = Class.new(Lutaml::Model::Collection) do
+        organizes :groups, klass
+      end
+
+      org = collection_class.organization
+      expect(org).to be_a(Lutaml::Model::Organization)
+      expect(org.name).to eq(:groups)
+      expect(org.group_class).to eq(klass)
+    end
+
+    it "creates organized attribute on Collection" do
+      klass = Class.new(Lutaml::Model::Serializable) do
+        attribute :name, :string
+      end
+
+      collection_class = Class.new(Lutaml::Model::Collection) do
+        organizes :groups, klass
+      end
+
+      expect(collection_class.attributes).to have_key(:groups)
+    end
+
+    it "stores consolidation_maps on Xml::Mapping" do
+      group_class = Class.new(Lutaml::Model::Serializable) do
+        attribute :name, :string
+      end
+
+      collection_class = Class.new(Lutaml::Model::Collection) do
+        organizes :entries, group_class
+
+        xml do
+          root "test"
+          consolidate_map by: :lang, to: :entries do
+            gather :lang, to: :lang
+            dispatch_by :type do
+              route "main" => :main
+            end
+          end
+        end
+      end
+
+      mapping = collection_class.mappings_for(:xml)
+      expect(mapping.consolidation_maps.size).to eq(1)
+      map = mapping.consolidation_maps.first
+      expect(map.by).to eq(:lang)
+      expect(map.to).to eq(:entries)
+      expect(map.rules.size).to eq(2)
+    end
+
+    it "stores pattern consolidation_maps" do
+      entry_class = Class.new(Lutaml::Model::Serializable) do
+        attribute :name, :string
+        attribute :key, :string
+        attribute :desc, :string
+      end
+
+      collection_class = Class.new(Lutaml::Model::Collection) do
+        organizes :entries, entry_class
+
+        xml do
+          root "test"
+          consolidate_map by: :pattern, to: :entries do
+            map_element "member", to: :name
+            map_element "member_key", to: :key
+            map_content to: :desc
+          end
+        end
+      end
+
+      mapping = collection_class.mappings_for(:xml)
+      map = mapping.consolidation_maps.first
+      expect(map.pattern?).to be true
+      expect(map.attribute_based?).to be false
+      expect(map.rules.size).to eq(3)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Consolidation mapping groups sibling XML elements into structured model instances. It solves the problem where multiple elements of the same name need to be organized by an attribute value and distributed into typed attributes on a group model.

Two patterns are supported:

- **Pattern A (Attribute-Based)**: Same element name, different attribute values (e.g., multiple `<title>` elements grouped by `xml:lang`, distributed by `type` attribute)
- **Pattern B (Sequential Pattern)**: Different element names in mixed content following a repeating pattern (e.g., `<member>`, `<member_key>`, text content in sequence)

## Key Components

| Component | Purpose |
|-----------|---------|
| `Organization` | Model-level declaration on Collection |
| `ConsolidationMap` | Format-level consolidation configuration |
| `ConsolidationRule` hierarchy | GatherRule, DispatchBlock, PatternRules |
| `Consolidation::Engine` | Strategy dispatcher to AttributeGrouper or PatternChunker |

## Design Principles

1. **Model-centric**: GroupClasses are plain models with attributes only
2. **Collection orchestrates**: all consolidation logic lives on Collection
3. **Format-agnostic model level**: `organizes` works for any format
4. **Round-trip safe**: raw items preserved for exact XML round-tripping

## Test plan

- [x] All 3950 tests pass
- [x] All rubocop offenses resolved
- [x] Pattern A tests: groups by language, assigns language, dispatches to correct attributes, handles missing attributes, preserves raw items, round-trips XML
- [x] Pattern A Type 2 tests: groups by type, dispatches by language
- [x] DSL structure tests: organization storage, attribute creation, consolidation_maps storage, pattern consolidation_maps