### PR TITLE
fix: strip whitespace from schemaLocation values before resolution

### DIFF
--- a/lib/lutaml/xml/schema/xsd/schema_path.rb
+++ b/lib/lutaml/xml/schema/xsd/schema_path.rb
@@ -34,6 +34,9 @@ module Lutaml
           def include_schema(schema_location)
             return unless schema_location
 
+            schema_location = schema_location.strip
+            return if schema_location.empty?
+
             resolved_location = resolve_schema_location(schema_location)
             if absolute_path?(resolved_location)
               return read_absolute_path(
@@ -54,6 +57,9 @@ module Lutaml
           end
 
           def location_for(schema_location)
+            schema_location = schema_location&.strip
+            return nil if schema_location.nil? || schema_location.empty?
+
             resolved_location = resolve_schema_location(schema_location)
             return resolved_location if absolute_path?(resolved_location) || absolute_url?(resolved_location)
 

--- a/spec/lutaml/xml/schema/xsd/glob_spec.rb
+++ b/spec/lutaml/xml/schema/xsd/glob_spec.rb
@@ -194,6 +194,18 @@ RSpec.describe Lutaml::Xml::Schema::Xsd::Glob do
       end
     end
 
+    context "with whitespace in schemaLocation" do
+      it "strips leading/trailing whitespace from schema location" do
+        clean = described_class.include_schema("metaschema.xsd")
+        padded = described_class.include_schema("  metaschema.xsd  ")
+        expect(padded).to eq(clean)
+      end
+
+      it "handles whitespace-only schema location gracefully" do
+        expect(described_class.include_schema("   ")).to be_nil
+      end
+    end
+
     context "with regex pattern mapping" do
       before do
         # Use forward slashes for cross-platform compatibility in regex patterns


### PR DESCRIPTION
## Problem

When an `xs:include`/`xs:import` has a `schemaLocation` with leading/trailing whitespace, `SchemaPath#include_schema` passes the unstripped value to `File.exist?`, causing false 'file not found' errors.

Example: `<include schemaLocation="path/to/IE_Imagery.xsd "/>` — the trailing space makes `File.exist?` fail.

## Fix

Strip whitespace from `schema_location` in `include_schema` and `location_for`. Return `nil` for whitespace-only values.

## Testing

- Added 2 specs verifying whitespace-padded input resolves identically to clean input
- All 29 existing glob specs pass

Fixes #672