### PR TITLE
fix: use __dir__ for caller location detection in warn_name_conflict

### DIFF
--- a/lib/lutaml/model/attribute.rb
+++ b/lib/lutaml/model/attribute.rb
@@ -775,9 +775,9 @@ instance_object = nil)
       def warn_name_conflict(name)
         # Find the first caller location outside the lutaml-model gem's lib directory
         # This ensures we report the user's code line, not internal gem code
-        gem_lib_pattern = %r{/lutaml-model.*/lib/}
+        gem_lib_dir = File.expand_path("../..", __dir__)
         location = caller_locations.find do |cl|
-          !gem_lib_pattern.match?(cl.path)
+          !cl.absolute_path.to_s.start_with?(gem_lib_dir)
         end
 
         Logger.warn(


### PR DESCRIPTION
## Problem

The `warn_name_conflict` method in `Attribute` used a regex pattern `/lutaml-model.*\/lib\//` to filter internal gem paths from `caller_locations`. This broke when the gem was loaded from a non-standard path — e.g., moxml's dependent test CI clones lutaml-model into `/dependent/`, which has no `lutaml-model` in the path.

This caused moxml's dependent-gems-test CI to fail on all platforms (see lutaml/moxml#202).

## Fix

Replace the regex with `File.expand_path("../..", __dir__)` to resolve the actual `lib/` directory from the source file location. Use `absolute_path.start_with?` for matching instead of regex.

This also fixes a subtle bug where the old gem-root-level pattern (`File.expand_path("../../..", __dir__)`) would incorrectly match `spec/` and other non-lib directories under the gem root.

## Test

```
bundle exec rspec spec/lutaml/model/attribute_spec.rb -e "validate_name"
# 153 examples, 0 failures
```