### PR TITLE
fix: prevent enum shorthand methods from shadowing separate attributes

### DIFF
--- a/lib/lutaml/model/serialize/attribute_definition.rb
+++ b/lib/lutaml/model/serialize/attribute_definition.rb
@@ -130,7 +130,9 @@ module Lutaml
             end
           end
 
-          unless method_defined?(:"#{name}=", false)
+          enum_shorthand_names = instance_variable_get(:@__enum_shorthand_names__) || Set.new
+          unless method_defined?(:"#{name}=",
+                                 false) && !enum_shorthand_names.include?(name.to_s)
             if attr.collection?
               define_method(:"#{name}=") do |value|
                 value_set_for(name)

--- a/lib/lutaml/model/serialize/enum_handling.rb
+++ b/lib/lutaml/model/serialize/enum_handling.rb
@@ -32,6 +32,15 @@ module Lutaml
               end
             end
 
+            # Record value name so regular attribute definitions can
+            # override these shorthand methods when an attribute shares
+            # the same name as an enum value (e.g. attribute :char with
+            # align values including "char").
+            enum_shorthand_names = klass.instance_variable_get(:@__enum_shorthand_names__) || Set.new
+            enum_shorthand_names << value.to_s
+            klass.instance_variable_set(:@__enum_shorthand_names__,
+                                        enum_shorthand_names)
+
             Utils.add_method_if_not_defined(klass, value.to_s) do
               public_send(:"#{value}?")
             end

--- a/spec/lutaml/model/enum_spec.rb
+++ b/spec/lutaml/model/enum_spec.rb
@@ -8,6 +8,17 @@ module EnumSpec
     attribute :multi_value, :string, values: %w[singular dual plural],
                                      collection: true, initialize_empty: true
   end
+
+  class WithCollision < Lutaml::Model::Serializable
+    attribute :align, :string, values: %w[left right center justify char]
+    attribute :char, :string
+
+    xml do
+      root "test"
+      map_attribute "align", to: :align
+      map_attribute "char", to: :char
+    end
+  end
 end
 
 RSpec.describe "Enum" do
@@ -162,6 +173,38 @@ RSpec.describe "Enum" do
   context "when values are not provided for an attribute" do
     it "is not marked as enum" do
       expect(without_enum_attr.enum?).to be(false)
+    end
+  end
+
+  context "when enum value name collides with a separate attribute name" do
+    let(:collision_class) do
+      EnumSpec::WithCollision
+    end
+
+    it "does not shadow the separate attribute getter" do
+      obj = collision_class.new(align: "center", char: ".")
+      expect(obj.char).to eq(".")
+    end
+
+    it "does not shadow the separate attribute setter" do
+      obj = collision_class.new
+      obj.char = "."
+      expect(obj.char).to eq(".")
+      expect(obj.align).to be_nil
+    end
+
+    it "preserves enum shorthand methods for non-colliding values" do
+      obj = collision_class.new
+      obj.center = true
+      expect(obj.center?).to be(true)
+      expect(obj.align).to eq("center")
+    end
+
+    it "parses both attributes correctly from XML" do
+      xml = '<test align="center" char="."/>'
+      obj = collision_class.from_xml(xml)
+      expect(obj.align).to eq("center")
+      expect(obj.char).to eq(".")
     end
   end
 end


### PR DESCRIPTION
When an enum attribute has a value that matches another attribute name (e.g. `attribute :align, :string, values: %w[... char]` alongside `attribute :char, :string`), the enum shorthand getter/setter methods would shadow the separate attribute setter, causing `char = "."` to set `@align` to `["char"]` instead of `@char` to `".".

**Root cause:** `add_enum_methods_to_model` creates convenience methods for each enum value string. The regular attribute definition setter guard (`unless method_defined?`) then skips creating the proper setter because the enum shorthand already defined one.

**Fix:** Track enum shorthand method names in `@__enum_shorthand_names__` and allow regular attribute definitions to override them.

All 4125 specs pass, rubocop clean.