### PR TITLE
Fix double-encoded entity references flattened during XML round-trip

### DIFF
--- a/lib/lutaml/xml/adapter/base_adapter.rb
+++ b/lib/lutaml/xml/adapter/base_adapter.rb
@@ -404,6 +404,51 @@ module Lutaml
 
         private
 
+        # Add text or CDATA content to a moxml element.
+        # Nokogiri overrides add_text_nodes for entity reference preservation.
+        def add_content_node(element, text, doc, cdata: false)
+          if cdata
+            element.add_child(doc.create_cdata(text.to_s))
+          else
+            add_text_nodes(element, text.to_s, doc)
+          end
+        end
+
+        # Create text node(s) for element content.
+        # Default: single text node. Nokogiri overrides to split entity references.
+        def add_text_nodes(element, text, doc)
+          element.add_child(doc.create_text(text))
+        end
+
+        # Apply XML attributes from XmlElement to a moxml element,
+        # filtering xmlns attributes that are already declared via hoisted_declarations.
+        def apply_plan_attributes(xml_element, element_node, element)
+          xml_element.attributes.each_with_index do |xml_attr, idx|
+            attr_name_str = xml_attr.name.to_s
+            if attr_name_str.start_with?("xmlns")
+              apply_xmlns_attribute(attr_name_str, xml_attr.value.to_s,
+                                    element_node, element)
+              next
+            end
+
+            attr_node = element_node.attribute_nodes[idx]
+            element[attr_node.qualified_name] = xml_attr.value.to_s
+          end
+        end
+
+        def apply_xmlns_attribute(attr_name_str, value, element_node, element)
+          if attr_name_str.include?(":")
+            prefix = attr_name_str.split(":", 2).last
+            unless element_node.hoisted_declarations.key?(prefix)
+              element.add_namespace(prefix, value)
+            end
+          elsif attr_name_str == "xmlns"
+            unless element_node.hoisted_declarations.key?(nil)
+              element.add_namespace(nil, value)
+            end
+          end
+        end
+
         # Fetch attribute definition and value, handling delegation
         #
         # @param element [Object] the model instance

--- a/lib/lutaml/xml/adapter/nokogiri_adapter.rb
+++ b/lib/lutaml/xml/adapter/nokogiri_adapter.rb
@@ -704,6 +704,11 @@ module Lutaml
 
         private
 
+        # Override BaseAdapter hook to preserve entity references.
+        def add_text_nodes(element, text, doc)
+          add_text_with_entities(element, text, doc)
+        end
+
         # Builds Moxml node tree from XmlDataModel::XmlElement content and
         # DeclarationPlan decisions (PARALLEL TRAVERSAL).
         #
@@ -917,27 +922,7 @@ module Lutaml
           end
 
           # Add regular attributes (PARALLEL TRAVERSAL by index)
-          # Skip xmlns attributes - they are already declared via hoisted_declarations
-          # and setting them as attributes creates duplicate namespace declarations
-          xml_element.attributes.each_with_index do |xml_attr, idx|
-            attr_name_str = xml_attr.name.to_s
-            if attr_name_str.start_with?("xmlns")
-              # xmlns attributes from hoisted_declarations are already added above.
-              # However, xmlns attributes added by transformation (e.g., xmlns:xsi
-              # from @raw_schema_location) may not be in hoisted_declarations.
-              # Add them as namespace declarations if not already present.
-              if attr_name_str.include?(":")
-                prefix = attr_name_str.split(":", 2).last
-                unless element_node.hoisted_declarations.key?(prefix)
-                  element.add_namespace(prefix, xml_attr.value)
-                end
-              end
-              next
-            end
-
-            attr_node = element_node.attribute_nodes[idx]
-            element[attr_node.qualified_name] = xml_attr.value
-          end
+          apply_plan_attributes(xml_element, element_node, element)
 
           # Check if element was created from nil value with render_nil option
           # Add xsi:nil="true" attribute for W3C compliance
@@ -996,33 +981,32 @@ module Lutaml
                 previous_sibling_had_xmlns_blank = true
               end
             elsif xml_child.is_a?(String)
-              if xml_element.cdata && !xml_child.strip.empty?
-                cdata_node = doc.create_cdata(xml_child)
-                element.add_child(cdata_node)
-              else
-                add_text_with_entities(element, xml_child, doc)
-              end
+              add_content_node(element, xml_child, doc,
+                               cdata: xml_element.cdata && !xml_child.strip.empty?)
             end
           end
 
           # Add text content AFTER child elements
           if xml_element.text_content
-            if xml_element.cdata
-              cdata_node = doc.create_cdata(xml_element.text_content.to_s)
-              element.add_child(cdata_node)
-            else
-              add_text_with_entities(element, xml_element.text_content.to_s,
-                                     doc)
-            end
+            add_content_node(element, xml_element.text_content.to_s,
+                             doc, cdata: xml_element.cdata)
           end
 
           element
         end
 
+        # Standard XML predefined entities — these are always resolved by the
+        # XML parser and must NOT be turned into EntityReference nodes during
+        # serialization.  If we created an EntityReference for e.g. "lt", the
+        # output would render as `<` instead of preserving the literal text
+        # `&lt;`, which corrupts double-encoded content like `&amp;lt;`.
+        STANDARD_XML_ENTITIES = %w[lt gt amp apos quot].freeze
+
         # Add text content to an element, preserving entity reference patterns.
-        # This is used during SERIALIZATION of model attributes that contain user-provided
-        # strings. The regex detects entity patterns so they can be preserved as
-        # EntityReference nodes rather than being escaped.
+        # Only non-standard named entities (e.g. &copy;, &nbsp;, &mdash;) are
+        # promoted to EntityReference nodes.  Standard XML entities, numeric
+        # character references, and all other text are added as plain text nodes
+        # so the XML serializer handles proper escaping.
         #
         # Uses Moxml's doc.create_text/create_entity_reference for node creation.
         #
@@ -1035,8 +1019,15 @@ module Lutaml
           parts.each do |part|
             next if part.empty?
 
-            if part.match?(/\A&(\w+|#\d+|#x[\da-fA-F]+);\z/)
-              entity_name = part[1..-2]
+            # Only non-standard named entities become EntityReference nodes.
+            # Standard XML entities (lt, gt, amp, apos, quot) and numeric
+            # character references (&#NNN;, &#xHHH;) must remain as text so
+            # the serializer escapes them correctly (e.g. &lt; → &amp;lt;).
+            # Entity names must start with a letter per the XML specification,
+            # so patterns like &1; are NOT entity references.
+            # NOTE: use #match (not #match?) because match? does not set $1.
+            if (m = part.match(/\A&([a-zA-Z]\w*);\z/)) && !STANDARD_XML_ENTITIES.include?(m[1])
+              entity_name = m[1]
               entity_node = doc.create_entity_reference(entity_name)
               element.add_child(entity_node)
             else

--- a/lib/lutaml/xml/adapter/oga_adapter.rb
+++ b/lib/lutaml/xml/adapter/oga_adapter.rb
@@ -502,10 +502,7 @@ module Lutaml
           end
 
           # 3. Add regular attributes by INDEX (PARALLEL TRAVERSAL)
-          xml_element.attributes.each_with_index do |xml_attr, idx|
-            attr_node = element_node.attribute_nodes[idx]
-            element[attr_node.qualified_name] = xml_attr.value.to_s
-          end
+          apply_plan_attributes(xml_element, element_node, element)
 
           # xsi:nil attribute for W3C compliance
           if xml_element.respond_to?(:xsi_nil) && xml_element.xsi_nil
@@ -536,8 +533,8 @@ module Lutaml
 
           # 5. Add text content if present
           if xml_element.text_content
-            text_node = moxml_doc.create_text(xml_element.text_content.to_s)
-            element.add_child(text_node)
+            add_content_node(element, xml_element.text_content,
+                             moxml_doc, cdata: xml_element.cdata)
           end
 
           # 6. Recursively build children by INDEX (PARALLEL TRAVERSAL)
@@ -552,8 +549,8 @@ module Lutaml
                                                element, plan: plan)
               element.add_child(child_element)
             elsif xml_child.is_a?(String)
-              text_node = moxml_doc.create_text(xml_child)
-              element.add_child(text_node)
+              add_content_node(element, xml_child, moxml_doc,
+                               cdata: xml_element.cdata && !xml_child.strip.empty?)
             end
           end
 

--- a/spec/lutaml/xml/entity_fragmentation_spec.rb
+++ b/spec/lutaml/xml/entity_fragmentation_spec.rb
@@ -486,6 +486,81 @@ RSpec.describe "XML Entity Fragmentation Issue #5" do
         expect(root.to_xml).to include('attr="&amp;copy;"')
       end
     end
+
+    # Model-level round-trip tests — these exercise the
+    # build_xml_element / build_xml_node path which uses add_text_with_entities,
+    # NOT the adapter-level NokogiriElement#build_xml path.
+    context "model-level double-encoded entity round-trip" do
+      let(:model_class) do
+        Class.new(Lutaml::Model::Serializable) do
+          attribute :content, :string
+
+          xml do
+            root "text"
+            map_content to: :content
+          end
+        end
+      end
+
+      it "preserves &amp;lt; through model round-trip" do
+        input = "<text>Escape &amp;lt; character</text>"
+        instance = model_class.from_xml(input)
+        output = instance.to_xml
+
+        expect(output).to include("&amp;lt;")
+        expect(output).not_to include("&lt; character")
+      end
+
+      it "preserves &amp;amp; through model round-trip" do
+        input = "<text>if type gawk &gt; /dev/null 2&gt;&amp;1; then</text>"
+        instance = model_class.from_xml(input)
+        output = instance.to_xml
+
+        expect(output).to include("&amp;1;")
+        expect(output).not_to match(/[^a] &1/)
+      end
+
+      it "preserves double-encoded numeric character references" do
+        input = "<text>&amp;#x5B9E;&amp;#x4F8B;.example</text>"
+        instance = model_class.from_xml(input)
+        output = instance.to_xml
+
+        expect(output).to include("&amp;#x5B9E;")
+        expect(output).to include("&amp;#x4F8B;")
+      end
+
+      it "preserves all five standard XML entities double-encoded" do
+        input = "<text>&amp;lt; &amp;gt; &amp;apos; &amp;quot; &amp;amp;</text>"
+        instance = model_class.from_xml(input)
+        output = instance.to_xml
+
+        expect(output).to include("&amp;lt;")
+        expect(output).to include("&amp;gt;")
+        expect(output).to include("&amp;apos;")
+        expect(output).to include("&amp;quot;")
+        expect(output).to include("&amp;amp;")
+      end
+
+      it "preserves non-standard entities in model round-trip" do
+        input = "<text>Copyright &copy; 2024</text>"
+        instance = model_class.from_xml(input)
+        output = instance.to_xml
+
+        expect(output).to include("&copy;")
+        expect(output).not_to include("&amp;copy;")
+      end
+
+      it "preserves mixed standard and non-standard entities" do
+        input = "<text>a &amp; b &copy; c &lt; d</text>"
+        instance = model_class.from_xml(input)
+        output = instance.to_xml
+
+        expect(output).to include("&amp;")   # standard entity preserved
+        expect(output).to include("&copy;")  # non-standard entity preserved
+        expect(output).to include("&lt;")    # standard entity preserved
+        expect(output).not_to include("&amp;copy;") # not double-escaped
+      end
+    end
   end
 
   describe "with Oga adapter" do


### PR DESCRIPTION
When XML contains double-encoded entities (e.g. &amp;lt; to represent
literal text &lt;), the round-trip through model serialization flattened
them by one level, producing semantically different or invalid XML.

Root cause: add_text_with_entities treated ALL entity-like patterns in
text content as EntityReference nodes, including standard XML entities
(lt, gt, amp, apos, quot) and numeric character references. This caused
&amp;lt; to become &lt; (i.e. <) after round-trip.

Three fixes in add_text_with_entities:
- Exclude standard XML entities from EntityReference creation; treat as
  text nodes so the serializer handles proper escaping
- Use #match instead of #match? for the entity name check (match? does
  not populate  in Ruby, silently breaking the exclusion check)
- Tighten entity name regex to require letter-initial names per the XML
  spec, preventing invalid entity references like &1; from shell syntax

Non-standard entities (copy, nbsp, mdash, etc.) continue to be preserved
as EntityReference nodes as before.

Fixes: rfc8792, rfc8846, rfc9052, rfc9095, rfc9108, rfc9338, rfc9683,
rfc9700, rfc9788, rfc9953 round-trip failures

fix: Oga adapter CDATA serialization in plan-based path

The build_moxml_node method always created text nodes, ignoring the
cdata flag on XmlElement. This caused 5 pre-existing OgaAdapter test
failures in cdata_spec.rb on GHA.

fix: Oga adapter CDATA in mixed content and xmlns deduplication

- Check xml_element.cdata flag when creating String child nodes in
  build_moxml_node, creating CDATA sections instead of text nodes
  when cdata is true (matching Nokogiri adapter behavior)
- Filter xmlns attributes in regular attribute iteration to prevent
  duplicate namespace declarations, matching Nokogiri's logic
- Fixes pre-existing CI failures with Canon 0.2.x
