### PR TITLE
fix: remove unused openssl dependency

### DIFF
--- a/lutaml-model.gemspec
+++ b/lutaml-model.gemspec
@@ -37,7 +37,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "concurrent-ruby"
   spec.add_dependency "liquid", "~> 5.0"
   spec.add_dependency "moxml", ">= 0.1.16"
-  spec.add_dependency "openssl", "~> 3.0"
   spec.add_dependency "ostruct"
   spec.add_dependency "rubyzip", "~> 2.3"
   spec.add_dependency "thor"


### PR DESCRIPTION
openssl is a default gem bundled with Ruby. Listing it as an explicit dependency causes bundler to resolve a version (e.g. 3.3.2) from rubygems that conflicts with the version bundled with the Ruby installation (e.g. 3.3.1 in Ruby 3.4.9), breaking `bundle exec` with:

```
You have already activated openssl 3.3.1, but your Gemfile requires openssl 3.3.2.
Since openssl is a default gem, you can either remove your dependency on it
or try updating to a newer version of bundler that supports openssl as a default gem.
```

This dependency is not used anywhere in the codebase.

Fixes: release workflow failures in downstream gems (e.g. ukiryu).