### PR TITLE
fix: namespace hoisting bug and improve mixed content docs

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -6314,10 +6314,11 @@ end
 
 The `mixed_content` method explicitly enables mixed content mode.
 
-Mixed content means that the XML element or type is whitespace and order
-sensitive, and therefore preserves them.
+Mixed content means that the XML element or type contains **interleaved text
+and child elements** whose order must be preserved during round-trip
+serialization.
 
-This is most typically used encoding rich-text or semantically-tagged text.
+This is most typically used for encoding rich-text or semantically-tagged text.
 
 [example]
 ====
@@ -6331,8 +6332,8 @@ This is most typically used encoding rich-text or semantically-tagged text.
 A mixed content mode:
 
 * Preserves text nodes interspersed with elements
-* Automatically enables ordered mode
-* Required for rich text content
+* Automatically enables ordered mode (`@ordered = true`)
+* Required for rich text content and round-trip fidelity
 
 Syntax:
 
@@ -6343,6 +6344,81 @@ xml do
   mixed_content  # Enables mixed content + ordered
 end
 ----
+
+[TIP]
+====
+When a model has `mixed_content`, use `map_content` with `collection: true`
+to capture the multiple text segments between child elements.
+Without `collection: true`, only the first (or last) text segment is captured.
+====
+
+.Complete round-trip with `mixed_content` and `map_content collection: true`
+[example]
+====
+[source,ruby]
+----
+class MathExpression < Lutaml::Model::Serializable
+  attribute :content, :string
+
+  xml do
+    element "math"
+    map_content to: :content
+  end
+end
+
+class Paragraph < Lutaml::Model::Serializable
+  attribute :text, :string, collection: true     # <1>
+  attribute :stem, MathExpression, collection: true
+
+  xml do
+    element 'p'
+    mixed_content                                 # <2>
+
+    map_content to: :text
+    map_element 'stem', to: :stem
+  end
+end
+----
+<1> `collection: true` is required -- mixed content produces multiple text segments
+<2> `mixed_content` enables ordered round-trip via `element_order` tracking
+
+Input XML:
+
+[source,xml]
+----
+<p>Temperature <stem>T</stem> minus <stem>T<sub>90</sub></stem></p>
+----
+
+Round-trip preserves interleaving:
+
+[source,ruby]
+----
+parsed = Paragraph.from_xml(xml)
+parsed.text
+# => ["Temperature ", " minus "]
+parsed.stem.map(&:content)
+# => ["T", "T90"]
+
+# Serialize back -- text and elements appear in their original positions
+serialized = parsed.to_xml
+# => "<p>Temperature <stem>T</stem> minus <stem>T<sub>90</sub></stem></p>"
+
+# Iterate in document order to access text and elements interleaved
+parsed.each_mixed_content do |node|
+  case node
+  when String
+    puts "Text: #{node.inspect}"
+  when MathExpression
+    puts "Math: #{node.content}"
+  end
+end
+# Output:
+#   Text: "Temperature "
+#   Math: T
+#   Text: " minus "
+#   Math: T90
+----
+====
 
 ===== Whitespace preservation with `xml_space`
 
@@ -6409,19 +6485,18 @@ parsed = RichText.from_xml(xml_input)
 ----
 ====
 
-To iterate over mixed content in document order, use the `each_mixed_content` method:
+===== When to use `mixed_content`
 
-[source,ruby]
-----
-parsed.each_mixed_content do |node|
-  case node
-  when String
-    puts "Text: #{node}"
-  when MyInlineElement
-    puts "Element: #{node.some_attribute}"
-  end
-end
-----
+Use `mixed_content` when an XML element contains **both text nodes and child
+elements in arbitrary order**. Common patterns include:
+
+* Rich text with inline formatting (`<p>text <b>bold</b> more text</p>`)
+* Scientific notation with inline math (`Temperature <stem>T</stem> minus ...`)
+* Annotation elements interspersed with prose
+
+Without `mixed_content`, serialization groups all text first then all elements
+(or vice versa), losing the original interleaving. This is the most common
+cause of XML round-trip failures in document-processing applications.
 
 ==== (DEPRECATED) Mixed content declaration (`root` method with `mixed:`)
 

--- a/docs/_guides/xml-mapping.adoc
+++ b/docs/_guides/xml-mapping.adoc
@@ -272,10 +272,11 @@ end
 
 The `mixed_content` method explicitly enables mixed content mode.
 
-Mixed content means that the XML element or type is whitespace and order
-sensitive, and therefore preserves them.
+Mixed content means that the XML element or type contains **interleaved text
+and child elements** whose order must be preserved during round-trip
+serialization.
 
-This is most typically used encoding rich-text or semantically-tagged text.
+This is most typically used for encoding rich-text or semantically-tagged text.
 
 [example]
 ====
@@ -289,8 +290,8 @@ This is most typically used encoding rich-text or semantically-tagged text.
 A mixed content mode:
 
 * Preserves text nodes interspersed with elements
-* Automatically enables ordered mode
-* Required for rich text content
+* Automatically enables ordered mode (`@ordered = true`)
+* Required for rich text content and round-trip fidelity
 
 Syntax:
 
@@ -301,6 +302,81 @@ xml do
   mixed_content  # Enables mixed content + ordered
 end
 ----
+
+[TIP]
+====
+When a model has `mixed_content`, use `map_content` with `collection: true`
+to capture the multiple text segments between child elements.
+Without `collection: true`, only the first (or last) text segment is captured.
+====
+
+.Complete round-trip with `mixed_content` and `map_content collection: true`
+[example]
+====
+[source,ruby]
+----
+class MathExpression < Lutaml::Model::Serializable
+  attribute :content, :string
+
+  xml do
+    element "math"
+    map_content to: :content
+  end
+end
+
+class Paragraph < Lutaml::Model::Serializable
+  attribute :text, :string, collection: true     # <1>
+  attribute :stem, MathExpression, collection: true
+
+  xml do
+    element 'p'
+    mixed_content                                 # <2>
+
+    map_content to: :text
+    map_element 'stem', to: :stem
+  end
+end
+----
+<1> `collection: true` is required -- mixed content produces multiple text segments
+<2> `mixed_content` enables ordered round-trip via `element_order` tracking
+
+Input XML:
+
+[source,xml]
+----
+<p>Temperature <stem>T</stem> minus <stem>T<sub>90</sub></stem></p>
+----
+
+Round-trip preserves interleaving:
+
+[source,ruby]
+----
+parsed = Paragraph.from_xml(xml)
+parsed.text
+# => ["Temperature ", " minus "]
+parsed.stem.map(&:content)
+# => ["T", "T90"]
+
+# Serialize back -- text and elements appear in their original positions
+serialized = parsed.to_xml
+# => "<p>Temperature <stem>T</stem> minus <stem>T<sub>90</sub></stem></p>"
+
+# Iterate in document order to access text and elements interleaved
+parsed.each_mixed_content do |node|
+  case node
+  when String
+    puts "Text: #{node.inspect}"
+  when MathExpression
+    puts "Math: #{node.content}"
+  end
+end
+# Output:
+#   Text: "Temperature "
+#   Math: T
+#   Text: " minus "
+#   Math: T90
+----
+====
 
 .Using `mixed_content` explicitly
 [example]
@@ -325,6 +401,35 @@ parsed = RichText.from_xml(xml_input)
 # Preserves: "This is ", "<b>bold</b>", " and ", "<i>italic</i>", " text"
 ----
 ====
+
+===== When to use `mixed_content`
+
+Use `mixed_content` when an XML element contains **both text nodes and child
+elements in arbitrary order**. Common patterns include:
+
+* Rich text with inline formatting (`<p>text <b>bold</b> more text</p>`)
+* Scientific notation with inline math (`Temperature <stem>T</stem> minus ...`)
+* Annotation elements interspersed with prose
+
+Without `mixed_content`, serialization groups all text first then all elements
+(or vice versa), losing the original interleaving. This is the most common
+cause of XML round-trip failures in document-processing applications.
+
+===== Iterating mixed content with index
+
+`each_mixed_content` returns an `Enumerator` when called without a block,
+so you can chain standard Ruby methods like `with_index`, `select`, `map`:
+
+[source,ruby]
+----
+parsed.each_mixed_content.with_index do |node, index|
+  puts "#{index}: #{node.inspect}"
+end
+# 0: "Temperature "
+# 1: #<MathExpression content="T">
+# 2: " minus "
+# 3: #<MathExpression content="T90">
+----
 
 ==== (DEPRECATED) Mixed content declaration (`root` method with `mixed:`)
 

--- a/docs/_guides/xml_mappings/05_common_patterns.adoc
+++ b/docs/_guides/xml_mappings/05_common_patterns.adoc
@@ -240,44 +240,82 @@ end
 
 === Mixed content
 
-.Model with mixed content (text + elements)
+.Model with mixed content (text + elements) -- round-trip example
 [example]
 ====
 [source,ruby]
 ----
+class MathExpression < Lutaml::Model::Serializable
+  attribute :content, :string
+
+  xml do
+    element "math"
+    map_content to: :content
+  end
+end
+
 class Paragraph < Lutaml::Model::Serializable
+  attribute :text, :string, collection: true     # collection: true required
   attribute :bold, :string, collection: true
-  attribute :italic, :string
+  attribute :stem, MathExpression, collection: true
 
   xml do
     element 'p'
-    mixed_content  # Enable mixed content
+    mixed_content  # Enable mixed content + ordered round-trip
+
+    map_content to: :text
     map_element 'bold', to: :bold
-    map_element 'i', to: :italic
+    map_element 'stem', to: :stem
   end
 end
 ----
 
 [source,xml]
 ----
-<p>My name is <bold>John Doe</bold>, and I'm <i>28</i> years old</p>
+<p>Temperature <stem>T</stem> minus <stem>T<sub>90</sub></stem></p>
 ----
 
 [source,ruby]
 ----
-> Paragraph.from_xml(xml)
-> #<Paragraph @bold="John Doe", @italic="28">
+parsed = Paragraph.from_xml(xml)
+
+# Access text segments and elements separately
+parsed.text   # => ["Temperature ", " minus "]
+parsed.stem.map(&:content)  # => ["T", "T90"]
+
+# Serialize back -- text and elements appear in their original positions
+parsed.to_xml
+# => "<p>Temperature <stem>T</stem> minus <stem>T<sub>90</sub></stem></p>"
+
+# Iterate in document order to process text and elements interleaved
+parsed.each_mixed_content do |node|
+  case node
+  when String
+    puts "Text: #{node.inspect}"
+  when MathExpression
+    puts "Math: #{node.content}"
+  end
+end
+# Output:
+#   Text: "Temperature "
+#   Math: T
+#   Text: " minus "
+#   Math: T90
 ----
 ====
 [NOTE]
-.map_content requires collection: true
+.map_content requires collection: true for mixed content
 ====
-For mixed content, `map_content` must be `collection: true` because XML like:
+For mixed content, `map_content` must target an attribute with `collection: true` because XML like:
 [source,xml]
 ----
 <hello><element1>hi</element1> ho <element2>he</element2>? Yes!</hello>
 ----
 has multiple text segments between elements. Each segment becomes an entry in the content collection.
+
+Without `mixed_content`, serialization groups all text first then all elements
+(or vice versa), losing the original interleaving. This is the most common
+cause of XML round-trip failures in document-processing applications.
 
 === Builder interface for mixed content
 
@@ -524,7 +562,7 @@ end
 `each_mixed_content` returns:
 
 * `self` when called with a block (for chaining)
-* An `Enumerator` when called without a block
+* An `Enumerator` when called without a block -- supports `with_index`, `select`, `map`, etc.
 
 [source,ruby]
 ----
@@ -535,6 +573,15 @@ para.each_mixed_content { |node| process(node) }
 enum = para.each_mixed_content
 enum.select { |node| node.is_a?(String) }
 enum.each { |node| process(node) }
+
+# With index - useful for positional processing
+para.each_mixed_content.with_index do |node, index|
+  puts "#{index}: #{node.inspect}"
+end
+# 0: "Temperature "
+# 1: #<MathExpression content="T">
+# 2: " minus "
+# 3: #<MathExpression content="T90">
 ----
 
 [NOTE]

--- a/docs/_guides/xml_mappings/07_best_practices.adoc
+++ b/docs/_guides/xml_mappings/07_best_practices.adoc
@@ -324,6 +324,66 @@ end
 
 == Mixed content practices
 
+=== Always declare `mixed_content` for elements with interleaved text and children
+
+When an XML element contains both text nodes and child elements in arbitrary
+order, the model **must** declare `mixed_content` to preserve round-trip
+fidelity. Without it, serialization groups all text first then all elements
+(or vice versa), losing the original interleaving.
+
+**Do:**
+
+[source,ruby]
+----
+class Paragraph < Lutaml::Model::Serializable
+  attribute :text, :string, collection: true     # collection: true required
+  attribute :bold, :string, collection: true
+
+  xml do
+    element 'p'
+    mixed_content  # Preserves text/element interleaving
+
+    map_content to: :text
+    map_element 'b', to: :bold
+  end
+end
+
+# Round-trip: <p>Hello <b>world</b> again</p> stays in the same order
+----
+
+**Don't:**
+
+[source,ruby]
+----
+class Paragraph < Lutaml::Model::Serializable
+  attribute :text, :string, collection: true
+  attribute :bold, :string, collection: true
+
+  xml do
+    element 'p'
+    # Missing mixed_content -- round-trip breaks!
+    # Output: <p><b>world</b>Hello  again</p>  (elements grouped before text)
+    map_content to: :text
+    map_element 'b', to: :bold
+  end
+end
+----
+
+=== Use `collection: true` on `map_content` target for mixed content
+
+Mixed content elements produce **multiple text segments** (one between each
+pair of child elements). The attribute mapped via `map_content` must be a
+collection to capture all segments.
+
+[source,ruby]
+----
+# WRONG -- only captures last text segment
+attribute :text, :string
+
+# CORRECT -- captures all text segments in order
+attribute :text, :string, collection: true
+----
+
 === Use explicit `mixed_content()` for clarity
 
 **Do:**

--- a/lib/lutaml/xml/nokogiri/element.rb
+++ b/lib/lutaml/xml/nokogiri/element.rb
@@ -217,12 +217,6 @@ module Lutaml
           namespace_attrs[namespace.attr_name] = uri
         end
 
-        node.children.each do |child|
-          build_namespace_attributes(child).each do |key, value|
-            namespace_attrs[key] ||= value
-          end
-        end
-
         namespace_attrs
       end
     end

--- a/lib/lutaml/xml/oga/element.rb
+++ b/lib/lutaml/xml/oga/element.rb
@@ -164,12 +164,6 @@ module Lutaml
             namespace_attrs[namespace.attr_name] = uri
           end
 
-          node.children.each do |child|
-            namespace_attrs = namespace_attrs.merge(
-              build_namespace_attributes(child),
-            )
-          end
-
           namespace_attrs
         end
       end

--- a/spec/lutaml/xml/namespace_no_hoisting_spec.rb
+++ b/spec/lutaml/xml/namespace_no_hoisting_spec.rb
@@ -1,0 +1,172 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require_relative "../../../lib/lutaml/model"
+
+RSpec.describe "Namespace declaration placement (no hoisting)" do
+  # Regression test: child element's default namespace declaration must NOT
+  # be hoisted to the parent element during round-trip serialization.
+  #
+  # Input:  <stem><math xmlns="http://www.w3.org/1998/Math/MathML">T</math></stem>
+  # Wrong:  <stem xmlns="http://www.w3.org/1998/Math/MathML"><math>T</math></stem>
+  # Right:  xmlns stays on <math>, not on <stem>
+
+  let(:mathml_namespace) do
+    Class.new(Lutaml::Xml::W3c::XmlNamespace) do
+      uri "http://www.w3.org/1998/Math/MathML"
+    end
+  end
+
+  let(:math_class) do
+    ns = mathml_namespace
+    Class.new do
+      include Lutaml::Model::Serialize
+
+      attribute :content, :string
+
+      xml do
+        element "math"
+        namespace ns
+        map_content to: :content
+      end
+
+      def self.name
+        "MathElement"
+      end
+    end
+  end
+
+  let(:stem_class) do
+    math = math_class
+    Class.new do
+      include Lutaml::Model::Serialize
+
+      attribute :block, :string
+      attribute :type, :string
+      attribute :math, math
+
+      xml do
+        element "stem"
+        map_attribute "block", to: :block
+        map_attribute "type", to: :type
+        map_element "math", to: :math
+      end
+
+      def self.name
+        "StemElement"
+      end
+    end
+  end
+
+  let(:input_xml) do
+    <<~XML
+      <stem block="false" type="MathML">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">T</math>
+      </stem>
+    XML
+  end
+
+  it "keeps xmlns on child element, not hoisted to parent" do
+    parsed = stem_class.from_xml(input_xml)
+
+    expect(parsed.block).to eq("false")
+    expect(parsed.type).to eq("MathML")
+    expect(parsed.math.content.strip).to eq("T")
+
+    serialized = parsed.to_xml
+
+    # The xmlns declaration must appear on <math>, NOT on <stem>
+    expect(serialized).to include('xmlns="http://www.w3.org/1998/Math/MathML"')
+    expect(serialized).not_to match(%r{<stem[^>]*xmlns="http://www\.w3\.org/1998/Math/MathML"})
+    expect(serialized).to match(%r{<math[^>]*xmlns="http://www\.w3\.org/1998/Math/MathML"})
+  end
+
+  it "round-trips with namespace on the correct element" do
+    parsed = stem_class.from_xml(input_xml)
+    serialized = parsed.to_xml
+
+    # Parse again to verify structural correctness
+    reparsed = stem_class.from_xml(serialized)
+    expect(reparsed.block).to eq("false")
+    expect(reparsed.type).to eq("MathML")
+    expect(reparsed.math.content.strip).to eq("T")
+
+    # Second serialization should produce same result as first
+    expect(reparsed.to_xml).to be_xml_equivalent_to(serialized)
+  end
+
+  context "with nested default namespace that differs from parent" do
+    let(:mathml_ns) do
+      Class.new(Lutaml::Xml::W3c::XmlNamespace) do
+        uri "http://www.w3.org/1998/Math/MathML"
+      end
+    end
+
+    let(:standoc_ns) do
+      Class.new(Lutaml::Xml::W3c::XmlNamespace) do
+        uri "https://www.metanorma.org/ns/standoc"
+      end
+    end
+
+    let(:nested_math_class) do
+      ns = mathml_ns
+      Class.new do
+        include Lutaml::Model::Serialize
+
+        attribute :content, :string
+
+        xml do
+          element "math"
+          namespace ns
+          map_content to: :content
+        end
+
+        def self.name
+          "NestedMath"
+        end
+      end
+    end
+
+    let(:stem_with_ns_class) do
+      ns = standoc_ns
+      math = nested_math_class
+      Class.new do
+        include Lutaml::Model::Serialize
+
+        attribute :block, :string
+        attribute :math, math
+
+        xml do
+          element "stem"
+          namespace ns
+          map_attribute "block", to: :block
+          map_element "math", to: :math
+        end
+
+        def self.name
+          "StemWithNs"
+        end
+      end
+    end
+
+    it "preserves distinct namespace declarations on each element" do
+      xml = <<~XML
+        <stem xmlns="https://www.metanorma.org/ns/standoc" block="false">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">µmol</math>
+        </stem>
+      XML
+
+      serialized = stem_with_ns_class.from_xml(xml).to_xml
+
+      # Each element should have its own xmlns — no hoisting
+      expect(serialized).to include('xmlns="https://www.metanorma.org/ns/standoc"')
+      expect(serialized).to include('xmlns="http://www.w3.org/1998/Math/MathML"')
+      expect(serialized).to include("µmol")
+
+      # stem must NOT carry the MathML namespace
+      expect(serialized).not_to match(
+        %r{<stem[^>]*xmlns="http://www\.w3\.org/1998/Math/MathML"},
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- **Fix namespace hoisting bug**: `build_namespace_attributes` in Nokogiri and Oga adapters was recursively collecting child namespace declarations and merging them into the parent. Removed the children loop so each element only declares its own `own_namespaces`. Ox and REXML already had correct behavior.
- **Improve mixed content documentation**: Added complete round-trip examples with `map_content collection: true`, `each_mixed_content` iteration (including `with_index`), and best practices for when/how to use `mixed_content`.

## Changes

### Bug fix
- `lib/lutaml/xml/nokogiri/element.rb` — removed children loop from `build_namespace_attributes`
- `lib/lutaml/xml/oga/element.rb` — same fix
- `spec/lutaml/xml/namespace_no_hoisting_spec.rb` — 3 new test cases

### Documentation
- `docs/_guides/xml-mapping.adoc` — complete round-trip example, `each_mixed_content` + `with_index`, "when to use" guidance
- `docs/_guides/xml_mappings/05_common_patterns.adoc` — replaced basic example with full round-trip, added `with_index` pattern
- `docs/_guides/xml_mappings/07_best_practices.adoc` — added "always declare mixed_content" and "collection: true" best practices
- `README.adoc` — same updates as xml-mapping.adoc

## Test plan
- [x] `bundle exec rspec spec/lutaml/xml/namespace_no_hoisting_spec.rb` — 3 examples, 0 failures
- [ ] Full test suite passes