### PR TITLE
chore: bump version to 0.8.4 for patch release

### DIFF
--- a/lib/lutaml/model/version.rb
+++ b/lib/lutaml/model/version.rb
@@ -2,6 +2,6 @@
 
 module Lutaml
   module Model
-    VERSION = "0.8.3"
+    VERSION = "0.8.4"
   end
 end


### PR DESCRIPTION
Version bump from 0.8.3 → 0.8.4 for the patch release containing the shared validation framework and performance optimizations from #678.