### PR TITLE
Fix Opal runtime compatibility for adapter loading

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -15782,6 +15782,20 @@ end
 ----
 
 
+[[opal-compatibility]]
+=== Opal compatibility
+
+Lutaml::Model supports running under https://opalrb.com[Opal] (Ruby compiled to
+JavaScript). The runtime is detected automatically and adapter selection is
+adjusted accordingly.
+
+* *XML*: Only the `:oga` adapter is available (auto-selected).
+* *JSON*: Only the `:standard_json` adapter is available.
+* *TOML*: Not available on Opal.
+* *Schema generation*: `to_xsd`, `to_relaxng`, and `from_xml` (XML schema
+  compilation) raise `NotImplementedError` on Opal.
+
+
 === Error handling
 
 When parsing invalid serialization format data, an `InvalidFormatError` is

--- a/docs/_pages/configuration.adoc
+++ b/docs/_pages/configuration.adoc
@@ -85,6 +85,31 @@ end
 
 NOTE: The `:tomlib` adapter is not available on Windows due to segmentation fault issues. On Windows, `:toml_rb` is automatically used as the default.
 
+== Opal runtime compatibility
+
+Lutaml::Model supports running under https://opalrb.com[Opal] (Ruby compiled to JavaScript) with some limitations. The library detects the runtime automatically via `Lutaml::Model::RuntimeCompatibility` and adapts its behavior accordingly.
+
+=== Adapter defaults on Opal
+
+[cols="1,2",options="header"]
+|===
+| Format | Behavior
+| XML | Only `:oga` is available (auto-selected). Nokogiri, Ox, and REXML require native extensions.
+| JSON | Only `:standard` is available. Oj and MultiJson require native extensions.
+| YAML | `:standard` (Psych ships with Opal's stdlib).
+| TOML | **Not available.** Both tomlib and toml-rb depend on native extensions.
+| Hash | `:standard` / `:standard_hash` (pure Ruby).
+|===
+
+=== Features unavailable on Opal
+
+The following features raise `NotImplementedError` when called under Opal:
+
+* `Lutaml::Model::Schema.to_xsd` — XSD schema generation requires Nokogiri
+* `Lutaml::Model::Schema.to_relaxng` — RELAX NG generation requires Nokogiri
+* `Lutaml::Model::Schema.from_xml` — XML schema compilation is not supported
+* `Lutaml::Xml::Schema::Xsd::Base#to_formatted_xml` — XSD formatted output requires the Canon gem
+
 == Configuration with class references
 
 For advanced use, specify adapter classes directly:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -116,7 +116,25 @@ cached_resolver.resolve(:string, context)  # Resolves and caches
 cached_resolver.resolve(:string, context)  # Returns cached value
 ```
 
-**Thread safety**: Uses Mutex for concurrent access.
+**Cache backend**: Uses `ConcurrentMapCache` on native Ruby (lock-free via Concurrent::Map) or `MutexHashCache` on Opal (Mutex + Hash). The backend is selected automatically and can be overridden per-instance.
+
+### RuntimeCompatibility
+
+**Responsibility**: Abstracts runtime differences between native Ruby and Opal.
+
+```ruby
+Lutaml::Model::RuntimeCompatibility.opal?   #=> false (native) / true (Opal)
+Lutaml::Model::RuntimeCompatibility.native?  #=> true  (native) / false (Opal)
+
+# Conditional autoload — only registers on native Ruby
+RuntimeCompatibility.autoload_native(self, OjAdapter: "path/to/oj_adapter")
+
+# Conditional require — skips on Opal
+RuntimeCompatibility.require_native("nokogiri", "ox")
+```
+
+On Opal, provides shim classes (`Mutex`, `ConditionVariable`, `Thread`) so
+code that references these compiles without errors.
 
 ### TypeSubstitution
 

--- a/lib/lutaml/json.rb
+++ b/lib/lutaml/json.rb
@@ -3,15 +3,38 @@
 # JSON format module
 # Provides Lutaml::Json namespace for JSON serialization
 
+require "lutaml/model/runtime_compatibility"
+require_relative "model"
+require_relative "key_value"
+
 module Lutaml
   module Json
     class Error < StandardError; end
 
-    autoload :Adapter, "#{__dir__}/json/adapter"
-    autoload :Schema, "#{__dir__}/json/schema"
+    require_relative "json/adapter/document"
+    require_relative "json/adapter/mapping"
+    require_relative "json/adapter/mapping_rule"
+    require_relative "json/adapter/transform"
+    require_relative "json/adapter/standard_adapter"
+    Lutaml::Model::RuntimeCompatibility.require_native(
+      "#{__dir__}/json/adapter/oj_adapter",
+      "#{__dir__}/json/adapter/multi_json_adapter",
+    )
+    require_relative "json/schema"
+
+    # Convenience aliases for common classes at the module level
+    # Allows Lutaml::Json::Mapping to resolve to Lutaml::Json::Adapter::Mapping
+    def self.const_missing(name)
+      if Adapter.const_defined?(name, false)
+        Adapter.const_get(name, false)
+      else
+        super
+      end
+    end
 
     # Detect available JSON adapters
     def self.detect_adapter
+      return :standard if defined?(::JSON) && Lutaml::Model::RuntimeCompatibility.opal?
       return :oj if defined?(::Oj)
       return :multi_json if defined?(::MultiJson)
       return :standard if defined?(::JSON)

--- a/lib/lutaml/json/adapter.rb
+++ b/lib/lutaml/json/adapter.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "lutaml/model/runtime_compatibility"
+
 module Lutaml
   module Json
     module Adapter
@@ -8,8 +10,11 @@ module Lutaml
       autoload :MappingRule, "#{__dir__}/adapter/mapping_rule"
       autoload :Transform, "#{__dir__}/adapter/transform"
       autoload :StandardAdapter, "#{__dir__}/adapter/standard_adapter"
-      autoload :OjAdapter, "#{__dir__}/adapter/oj_adapter"
-      autoload :MultiJsonAdapter, "#{__dir__}/adapter/multi_json_adapter"
+      Lutaml::Model::RuntimeCompatibility.autoload_native(
+        self,
+        OjAdapter: "#{__dir__}/adapter/oj_adapter",
+        MultiJsonAdapter: "#{__dir__}/adapter/multi_json_adapter",
+      )
     end
   end
 end

--- a/lib/lutaml/key_value.rb
+++ b/lib/lutaml/key_value.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "model"
-
 module Lutaml
   module KeyValue
     autoload :DataModel, "#{__dir__}/key_value/data_model"
@@ -15,6 +13,8 @@ module Lutaml
     autoload :Adapter, "#{__dir__}/key_value/adapter"
   end
 end
+
+require_relative "model"
 
 # Register KeyValue transformation builders for all key-value formats
 %i[json yaml toml hash].each do |format|

--- a/lib/lutaml/key_value/adapter/json.rb
+++ b/lib/lutaml/key_value/adapter/json.rb
@@ -2,6 +2,8 @@
 
 require "json"
 
+require "lutaml/model/runtime_compatibility"
+
 module Lutaml
   module KeyValue
     module Adapter
@@ -11,8 +13,11 @@ module Lutaml
         autoload :MappingRule, "#{__dir__}/json/mapping_rule"
         autoload :Transform, "#{__dir__}/json/transform"
         autoload :StandardAdapter, "#{__dir__}/json/standard_adapter"
-        autoload :OjAdapter, "#{__dir__}/json/oj_adapter"
-        autoload :MultiJsonAdapter, "#{__dir__}/json/multi_json_adapter"
+        Lutaml::Model::RuntimeCompatibility.autoload_native(
+          self,
+          OjAdapter: "#{__dir__}/json/oj_adapter",
+          MultiJsonAdapter: "#{__dir__}/json/multi_json_adapter",
+        )
       end
     end
   end

--- a/lib/lutaml/key_value/adapter/toml.rb
+++ b/lib/lutaml/key_value/adapter/toml.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "lutaml/model/runtime_compatibility"
+
 module Lutaml
   module KeyValue
     module Adapter
@@ -8,8 +10,11 @@ module Lutaml
         autoload :Mapping, "#{__dir__}/toml/mapping"
         autoload :MappingRule, "#{__dir__}/toml/mapping_rule"
         autoload :Transform, "#{__dir__}/toml/transform"
-        autoload :TomlibAdapter, "#{__dir__}/toml/tomlib_adapter"
-        autoload :TomlRbAdapter, "#{__dir__}/toml/toml_rb_adapter"
+        Lutaml::Model::RuntimeCompatibility.autoload_native(
+          self,
+          TomlibAdapter: "#{__dir__}/toml/tomlib_adapter",
+          TomlRbAdapter: "#{__dir__}/toml/toml_rb_adapter",
+        )
       end
     end
   end

--- a/lib/lutaml/key_value/adapter/yaml/standard_adapter.rb
+++ b/lib/lutaml/key_value/adapter/yaml/standard_adapter.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "date"
 require "yaml"
 
 module Lutaml

--- a/lib/lutaml/key_value/transformation.rb
+++ b/lib/lutaml/key_value/transformation.rb
@@ -33,25 +33,31 @@ module Lutaml
       def initialize(model_class, mapping_dsl, format, register)
         # Extract register_id before super
         register_id = extract_register_id(register)
+        transformation_factory = ->(type_class) {
+          build_child_transformation(type_class)
+        }
 
         # Set up serializers before calling super
         # The super will call compile_rules and freeze
+        @rule_compiler = RuleCompiler.new(
+          model_class: model_class,
+          register_id: register_id,
+          format: format,
+          transformation_factory: transformation_factory,
+        )
+
         @value_serializer = ValueSerializer.new(
           format: format,
           register_id: register_id,
           model_class: model_class,
-          transformation_factory: ->(type_class) {
-            build_child_transformation(type_class)
-          },
+          transformation_factory: transformation_factory,
         )
 
         @collection_serializer = CollectionSerializer.new(
           format: format,
           register_id: register_id,
           value_serializer: @value_serializer,
-          transformation_factory: ->(type_class) {
-            build_child_transformation(type_class)
-          },
+          transformation_factory: transformation_factory,
         )
 
         super
@@ -124,41 +130,21 @@ register = self.register)
       #
       # @return [RuleCompiler] The rule compiler
       def rule_compiler
-        @rule_compiler ||= RuleCompiler.new(
-          model_class: model_class,
-          register_id: register_id,
-          format: format,
-          transformation_factory: ->(type_class) {
-            build_child_transformation(type_class)
-          },
-        )
+        @rule_compiler
       end
 
       # Get the value serializer instance
       #
       # @return [ValueSerializer] The value serializer
       def value_serializer
-        @value_serializer ||= ValueSerializer.new(
-          format: format,
-          register_id: register_id,
-          transformation_factory: ->(type_class) {
-            build_child_transformation(type_class)
-          },
-        )
+        @value_serializer
       end
 
       # Get the collection serializer instance
       #
       # @return [CollectionSerializer] The collection serializer
       def collection_serializer
-        @collection_serializer ||= CollectionSerializer.new(
-          format: format,
-          register_id: register_id,
-          value_serializer: value_serializer,
-          transformation_factory: ->(type_class) {
-            build_child_transformation(type_class)
-          },
-        )
+        @collection_serializer
       end
 
       # Check if a mapping rule should be applied based on only/except options

--- a/lib/lutaml/model.rb
+++ b/lib/lutaml/model.rb
@@ -14,6 +14,7 @@ module Lutaml
   module Model
     # Autoloads for lazy loading - set up BEFORE any requires
     # These must be declared before files that reference these constants
+    autoload :RuntimeCompatibility, "#{__dir__}/model/runtime_compatibility"
     autoload :UninitializedClass, "#{__dir__}/model/uninitialized_class"
     autoload :Errors, "#{__dir__}/model/errors"
     autoload :Services, "#{__dir__}/model/services"

--- a/lib/lutaml/model/cached_type_resolver.rb
+++ b/lib/lutaml/model/cached_type_resolver.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "concurrent"
-
 module Lutaml
   module Model
     # CachedTypeResolver adds caching to any TypeResolver using the Decorator pattern.
@@ -12,7 +10,7 @@ module Lutaml
     #
     # This class:
     # - Decorates any TypeResolver-like object (duck typing)
-    # - Uses Concurrent::Map for lock-free, parallel-safe caching
+    # - Uses a runtime-selected cache backend
     # - Centralized cache management - ONE place to clear ALL type caches
     #
     # @api private
@@ -27,23 +25,38 @@ module Lutaml
     #   resolver.clear_all_caches          # Clear all caches
     #
     class CachedTypeResolver
+      RuntimeCompatibility.autoload_native(
+        self,
+        ConcurrentMapCache: "#{__dir__}/cached_type_resolver/concurrent_map_cache",
+      )
+      autoload :MutexHashCache,
+               "#{__dir__}/cached_type_resolver/mutex_hash_cache"
+
       # @return [Object] The delegate resolver (typically TypeResolver)
-      attr_reader :delegate
+      attr_reader :delegate, :cache_backend
+
+      def self.default_cache_backend
+        if RuntimeCompatibility.opal?
+          MutexHashCache.new
+        else
+          ConcurrentMapCache.new
+        end
+      end
 
       # Create a new CachedTypeResolver.
       #
       # @param delegate [Object] Any object responding to #resolve(name, context)
-      def initialize(delegate:)
+      # @param cache_backend [Object] Any object implementing the resolver cache
+      #   interface used internally by CachedTypeResolver
+      def initialize(delegate:, cache_backend: self.class.default_cache_backend)
         @delegate = delegate
-        # Concurrent::Map uses CAS (compare-and-swap) operations internally
-        # No external mutex needed - fully parallel-safe
-        @cache = Concurrent::Map.new
+        @cache_backend = cache_backend
       end
 
       # Resolve a type name to a class, using cache if available.
       #
-      # Uses Concurrent::Map's atomic compute_if_absent for lock-free caching.
-      # Multiple threads can safely call this simultaneously without contention.
+      # Cache backends synchronize storage, but compute outside exclusive cache
+      # updates so recursive type resolution can populate related keys.
       #
       # @param name [Symbol, String, Class] The type name or class to resolve
       # @param context [TypeContext] The resolution context
@@ -55,11 +68,7 @@ module Lutaml
 
         cache_key = build_cache_key(name, context)
 
-        # Concurrent::Map#compute_if_absent is atomic:
-        # - If key exists, returns cached value
-        # - If key doesn't exist, computes, stores, and returns value
-        # No mutex needed - CAS handles parallel access safely
-        @cache.compute_if_absent(cache_key) do
+        @cache_backend.fetch_or_store(cache_key) do
           @delegate.resolve(name, context)
         end
       end
@@ -75,7 +84,7 @@ module Lutaml
         cache_key = build_cache_key(name, context)
 
         # Check cache first (fast path)
-        return true if @cache.key?(cache_key)
+        return true if @cache_backend.key?(cache_key)
 
         # Not in cache - delegate
         @delegate.resolvable?(name, context)
@@ -97,26 +106,25 @@ module Lutaml
       # @param context_id [Symbol] The context ID to clear caches for
       # @return [void]
       def clear_cache(context_id)
-        # Concurrent::Map#keys returns a snapshot - safe to iterate
-        @cache.each_key do |key|
-          @cache.delete(key) if key[0] == context_id
-        end
+        @cache_backend.clear_context(context_id)
       end
 
       # Clear all caches.
       #
       # @return [void]
       def clear_all_caches
-        @cache.clear
+        @cache_backend.clear
       end
 
       # Get cache statistics (useful for debugging/monitoring).
       #
       # @return [Hash] Cache statistics
       def cache_stats
+        keys = @cache_backend.keys
+
         {
-          size: @cache.size,
-          keys: @cache.keys,
+          size: keys.size,
+          keys: keys,
         }
       end
 

--- a/lib/lutaml/model/cached_type_resolver/concurrent_map_cache.rb
+++ b/lib/lutaml/model/cached_type_resolver/concurrent_map_cache.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "concurrent"
+
+module Lutaml
+  module Model
+    class CachedTypeResolver
+      # Concurrent::Map-backed cache optimized for native Ruby runtimes.
+      #
+      # The value block runs outside an atomic compute section so nested type
+      # resolution can re-enter the cache. Under concurrent misses, more than
+      # one thread may compute; the first stored value wins.
+      class ConcurrentMapCache
+        def initialize(store: Concurrent::Map.new)
+          @store = store
+        end
+
+        def fetch_or_store(cache_key)
+          return @store[cache_key] if @store.key?(cache_key)
+
+          value = yield
+          @store.put_if_absent(cache_key, value)
+          @store[cache_key]
+        end
+
+        def key?(cache_key)
+          @store.key?(cache_key)
+        end
+
+        def clear_context(context_id)
+          @store.each_key do |key|
+            @store.delete(key) if key[0] == context_id
+          end
+        end
+
+        def clear
+          @store.clear
+        end
+
+        def keys
+          @store.keys
+        end
+      end
+    end
+  end
+end

--- a/lib/lutaml/model/cached_type_resolver/mutex_hash_cache.rb
+++ b/lib/lutaml/model/cached_type_resolver/mutex_hash_cache.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Lutaml
+  module Model
+    class CachedTypeResolver
+      # Hash-backed cache that only relies on Mutex semantics available on Opal.
+      class MutexHashCache
+        def initialize(store: {}, mutex: Mutex.new)
+          @store = store
+          @mutex = mutex
+        end
+
+        def fetch_or_store(cache_key)
+          found = false
+          cached_value = @mutex.synchronize do
+            if @store.key?(cache_key)
+              found = true
+              @store[cache_key]
+            end
+          end
+          return cached_value if found
+
+          value = yield
+
+          @mutex.synchronize do
+            @store[cache_key] = value unless @store.key?(cache_key)
+            @store[cache_key]
+          end
+        end
+
+        def key?(cache_key)
+          @mutex.synchronize { @store.key?(cache_key) }
+        end
+
+        def clear_context(context_id)
+          @mutex.synchronize do
+            @store.delete_if { |key, _| key[0] == context_id }
+          end
+        end
+
+        def clear
+          @mutex.synchronize { @store.clear }
+        end
+
+        def keys
+          @mutex.synchronize { @store.keys.dup }
+        end
+      end
+    end
+  end
+end

--- a/lib/lutaml/model/configuration.rb
+++ b/lib/lutaml/model/configuration.rb
@@ -12,6 +12,11 @@ module Lutaml
     #   end
     #
     class Configuration
+      # Static defaults captured at boot. Use RuntimeCompatibility directly for
+      # per-call runtime checks that tests may stub.
+      OPAL_RUNTIME = Lutaml::Model::RuntimeCompatibility.opal?
+      WINDOWS_PLATFORM = Lutaml::Model::RuntimeCompatibility.windows?
+
       # Bootstrap format list for key-value adapters.
       # NOTE: XML is NOT listed here — it registers dynamically via FormatRegistry.
       AVAILABLE_FORMATS = %i[json jsonl yaml toml hash].freeze
@@ -31,8 +36,14 @@ module Lutaml
             default: :standard,
           },
           toml: {
-            available: %i[tomlib toml_rb],
-            default: Gem.win_platform? ? :toml_rb : :tomlib,
+            available: OPAL_RUNTIME ? [] : %i[tomlib toml_rb],
+            default: if OPAL_RUNTIME
+                       nil
+                     elsif WINDOWS_PLATFORM
+                       :toml_rb
+                     else
+                       :tomlib
+                     end,
           },
           hash: {
             available: %i[standard standard_hash],
@@ -72,7 +83,7 @@ module Lutaml
 
       # Check if running on Windows platform
       def self.windows_platform?
-        Gem.win_platform?
+        WINDOWS_PLATFORM
       end
 
       # Dynamic accessor for adapter types
@@ -227,7 +238,11 @@ module Lutaml
         end
 
         # Default key-value adapter loading
-        adapter_path = File.join(__dir__, "../key_value/adapter", adapter, type)
+        adapter_path = if Lutaml::Model::RuntimeCompatibility.opal?
+                         "lutaml/key_value/adapter/#{adapter}/#{type}"
+                       else
+                         File.join(__dir__, "../key_value/adapter", adapter, type)
+                       end
         require adapter_path
       rescue LoadError
         raise UnknownAdapterTypeError.new(adapter, type), cause: nil

--- a/lib/lutaml/model/instrumentation.rb
+++ b/lib/lutaml/model/instrumentation.rb
@@ -155,6 +155,8 @@ module Lutaml
         #
         # @return [Float] the current monotonic time in seconds
         def monotonic_time
+          return Time.now.to_f if Lutaml::Model::RuntimeCompatibility.opal?
+
           Process.clock_gettime(Process::CLOCK_MONOTONIC)
         end
 
@@ -162,10 +164,11 @@ module Lutaml
         #
         # @return [Integer, nil] memory in bytes, or nil if not available
         def memory_usage
+          return nil if Lutaml::Model::RuntimeCompatibility.opal?
           return nil unless defined?(GC)
 
           GC.start if GC.respond_to?(:compact)
-          `ps -o rss= -p #{Process.pid}`.to_i * 1024
+          IO.popen(["ps", "-o", "rss=", "-p", Process.pid.to_s], &:read).to_i * 1024
         rescue StandardError
           nil
         end

--- a/lib/lutaml/model/json.rb
+++ b/lib/lutaml/model/json.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 
+# JSON format entry point
+# Provides Lutaml::Json namespace helpers before exposing Model aliases
+
+require_relative "../json"
+
 # Backward compatibility - provides Lutaml::Model::Json namespace as alias to Lutaml::Json
 
 module Lutaml
@@ -10,8 +15,11 @@ module Lutaml
       Mapping = ::Lutaml::Json::Adapter::Mapping
       MappingRule = ::Lutaml::Json::Adapter::MappingRule
       Transform = ::Lutaml::Json::Adapter::Transform
-      OjAdapter = ::Lutaml::Json::Adapter::OjAdapter
-      MultiJsonAdapter = ::Lutaml::Json::Adapter::MultiJsonAdapter
+      Lutaml::Model::RuntimeCompatibility.define_native_aliases(
+        self,
+        OjAdapter: "::Lutaml::Json::Adapter::OjAdapter",
+        MultiJsonAdapter: "::Lutaml::Json::Adapter::MultiJsonAdapter",
+      )
     end
   end
 end

--- a/lib/lutaml/model/register.rb
+++ b/lib/lutaml/model/register.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+require_relative "runtime_compatibility"
+
+Lutaml::Model::RuntimeCompatibility.require_native("concurrent")
+
 module Lutaml
   module Model
     # Register is a collection of models (types) for a specific context.
@@ -41,10 +45,14 @@ module Lutaml
       # @return [Hash{String => NamespaceBinding}] Namespace URI to binding map
       attr_reader :bound_namespaces
 
-      # Thread-safe cache for resolve_for_child results.
+      # Cache for resolve_for_child results.
       # Key: [child_class.object_id, parent_register] → Value: resolved register Symbol or nil.
       # Classes are singletons so object_id is stable for the process lifetime.
-      RESOLVE_CACHE = Concurrent::Map.new
+      RESOLVE_CACHE = if RuntimeCompatibility.opal?
+                        {}
+                      else
+                        Concurrent::Map.new
+                      end
 
       # Clear the resolve_for_child cache.
       # Called from add_fallback and GlobalContext.clear_caches.
@@ -73,8 +81,16 @@ module Lutaml
       # @return [Symbol, nil] The register ID to use for the child
       def self.resolve_for_child(child_class, parent_register)
         cache_key = [child_class.object_id, parent_register]
-        RESOLVE_CACHE.compute_if_absent(cache_key) do
-          _resolve_for_child_uncached(child_class, parent_register)
+
+        if RuntimeCompatibility.opal?
+          return RESOLVE_CACHE[cache_key] if RESOLVE_CACHE.key?(cache_key)
+
+          RESOLVE_CACHE[cache_key] =
+            _resolve_for_child_uncached(child_class, parent_register)
+        else
+          RESOLVE_CACHE.compute_if_absent(cache_key) do
+            _resolve_for_child_uncached(child_class, parent_register)
+          end
         end
       end
 

--- a/lib/lutaml/model/runtime_compatibility.rb
+++ b/lib/lutaml/model/runtime_compatibility.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+module Lutaml
+  module Model
+    module RuntimeCompatibility
+      def self.opal?
+        return @opal if defined?(@opal)
+
+        @opal = RUBY_ENGINE == "opal"
+      end
+
+      def self.windows?
+        defined?(Gem) &&
+          Gem.respond_to?(:win_platform?) &&
+          Gem.win_platform?
+      end
+
+      def self.native?
+        !opal?
+      end
+
+      def self.autoload_native(namespace, constant_paths)
+        return unless native?
+
+        constant_paths.each do |constant_name, path|
+          namespace.autoload(constant_name, path)
+        end
+      end
+
+      def self.require_native(*paths)
+        return unless native?
+
+        paths.each { |path| require path }
+      end
+
+      def self.define_native_aliases(namespace, constant_targets)
+        return unless native?
+
+        constant_targets.each do |constant_name, target_name|
+          namespace.const_set(constant_name, constantize(target_name))
+        end
+      end
+
+      def self.safe_constantize(name)
+        parts = constant_parts(name)
+        return nil if parts.empty?
+        return nil unless Object.const_defined?(parts.first)
+
+        parts.inject(Object) do |mod, part|
+          mod.const_get(part)
+        end
+      rescue NameError
+        nil
+      end
+
+      def self.constantize(name)
+        constant_parts(name).inject(Object) do |mod, part|
+          mod.const_get(part, false)
+        end
+      end
+      private_class_method :constantize
+
+      def self.constant_parts(name)
+        name.to_s.split("::").reject(&:empty?)
+      end
+      private_class_method :constant_parts
+    end
+  end
+end
+
+if Lutaml::Model::RuntimeCompatibility.opal?
+  unless defined?(Mutex)
+    class ::Mutex
+      def synchronize
+        yield
+      end
+    end
+  end
+
+  unless defined?(ConditionVariable)
+    class ::ConditionVariable
+      def wait(*); end
+
+      def broadcast; end
+    end
+  end
+
+  unless defined?(Thread)
+    class ::Thread
+      def self.current
+        @current ||= {}
+      end
+    end
+  end
+end

--- a/lib/lutaml/model/schema.rb
+++ b/lib/lutaml/model/schema.rb
@@ -8,7 +8,12 @@ module Lutaml
       autoload :Helpers, "#{__dir__}/schema/helpers"
       autoload :JsonSchema, "#{__dir__}/schema/json_schema"
       autoload :YamlSchema, "#{__dir__}/schema/yaml_schema"
-      autoload :XmlCompiler, "#{__dir__}/schema/xml_compiler"
+      Lutaml::Model::RuntimeCompatibility.autoload_native(
+        self,
+        {
+          XmlCompiler: "#{__dir__}/schema/xml_compiler",
+        },
+      )
       autoload :Generator, "#{__dir__}/schema/generator"
       autoload :Renderer, "#{__dir__}/schema/renderer"
       autoload :Decorators, "#{__dir__}/schema/decorators"

--- a/lib/lutaml/model/schema/xml_compiler.rb
+++ b/lib/lutaml/model/schema/xml_compiler.rb
@@ -141,6 +141,8 @@ module Lutaml
         end
 
         def require_classes(classes_hash)
+          return if Lutaml::Model::RuntimeCompatibility.opal?
+
           Dir.mktmpdir do |dir|
             # Create subdirectory for class files (matches autoload path in registry)
             module_subdir = "generatedmodels"

--- a/lib/lutaml/model/serialize/format_conversion.rb
+++ b/lib/lutaml/model/serialize/format_conversion.rb
@@ -83,19 +83,24 @@ module Lutaml
         def format_error_types
           @format_error_types_base ||= begin
             errors = [
-              Psych::SyntaxError,
-              JSON::ParserError,
+              Lutaml::Model::RuntimeCompatibility.safe_constantize("Psych::SyntaxError"),
+              Lutaml::Model::RuntimeCompatibility.safe_constantize("JSON::ParserError"),
               NoMethodError,
               TypeError,
               ArgumentError,
             ]
 
             # Collect format-specific error types from FormatRegistry
+            compatibility = Lutaml::Model::RuntimeCompatibility
             FormatRegistry.all.each_value do |info|
               next unless info[:error_types]
 
               info[:error_types].each do |error_class|
-                cls = error_class.is_a?(String) ? safe_get_const(error_class) : error_class
+                cls = if error_class.is_a?(String)
+                        compatibility.safe_constantize(error_class)
+                      else
+                        error_class
+                      end
                 errors << cls
               end
             end
@@ -103,10 +108,11 @@ module Lutaml
             errors.compact.freeze
           end
 
-          # Legacy TOML error types (lazily loaded — must check on each call)
-          toml_errors = safe_get_const("TomlRB::ParseError")
+          # Legacy TOML error types are lazy, so check them on each call.
+          compatibility = Lutaml::Model::RuntimeCompatibility
+          toml_errors = compatibility.safe_constantize("TomlRB::ParseError")
           toml_errors = Array(toml_errors)
-          tomllib_err = safe_get_const("Tomlib::ParseError")
+          tomllib_err = compatibility.safe_constantize("Tomlib::ParseError")
           toml_errors << tomllib_err if tomllib_err
 
           @format_error_types_base + toml_errors
@@ -115,18 +121,6 @@ module Lutaml
         # Reset cached error types (for test isolation)
         def reset_format_error_types_cache!
           @format_error_types_base = nil
-        end
-
-        # Safely get a constant by name
-        #
-        # @param error_class [String] The constant name
-        # @return [Class, nil] The constant or nil if not defined
-        def safe_get_const(error_class)
-          return unless Object.const_defined?(error_class.split("::").first)
-
-          error_class.split("::").inject(Object) do |mod, part|
-            mod.const_get(part)
-          end
         end
 
         # Create a model instance from a parsed document

--- a/lib/lutaml/model/toml.rb
+++ b/lib/lutaml/model/toml.rb
@@ -5,16 +5,21 @@
 module Lutaml
   module Model
     module Toml
-      TomlibAdapter = ::Lutaml::Toml::Adapter::TomlibAdapter
-      TomlRbAdapter = ::Lutaml::Toml::Adapter::TomlRbAdapter
+      Lutaml::Model::RuntimeCompatibility.define_native_aliases(
+        self,
+        TomlibAdapter: "::Lutaml::Toml::Adapter::TomlibAdapter",
+        TomlRbAdapter: "::Lutaml::Toml::Adapter::TomlRbAdapter",
+      )
       Document = ::Lutaml::Toml::Adapter::Document
       Mapping = ::Lutaml::Toml::Adapter::Mapping
       MappingRule = ::Lutaml::Toml::Adapter::MappingRule
       Transform = ::Lutaml::Toml::Adapter::Transform
 
       def self.detect_toml_adapter
+        return nil if Lutaml::Model::RuntimeCompatibility.opal?
+
         # Skip tomlib on Windows entirely due to segfault issues
-        if Gem.win_platform?
+        if Lutaml::Model::RuntimeCompatibility.windows?
           return :toml_rb if Lutaml::Model::Utils.safe_load("toml-rb", :TomlRb)
 
           return nil

--- a/lib/lutaml/model/transformation_registry.rb
+++ b/lib/lutaml/model/transformation_registry.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-require "concurrent"
+require_relative "runtime_compatibility"
+
+Lutaml::Model::RuntimeCompatibility.require_native("concurrent")
 
 module Lutaml
   module Model
@@ -88,7 +90,11 @@ module Lutaml
 
       def initialize
         @transformations = {} # Cache for transformation instances (mutex-protected for cycle detection)
-        @mappings = Concurrent::Map.new # Lock-free cache for resolved mappings
+        @mappings = if RuntimeCompatibility.opal?
+                      {}
+                    else
+                      Concurrent::Map.new
+                    end
         @mutex = Mutex.new
         @building_threads = {} # Track which thread is building each transformation
         @condition = ConditionVariable.new
@@ -172,7 +178,7 @@ module Lutaml
         register_id = extract_register_id(register)
         key = [model_class.object_id, format, register_id]
 
-        # Fast path: Concurrent::Map#[] is thread-safe and lock-free
+        # Fast path: native Ruby uses Concurrent::Map, Opal uses Hash.
         cached = @mappings[key]
         return cached if cached
 
@@ -183,7 +189,6 @@ module Lutaml
 
         mapping.ensure_mappings_imported!(register_id)
 
-        # Concurrent::Map#[]= is thread-safe (CAS-based, no mutex)
         @mappings[key] = mapping
         mapping
       end

--- a/lib/lutaml/toml.rb
+++ b/lib/lutaml/toml.rb
@@ -3,11 +3,23 @@
 # TOML format module
 # Provides Lutaml::Toml namespace for TOML serialization
 
+require "lutaml/model/runtime_compatibility"
+require_relative "key_value"
+require_relative "toml/adapter"
+
 module Lutaml
   module Toml
     class Error < StandardError; end
 
-    autoload :Adapter, "#{__dir__}/toml/adapter"
+    # Convenience aliases for common classes at the module level
+    # Allows Lutaml::Toml::Mapping to resolve to Lutaml::Toml::Adapter::Mapping
+    def self.const_missing(name)
+      if Adapter.const_defined?(name, false)
+        Adapter.const_get(name, false)
+      else
+        super
+      end
+    end
   end
 end
 
@@ -15,7 +27,7 @@ end
 Lutaml::Model::FormatRegistry.register(
   :toml,
   mapping_class: Lutaml::Toml::Adapter::Mapping,
-  adapter_class: Lutaml::Toml::Adapter::TomlibAdapter,
+  adapter_class: nil,
   transformer: Lutaml::Toml::Adapter::Transform,
   key_value: true,
 )
@@ -23,3 +35,7 @@ Lutaml::Model::FormatRegistry.register(
 # Register TOML type serializers
 require_relative "toml/type/serializers"
 Lutaml::Toml::Type::Serializers.register_all!
+
+if (adapter = Lutaml::Model::Toml.detect_toml_adapter)
+  Lutaml::Model::Config.toml_adapter_type = adapter
+end

--- a/lib/lutaml/toml/adapter.rb
+++ b/lib/lutaml/toml/adapter.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "lutaml/model/runtime_compatibility"
+
 module Lutaml
   module Toml
     module Adapter
@@ -7,8 +9,11 @@ module Lutaml
       autoload :Mapping, "#{__dir__}/adapter/mapping"
       autoload :MappingRule, "#{__dir__}/adapter/mapping_rule"
       autoload :Transform, "#{__dir__}/adapter/transform"
-      autoload :TomlRbAdapter, "#{__dir__}/adapter/toml_rb_adapter"
-      autoload :TomlibAdapter, "#{__dir__}/adapter/tomlib_adapter"
+      Lutaml::Model::RuntimeCompatibility.autoload_native(
+        self,
+        TomlRbAdapter: "#{__dir__}/adapter/toml_rb_adapter",
+        TomlibAdapter: "#{__dir__}/adapter/tomlib_adapter",
+      )
     end
   end
 end

--- a/lib/lutaml/xml.rb
+++ b/lib/lutaml/xml.rb
@@ -40,11 +40,12 @@ module Lutaml
     autoload :Serialization, "#{__dir__}/xml/serialization"
 
     # XML Schema modules
-    require_relative "xml/schema"
+    autoload :Schema, "#{__dir__}/xml/schema"
 
     # Detect available XML adapter
     # @return [Symbol, nil] :nokogiri, :ox, :oga, :rexml, or nil
     def self.detect_xml_adapter
+      return :oga if Lutaml::Model::RuntimeCompatibility.opal?
       return :nokogiri if Lutaml::Model::Utils.safe_load("nokogiri", :Nokogiri)
       return :ox if Lutaml::Model::Utils.safe_load("ox", :Ox)
       return :oga if Lutaml::Model::Utils.safe_load("oga", :Oga)
@@ -85,6 +86,8 @@ module Lutaml
     autoload :Listener, "#{__dir__}/xml/listener"
     autoload :Document, "#{__dir__}/xml/document"
     autoload :Transformation, "#{__dir__}/xml/transformation"
+    autoload :CustomMethodWrapper,
+             "#{__dir__}/xml/transformation/custom_method_wrapper"
     autoload :Transform, "#{__dir__}/xml/transform"
     autoload :Adapter, "#{__dir__}/xml/adapter"
     autoload :XmlElement, "#{__dir__}/xml/xml_element"
@@ -143,14 +146,14 @@ module Lutaml
     autoload :TransformationSupport, "#{__dir__}/xml/transformation_support"
     autoload :SharedDsl, "#{__dir__}/xml/shared_dsl"
 
-    # Autoload adapter element classes (defined in subdirectories)
-    autoload :NokogiriElement, "#{__dir__}/xml/nokogiri/element"
-
-    # Autoload adapter module namespaces
-    autoload :Nokogiri, "#{__dir__}/xml/nokogiri"
-    autoload :Ox, "#{__dir__}/xml/ox"
     autoload :Oga, "#{__dir__}/xml/oga"
-    autoload :Rexml, "#{__dir__}/xml/rexml"
+    Lutaml::Model::RuntimeCompatibility.autoload_native(
+      self,
+      NokogiriElement: "#{__dir__}/xml/nokogiri/element",
+      Nokogiri: "#{__dir__}/xml/nokogiri",
+      Ox: "#{__dir__}/xml/ox",
+      Rexml: "#{__dir__}/xml/rexml",
+    )
   end
 end
 
@@ -169,10 +172,17 @@ Lutaml::Model::FormatRegistry.register(
     Ox::ParseError
     REXML::ParseException
   ],
-  adapter_options: {
-    available: %i[nokogiri ox oga rexml],
-    default: :nokogiri,
-  },
+  adapter_options: if Lutaml::Model::RuntimeCompatibility.opal?
+                     {
+                       available: %i[oga],
+                       default: :oga,
+                     }
+                   else
+                     {
+                       available: %i[nokogiri ox oga rexml],
+                       default: :nokogiri,
+                     }
+                   end,
 )
 
 # Register XML transformation builder
@@ -200,6 +210,24 @@ Lutaml::Model::Serialize.prepend(
   Lutaml::Xml::Serialization::InstanceMethods,
 )
 
+# Opal does not propagate methods prepended into an already-included module
+# to classes that included it before the prepend. Serializable includes
+# Serialize during model boot, so make the XML instance API available on the
+# concrete base class as well.
+if Lutaml::Model::RuntimeCompatibility.opal?
+  Lutaml::Model::Serializable.singleton_class.prepend(
+    Lutaml::Xml::Serialization::ModelImportExt,
+  )
+
+  Lutaml::Model::Serializable.singleton_class.prepend(
+    Lutaml::Xml::Serialization::FormatConversion,
+  )
+
+  Lutaml::Model::Serializable.prepend(
+    Lutaml::Xml::Serialization::InstanceMethods,
+  )
+end
+
 # Register XML-specific attribute override warning names
 Lutaml::Model::Attribute.format_specific_warn_names.push(:element_order,
                                                          :schema_location, :encoding, :doctype, :ordered?, :mixed?)
@@ -216,16 +244,30 @@ Lutaml::Xml::Type::Serializers.register_all!
 
 # Register XML schema methods
 Lutaml::Model::Schema.register_method(:to_xsd) do |klass, options = {}|
-  require_relative "xml/schema/xsd_schema"
+  if Lutaml::Model::RuntimeCompatibility.opal?
+    raise NotImplementedError,
+          "XSD schema generation is not available under Opal."
+  end
+
   Lutaml::Xml::Schema::XsdSchema.generate(klass, options)
 end
 
 Lutaml::Model::Schema.register_method(:to_relaxng) do |klass, options = {}|
-  require_relative "xml/schema/relaxng_schema"
+  if Lutaml::Model::RuntimeCompatibility.opal?
+    raise NotImplementedError,
+          "RELAX NG schema generation requires Nokogiri, " \
+          "which is not available under Opal."
+  end
+
   Lutaml::Xml::Schema::RelaxngSchema.generate(klass, options)
 end
 
 Lutaml::Model::Schema.register_method(:from_xml) do |xml, options = {}|
+  if Lutaml::Model::RuntimeCompatibility.opal?
+    raise NotImplementedError,
+          "XML schema compilation is not available under Opal."
+  end
+
   Lutaml::Model::Schema::XmlCompiler.to_models(xml, options)
 end
 

--- a/lib/lutaml/xml/adapter.rb
+++ b/lib/lutaml/xml/adapter.rb
@@ -8,10 +8,13 @@ module Lutaml
       autoload :AdapterHelpers, "#{__dir__}/adapter/adapter_helpers"
       autoload :BaseAdapter, "#{__dir__}/adapter/base_adapter"
       autoload :NamespaceData, "#{__dir__}/adapter/namespace_data"
-      autoload :NokogiriAdapter, "#{__dir__}/adapter/nokogiri_adapter"
       autoload :OgaAdapter, "#{__dir__}/adapter/oga_adapter"
-      autoload :OxAdapter, "#{__dir__}/adapter/ox_adapter"
-      autoload :RexmlAdapter, "#{__dir__}/adapter/rexml_adapter"
+      Lutaml::Model::RuntimeCompatibility.autoload_native(
+        self,
+        NokogiriAdapter: "#{__dir__}/adapter/nokogiri_adapter",
+        OxAdapter: "#{__dir__}/adapter/ox_adapter",
+        RexmlAdapter: "#{__dir__}/adapter/rexml_adapter",
+      )
     end
   end
 end

--- a/lib/lutaml/xml/adapter/oga_adapter.rb
+++ b/lib/lutaml/xml/adapter/oga_adapter.rb
@@ -507,7 +507,7 @@ module Lutaml
                                                          effective_uri)
 
             xmlns_name = prefix ? "xmlns:#{prefix}" : "xmlns"
-            element[xmlns_name] = effective_uri
+            add_moxml_attribute(element, xmlns_name, effective_uri)
           end
 
           # 3. Add regular attributes by INDEX (PARALLEL TRAVERSAL)
@@ -515,17 +515,17 @@ module Lutaml
 
           # xsi:nil attribute for W3C compliance
           if xml_element.respond_to?(:xsi_nil) && xml_element.xsi_nil
-            element["xsi:nil"] = "true"
+            add_moxml_attribute(element, "xsi:nil", "true")
           end
 
           # schema_location attribute from ElementNode
           element_node.schema_location_attr&.each do |attr_name, attr_value|
-            element[attr_name] = attr_value
+            add_moxml_attribute(element, attr_name, attr_value)
           end
 
           # W3C Compliance: xmlns="" for blank namespace opt-out
           if element_node.needs_xmlns_blank
-            element["xmlns"] = ""
+            add_moxml_attribute(element, "xmlns", "")
           end
 
           # Handle raw content (map_all directive)
@@ -564,6 +564,19 @@ module Lutaml
           end
 
           element
+        end
+
+        def add_moxml_attribute(element, name, value)
+          name = name.to_s
+          value = value.to_s
+
+          if name == "xmlns"
+            element.add_namespace(nil, value)
+          elsif name.start_with?("xmlns:")
+            element.add_namespace(name.split(":", 2).last, value)
+          else
+            element[name] = value
+          end
         end
 
         # Check if immediate parent element has xmlns declaration

--- a/lib/lutaml/xml/adapter_loader.rb
+++ b/lib/lutaml/xml/adapter_loader.rb
@@ -13,7 +13,11 @@ module Lutaml
       # @param _adapter [String] The adapter format name ("xml")
       # @param type [String] The normalized type name (e.g., "nokogiri_adapter")
       def self.load_adapter_file(_adapter, type)
-        adapter_path = File.join(File.dirname(__FILE__), "adapter", type)
+        adapter_path = if Lutaml::Model::RuntimeCompatibility.opal?
+                         "lutaml/xml/adapter/#{type}"
+                       else
+                         File.join(File.dirname(__FILE__), "adapter", type)
+                       end
         require adapter_path
       rescue LoadError
         raise Lutaml::Model::UnknownAdapterTypeError.new("xml", type),

--- a/lib/lutaml/xml/builder.rb
+++ b/lib/lutaml/xml/builder.rb
@@ -4,10 +4,13 @@ module Lutaml
   module Xml
     # Builder module for XML generation
     module Builder
-      autoload :Nokogiri, "#{__dir__}/builder/nokogiri"
-      autoload :Ox, "#{__dir__}/builder/ox"
       autoload :Oga, "#{__dir__}/builder/oga"
-      autoload :Rexml, "#{__dir__}/builder/rexml"
+      Lutaml::Model::RuntimeCompatibility.autoload_native(
+        self,
+        Nokogiri: "#{__dir__}/builder/nokogiri",
+        Ox: "#{__dir__}/builder/ox",
+        Rexml: "#{__dir__}/builder/rexml",
+      )
     end
   end
 end

--- a/lib/lutaml/xml/builder/base.rb
+++ b/lib/lutaml/xml/builder/base.rb
@@ -10,6 +10,9 @@ module Lutaml
       class Base
         def self.build(options = {})
           context = Moxml.new(moxml_backend)
+          if Lutaml::Model::RuntimeCompatibility.opal?
+            context.config.namespace_validation_mode = :lenient
+          end
           doc = context.create_document
           instance = new(doc, context, options)
           yield(instance) if block_given?

--- a/lib/lutaml/xml/document.rb
+++ b/lib/lutaml/xml/document.rb
@@ -264,9 +264,11 @@ module Lutaml
 
       # Check if a child node is an EntityReference
       def entity_reference_node?(child)
-        child.is_a?(Lutaml::Xml::NokogiriElement) &&
-          child.adapter_node.respond_to?(:entity_reference?) &&
-          child.adapter_node.entity_reference?
+        return false unless defined?(::Nokogiri)
+        return false unless child.is_a?(Lutaml::Xml::NokogiriElement)
+
+        node = child.adapter_node
+        node.respond_to?(:entity_reference?) && node.entity_reference?
       end
 
       def setup_register(register)

--- a/lib/lutaml/xml/element.rb
+++ b/lib/lutaml/xml/element.rb
@@ -18,10 +18,12 @@ module Lutaml
                      namespace_uri: nil, namespace_prefix: nil)
         @type = type # "Text" or "Element" - deprecated, kept for backward compatibility
         @name = name
-        # For text nodes, store both marker ("text") and actual content
-        @text_content = text_content || name
         # Infer node_type from type for backward compatibility if not provided
         @node_type = node_type || infer_node_type(type, name)
+        # For text nodes, store both marker ("text") and actual content.
+        # Regular element-order entries do not carry text content.
+        @text_content = text_content
+        @text_content ||= name if text? || cdata?
         @namespace_uri = namespace_uri
         @namespace_prefix = namespace_prefix
       end

--- a/lib/lutaml/xml/mapping.rb
+++ b/lib/lutaml/xml/mapping.rb
@@ -628,10 +628,16 @@ module Lutaml
         end
 
         if name == "schemaLocation"
+          location = caller_locations(1, 1)[0]
+          caller_file = if defined?(File) && File.respond_to?(:basename)
+                          File.basename(location.path)
+                        else
+                          location.path.to_s.split("/").last
+                        end
           ::Lutaml::Model::Logger.warn_auto_handling(
             name: name,
-            caller_file: File.basename(caller_locations(1, 1)[0].path),
-            caller_line: caller_locations(1, 1)[0].lineno,
+            caller_file: caller_file,
+            caller_line: location.lineno,
           )
         end
 

--- a/lib/lutaml/xml/schema.rb
+++ b/lib/lutaml/xml/schema.rb
@@ -3,11 +3,14 @@
 module Lutaml
   module Xml
     module Schema
-      autoload :Xsd, "#{__dir__}/schema/xsd"
-      autoload :XsdSchema, "#{__dir__}/schema/xsd_schema"
-      autoload :RelaxngSchema, "#{__dir__}/schema/relaxng_schema"
-      autoload :Builder, "#{__dir__}/schema/builder"
-      autoload :BuiltinTypes, "#{__dir__}/schema/builtin_types"
+      Lutaml::Model::RuntimeCompatibility.autoload_native(
+        self,
+        Xsd: "#{__dir__}/schema/xsd",
+        XsdSchema: "#{__dir__}/schema/xsd_schema",
+        RelaxngSchema: "#{__dir__}/schema/relaxng_schema",
+        Builder: "#{__dir__}/schema/builder",
+        BuiltinTypes: "#{__dir__}/schema/builtin_types",
+      )
     end
   end
 end

--- a/lib/lutaml/xml/schema/builder.rb
+++ b/lib/lutaml/xml/schema/builder.rb
@@ -8,7 +8,10 @@ module Lutaml
       # Nokogiri and Oga. When the configured XML adapter is Ox or REXML, we
       # default to Nokogiri for schema generation.
       class Builder
-        autoload :Nokogiri, "#{__dir__}/builder/nokogiri"
+        Lutaml::Model::RuntimeCompatibility.autoload_native(
+          self,
+          Nokogiri: "#{__dir__}/builder/nokogiri",
+        )
         autoload :Oga, "#{__dir__}/builder/oga"
 
         attr_reader :builder, :adapter_type

--- a/lib/lutaml/xml/schema/xsd.rb
+++ b/lib/lutaml/xml/schema/xsd.rb
@@ -5,8 +5,8 @@
 # dependency since lutaml/xml.rb requires lutaml/model. The adapter type
 # is already set by lutaml/xml.rb at the end.
 
-adapter = RUBY_ENGINE == "opal" ? :oga : :nokogiri
-Lutaml::Model::Config.xml_adapter_type = adapter unless defined?(Lutaml::Model::Config.xml_adapter_type)
+adapter = Lutaml::Model::RuntimeCompatibility.opal? ? :oga : :nokogiri
+Lutaml::Model::Config.xml_adapter_type ||= adapter
 
 # Require the XsdNamespace class for XSD schema support
 require_relative "xsd_namespace"

--- a/lib/lutaml/xml/schema/xsd/base.rb
+++ b/lib/lutaml/xml/schema/xsd/base.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "canon"
+Lutaml::Model::RuntimeCompatibility.require_native("canon")
 
 module Lutaml
   module Xml
@@ -11,6 +11,11 @@ module Lutaml
           ELEMENT_ORDER_IGNORABLE = %w[import include].freeze
 
           def to_formatted_xml(except: [])
+            unless Lutaml::Model::RuntimeCompatibility.native?
+              raise NotImplementedError,
+                    "XSD formatted XML output is not available under Opal"
+            end
+
             Canon.format_xml(
               to_xml(except: except),
             ).gsub(XML_DECLARATION_REGEX, "")

--- a/lib/lutaml/xml/transformation/custom_method_wrapper.rb
+++ b/lib/lutaml/xml/transformation/custom_method_wrapper.rb
@@ -69,29 +69,25 @@ module Lutaml
         parent = parent_or_element
 
         if element_or_string.is_a?(String)
-          # Parse XML string and add as child elements
-          # This handles cases like doc.add_element(parent, "<city>B</city>")
-          # We need to parse the XML and add each element as a proper child
-          # to maintain correct ordering in the output
-          begin
-            require "moxml" unless defined?(Moxml)
-            fragment_doc = Moxml.new.parse(
-              "<__wrapper__>#{element_or_string}</__wrapper__>",
-            )
-
-            # Convert each parsed element to our XmlDataModel format
-            # and add as proper children to maintain ordering
-            add_fragment_children_to_parent(fragment_doc.root, parent)
-          rescue StandardError
-            # Fallback: if parsing fails, store as raw content
-            existing_raw = parent.raw_content
-            parent.raw_content = existing_raw ? existing_raw + element_or_string : element_or_string
-          end
+          add_xml_fragment_or_raw_content(parent, element_or_string)
         else
           # Add as child element
           parent.add_child(element_or_string)
         end
         element_or_string
+      end
+
+      def add_xml_fragment_or_raw_content(parent, fragment_string)
+        require "moxml" unless defined?(Moxml)
+        fragment_doc = Moxml.new.parse(fragment_string, fragment: true)
+        add_fragment_children_to_parent(fragment_doc, parent)
+      rescue LoadError, StandardError
+        append_raw_content(parent, fragment_string)
+      end
+
+      def append_raw_content(parent, content)
+        existing_raw = parent.raw_content
+        parent.raw_content = existing_raw ? existing_raw + content : content
       end
 
       # Helper method to recursively add parsed XML nodes to parent
@@ -133,6 +129,9 @@ module Lutaml
           parent.add_child(element)
         end
       end
+      private :add_xml_fragment_or_raw_content,
+              :append_raw_content,
+              :add_fragment_children_to_parent
 
       # Add text to element (mimics old adapter API)
       #

--- a/lib/lutaml/xml/transformation/rule_applier.rb
+++ b/lib/lutaml/xml/transformation/rule_applier.rb
@@ -239,7 +239,7 @@ register_id)
         # @param model_class [Class] The model class
         # @param model_instance [Object] The model instance
         def apply_custom_method(parent, rule, model_class, model_instance)
-          wrapper = CustomMethodWrapper.new(parent, rule)
+          wrapper = ::Lutaml::Xml::CustomMethodWrapper.new(parent, rule)
           mapper_instance = model_class.new
           mapper_instance.send(rule.custom_methods[:to], model_instance,
                                parent, wrapper)

--- a/lib/lutaml/xml/transformation_support.rb
+++ b/lib/lutaml/xml/transformation_support.rb
@@ -3,8 +3,6 @@
 module Lutaml
   module Xml
     module TransformationSupport
-      autoload :CustomMethodWrapper,
-               "#{__dir__}/transformation/custom_method_wrapper"
       autoload :RuleCompiler, "#{__dir__}/transformation/rule_compiler"
       autoload :SkipLogic, "#{__dir__}/transformation/skip_logic"
       autoload :ValueSerializer, "#{__dir__}/transformation/value_serializer"

--- a/lib/lutaml/yaml/adapter/standard_adapter.rb
+++ b/lib/lutaml/yaml/adapter/standard_adapter.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "date"
 require "yaml"
 
 module Lutaml

--- a/lutaml-model.gemspec
+++ b/lutaml-model.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
   # required for liquid
   spec.add_dependency "base64"
   spec.add_dependency "bigdecimal"
+  spec.add_dependency "canon"
   spec.add_dependency "concurrent-ruby"
   spec.add_dependency "liquid", "~> 5.0"
   spec.add_dependency "moxml", ">= 0.1.16"

--- a/spec/lutaml/key_value/transformation_spec.rb
+++ b/spec/lutaml/key_value/transformation_spec.rb
@@ -263,4 +263,28 @@ RSpec.describe Lutaml::KeyValue::Transformation do
       expect(hash).to be_a(Hash)
     end
   end
+
+  describe "immutability" do
+    class FrozenLazyTransformation < described_class
+      private
+
+      def compile_rules(_mapping_dsl)
+        []
+      end
+    end
+
+    it "does not lazily initialize collaborators after freeze" do
+      transformation = FrozenLazyTransformation.new(
+        KVSimpleModel,
+        KVSimpleModel.mappings_for(:json),
+        :json,
+        nil,
+      )
+
+      expect(transformation).to be_frozen
+
+      rule = instance_double(Lutaml::Model::CompiledRule, attribute_name: :name)
+      expect { transformation.send(:valid_mapping?, rule, {}) }.not_to raise_error
+    end
+  end
 end

--- a/spec/lutaml/model/cached_type_resolver_spec.rb
+++ b/spec/lutaml/model/cached_type_resolver_spec.rb
@@ -8,13 +8,94 @@ RSpec.describe Lutaml::Model::CachedTypeResolver do
   let(:custom_class) { Class.new }
   let(:resolver) { described_class.new(delegate: Lutaml::Model::TypeResolver) }
 
+  shared_examples "a resolver cache backend" do
+    let(:cache_key) { %i[test custom] }
+    let(:other_cache_key) { %i[other custom] }
+
+    it "stores and reuses cached values" do
+      expect(cache_backend.fetch_or_store(cache_key) { :first }).to eq(:first)
+      expect(cache_backend.fetch_or_store(cache_key) { :second }).to eq(:first)
+      expect(cache_backend.keys).to contain_exactly(cache_key)
+    end
+
+    it "checks whether a cache key exists" do
+      cache_backend.fetch_or_store(cache_key) { :first }
+
+      expect(cache_backend.key?(cache_key)).to be true
+      expect(cache_backend.key?(other_cache_key)).to be false
+    end
+
+    it "clears keys for a specific context" do
+      cache_backend.fetch_or_store(cache_key) { :first }
+      cache_backend.fetch_or_store(other_cache_key) { :second }
+
+      cache_backend.clear_context(:test)
+
+      expect(cache_backend.keys).to contain_exactly(other_cache_key)
+    end
+
+    it "clears all keys" do
+      cache_backend.fetch_or_store(cache_key) { :first }
+      cache_backend.fetch_or_store(other_cache_key) { :second }
+
+      cache_backend.clear
+
+      expect(cache_backend.keys).to be_empty
+    end
+
+    it "allows recursive cache population from the computed value block" do
+      result = cache_backend.fetch_or_store(cache_key) do
+        cache_backend.fetch_or_store(other_cache_key) { :nested }
+        :outer
+      end
+
+      expect(result).to eq(:outer)
+      expect(cache_backend.fetch_or_store(other_cache_key) { :other }).to eq(:nested)
+    end
+  end
+
   before do
     registry.register(:custom, custom_class)
+  end
+
+  describe described_class::ConcurrentMapCache do
+    subject(:cache_backend) { described_class.new }
+
+    it_behaves_like "a resolver cache backend"
+  end
+
+  describe described_class::MutexHashCache do
+    subject(:cache_backend) { described_class.new }
+
+    it_behaves_like "a resolver cache backend"
   end
 
   describe "#initialize" do
     it "stores the delegate resolver" do
       expect(resolver.delegate).to eq(Lutaml::Model::TypeResolver)
+    end
+
+    it "uses ConcurrentMapCache by default on native Ruby" do
+      expect(resolver.cache_backend).to be_a(described_class::ConcurrentMapCache)
+    end
+
+    it "uses MutexHashCache by default on Opal" do
+      allow(Lutaml::Model::RuntimeCompatibility).to receive(:opal?).and_return(true)
+
+      opal_resolver = described_class.new(delegate: Lutaml::Model::TypeResolver)
+
+      expect(opal_resolver.cache_backend).to be_a(described_class::MutexHashCache)
+    end
+
+    it "accepts an injected cache backend" do
+      cache_backend = described_class::MutexHashCache.new
+
+      injected_resolver = described_class.new(
+        delegate: Lutaml::Model::TypeResolver,
+        cache_backend: cache_backend,
+      )
+
+      expect(injected_resolver.cache_backend).to equal(cache_backend)
     end
   end
 
@@ -236,6 +317,42 @@ RSpec.describe Lutaml::Model::CachedTypeResolver do
       stats = resolver.cache_stats
       expect(stats[:size]).to eq(1)
       expect(stats[:keys]).to contain_exactly(%i[ctx2 custom])
+    end
+  end
+
+  describe "Opal compatibility" do
+    let(:resolver) { described_class.new(delegate: Lutaml::Model::TypeResolver) }
+
+    before do
+      allow(Lutaml::Model::RuntimeCompatibility).to receive(:opal?).and_return(true)
+    end
+
+    it "uses the MutexHashCache by default on Opal" do
+      expect(resolver.cache_backend).to be_a(described_class::MutexHashCache)
+    end
+
+    it "does not autoload the native ConcurrentMapCache on Opal" do
+      hide_const("Lutaml::Model::CachedTypeResolver::ConcurrentMapCache")
+
+      load File.expand_path("../../../lib/lutaml/model/cached_type_resolver.rb", __dir__)
+
+      expect(described_class.autoload?(:ConcurrentMapCache)).to be_nil
+    end
+
+    it "caches resolved types without Concurrent::Map" do
+      resolver.resolve(:custom, context)
+      registry.clear
+
+      expect(resolver.resolve(:custom, context)).to eq(custom_class)
+      expect(resolver.cache_stats[:keys]).to eq([%i[test custom]])
+    end
+
+    it "clears the Opal cache" do
+      resolver.resolve(:custom, context)
+
+      resolver.clear_all_caches
+
+      expect(resolver.cache_stats[:size]).to eq(0)
     end
   end
 end

--- a/spec/lutaml/model/json_spec.rb
+++ b/spec/lutaml/model/json_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "lutaml/json"
+
+RSpec.describe Lutaml::Model::Json do
+  describe "standalone loading" do
+    let(:lib_path) { File.expand_path("../../../lib", __dir__) }
+
+    it "loads require 'lutaml/json' without preloading lutaml/model" do
+      # rubocop:disable Style/CommandLiteral
+      result = `#{RbConfig.ruby} -I#{lib_path} -e 'require "lutaml/json"; puts :ok' 2>&1`
+      # rubocop:enable Style/CommandLiteral
+
+      expect($?.success?).to be(true), result
+      expect(result).to include("ok")
+    end
+  end
+
+  describe "adapter autoloading" do
+    it "does not autoload native JSON adapters on Opal" do
+      %i[OjAdapter MultiJsonAdapter].each do |constant_name|
+        hide_const("Lutaml::Json::Adapter::#{constant_name}")
+      end
+
+      allow(Lutaml::Model::RuntimeCompatibility).to receive(:opal?).and_return(true)
+      load File.expand_path("../../../lib/lutaml/json/adapter.rb", __dir__)
+
+      expect(Lutaml::Json::Adapter.autoload?(:OjAdapter)).to be_nil
+      expect(Lutaml::Json::Adapter.autoload?(:MultiJsonAdapter)).to be_nil
+    end
+  end
+end

--- a/spec/lutaml/model/runtime_compatibility_spec.rb
+++ b/spec/lutaml/model/runtime_compatibility_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Lutaml::Model::RuntimeCompatibility do
+  describe ".opal?" do
+    it "memoizes false results on native Ruby" do
+      skip "native-only memoization example" if RUBY_ENGINE == "opal"
+
+      described_class.remove_instance_variable(:@opal) if described_class.instance_variable_defined?(:@opal)
+
+      expect(described_class.opal?).to be(false)
+      expect(described_class.instance_variable_defined?(:@opal)).to be(true)
+      expect(described_class.instance_variable_get(:@opal)).to be(false)
+    end
+  end
+
+  describe ".safe_constantize" do
+    it "returns nil when the top-level constant is missing" do
+      expect(described_class.safe_constantize("MissingTopLevel::Error")).to be_nil
+    end
+
+    it "matches Ruby constant lookup through inherited namespaces" do
+      parent = Class.new
+      error_class = Class.new(StandardError)
+      parent.const_set(:InheritedError, error_class)
+      child = Class.new(parent)
+
+      stub_const("RuntimeCompatibilityParent", parent)
+      stub_const("RuntimeCompatibilityChild", child)
+
+      expect(described_class.safe_constantize("RuntimeCompatibilityChild::InheritedError"))
+        .to eq(error_class)
+    end
+  end
+end

--- a/spec/lutaml/model/toml_spec.rb
+++ b/spec/lutaml/model/toml_spec.rb
@@ -4,6 +4,24 @@ require "spec_helper"
 require "lutaml/model/toml"
 
 RSpec.describe Lutaml::Model::Toml do
+  describe "format registration" do
+    it "does not eagerly register a native TOML adapter class" do
+      expect(Lutaml::Model::FormatRegistry.info(:toml)[:adapter_class]).to be_nil
+    end
+
+    it "does not autoload native TOML adapters on Opal" do
+      %i[TomlRbAdapter TomlibAdapter].each do |constant_name|
+        hide_const("Lutaml::Toml::Adapter::#{constant_name}")
+      end
+
+      allow(Lutaml::Model::RuntimeCompatibility).to receive(:opal?).and_return(true)
+      load File.expand_path("../../../lib/lutaml/toml/adapter.rb", __dir__)
+
+      expect(Lutaml::Toml::Adapter.autoload?(:TomlRbAdapter)).to be_nil
+      expect(Lutaml::Toml::Adapter.autoload?(:TomlibAdapter)).to be_nil
+    end
+  end
+
   describe ".detect_toml_adapter" do
     before do
       # Hide any existing constants first
@@ -42,6 +60,16 @@ RSpec.describe Lutaml::Model::Toml do
     end
 
     context "when neither adapter is available" do
+      it "returns nil" do
+        expect(described_class.detect_toml_adapter).to be_nil
+      end
+    end
+
+    context "when running on Opal" do
+      before do
+        allow(Lutaml::Model::RuntimeCompatibility).to receive(:opal?).and_return(true)
+      end
+
       it "returns nil" do
         expect(described_class.detect_toml_adapter).to be_nil
       end

--- a/spec/lutaml/xml/builder/builder_spec.rb
+++ b/spec/lutaml/xml/builder/builder_spec.rb
@@ -190,6 +190,24 @@ RSpec.describe "XML Builder consistency" do
 
   describe Lutaml::Xml::Builder::Oga do
     it_behaves_like "a consistent XML builder"
+
+    it "defaults namespace validation to lenient under Opal" do
+      allow(Lutaml::Model::RuntimeCompatibility).to receive(:opal?)
+        .and_return(true)
+
+      builder = described_class.build do |xml|
+        xml.create_and_add_element(
+          "root",
+          attributes: {
+            "xmlns" => "-//OASIS//DTD XML Exchange Table Model 19990315//EN",
+          },
+        )
+      end
+
+      expect(builder.to_xml).to include(
+        'xmlns="-//OASIS//DTD XML Exchange Table Model 19990315//EN"',
+      )
+    end
   end
 
   describe Lutaml::Xml::Builder::Rexml do

--- a/spec/lutaml/xml/element_spec.rb
+++ b/spec/lutaml/xml/element_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Lutaml::Xml::Element do
+  it "does not treat regular element names as text content" do
+    element = described_class.new("Element", "paragraph")
+
+    expect(element).to be_element
+    expect(element.element_tag).to eq("paragraph")
+    expect(element.text_content).to be_nil
+  end
+
+  it "keeps legacy text nodes readable as text content" do
+    element = described_class.new("Text", "content")
+
+    expect(element).to be_text
+    expect(element.text_content).to eq("content")
+  end
+
+  it "keeps legacy CDATA nodes readable as text content" do
+    element = described_class.new("Text", "#cdata-section",
+                                  text_content: "content")
+
+    expect(element).to be_cdata
+    expect(element.text_content).to eq("content")
+  end
+end

--- a/spec/lutaml/xml/transformation/custom_method_wrapper_spec.rb
+++ b/spec/lutaml/xml/transformation/custom_method_wrapper_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "lutaml/xml"
+
+RSpec.describe Lutaml::Xml::CustomMethodWrapper do
+  describe "#add_element" do
+    it "parses XML fragments through Moxml when Opal is active" do
+      parent = Lutaml::Xml::DataModel::XmlElement.new("parent")
+      wrapper = described_class.new(parent, nil)
+
+      allow(Lutaml::Model::RuntimeCompatibility).to receive(:opal?)
+        .and_return(true)
+
+      wrapper.add_element(
+        parent,
+        "<a title=\"copyright\">one</a><b>two</b>",
+      )
+
+      expect(parent.raw_content).to be_nil
+      expect(parent.children.map(&:name)).to eq(%w[a b])
+      expect(parent.children[0].attributes.first.value).to eq("copyright")
+      expect(parent.children[0].text_content).to eq("one")
+      expect(parent.children[1].text_content).to eq("two")
+    end
+  end
+
+  describe "RuleApplier integration" do
+    it "loads the wrapper through the public XML autoload path" do
+      parent = Lutaml::Xml::DataModel::XmlElement.new("parent")
+      model_class = Class.new do
+        def custom_to_xml(_model, parent, wrapper)
+          wrapper.add_text(parent, "ok")
+        end
+      end
+      rule = Struct.new(:custom_methods).new({ to: :custom_to_xml })
+      applier = Class.new do
+        include Lutaml::Xml::TransformationSupport::RuleApplier
+
+        public :apply_custom_method
+      end.new
+
+      applier.apply_custom_method(parent, rule, model_class, Object.new)
+
+      expect(parent.text_content).to eq("ok")
+    end
+  end
+end

--- a/spec/lutaml/xml/xml_spec.rb
+++ b/spec/lutaml/xml/xml_spec.rb
@@ -4,6 +4,61 @@ require "spec_helper"
 require "lutaml/xml"
 
 RSpec.describe Lutaml::Xml do
+  describe "standalone loading" do
+    let(:lib_path) { File.expand_path("../../../lib", __dir__) }
+
+    it "lazy-loads the schema namespace from the XML entry point" do
+      # rubocop:disable Style/CommandLiteral
+      result = `#{RbConfig.ruby} -I#{lib_path} -e 'require "lutaml/xml"; abort "missing Schema autoload" unless Lutaml::Xml.autoload?(:Schema); abort "missing Xsd autoload" unless Lutaml::Xml::Schema.const_defined?(:Xsd, false); puts :ok' 2>&1`
+      # rubocop:enable Style/CommandLiteral
+
+      expect($?.success?).to be(true), result
+      expect(result).to include("ok")
+    end
+  end
+
+  describe "schema autoloads" do
+    it "matches native-only schema autoload availability" do
+      expect(described_class::Schema.const_defined?(:Xsd, false))
+        .to be(!Lutaml::Model::RuntimeCompatibility.opal?)
+    end
+  end
+
+  describe "schema methods" do
+    before do
+      allow(Lutaml::Model::RuntimeCompatibility).to receive(:opal?)
+        .and_return(true)
+    end
+
+    it "raises NotImplementedError for XSD generation under Opal" do
+      expect do
+        Lutaml::Model::Schema.to_xsd(Object)
+      end.to raise_error(
+        NotImplementedError,
+        "XSD schema generation is not available under Opal.",
+      )
+    end
+
+    it "raises NotImplementedError for RELAX NG generation under Opal" do
+      expect do
+        Lutaml::Model::Schema.to_relaxng(Object)
+      end.to raise_error(
+        NotImplementedError,
+        "RELAX NG schema generation requires Nokogiri, " \
+        "which is not available under Opal.",
+      )
+    end
+
+    it "raises NotImplementedError for XML schema compilation under Opal" do
+      expect do
+        Lutaml::Model::Schema.from_xml("<schema/>")
+      end.to raise_error(
+        NotImplementedError,
+        "XML schema compilation is not available under Opal.",
+      )
+    end
+  end
+
   describe ".detect_xml_adapter" do
     before do
       # Hide any existing constants first


### PR DESCRIPTION
## Summary

Adds runtime compatibility handling so adapter, schema, and XML serialization loading work correctly under Opal.

## Changes

- Adds shared runtime helpers for Opal/native checks, native-only requires/autoloads, and safe constant lookup.
- Uses Opal-safe load paths for key-value and XML adapters.
- Avoids native-only TOML adapter defaults in Opal.
- Ensures XML serialization/import methods are applied directly to `Serializable` under Opal.
- Keeps Nokogiri-specific entity handling limited to native XML parsing paths.
