### PR TITLE
Fix Opal runtime autoload compatibility

### DIFF
--- a/lib/lutaml/xml/schema.rb
+++ b/lib/lutaml/xml/schema.rb
@@ -3,11 +3,14 @@
 module Lutaml
   module Xml
     module Schema
-      autoload :Xsd, "#{__dir__}/schema/xsd"
-      autoload :XsdSchema, "#{__dir__}/schema/xsd_schema"
-      autoload :RelaxngSchema, "#{__dir__}/schema/relaxng_schema"
-      autoload :Builder, "#{__dir__}/schema/builder"
-      autoload :BuiltinTypes, "#{__dir__}/schema/builtin_types"
+      Lutaml::Model::RuntimeCompatibility.autoload_native(
+        self,
+        Xsd: "#{__dir__}/schema/xsd",
+        XsdSchema: "#{__dir__}/schema/xsd_schema",
+        RelaxngSchema: "#{__dir__}/schema/relaxng_schema",
+        Builder: "#{__dir__}/schema/builder",
+        BuiltinTypes: "#{__dir__}/schema/builtin_types",
+      )
     end
   end
 end

--- a/lib/lutaml/xml/schema/xsd.rb
+++ b/lib/lutaml/xml/schema/xsd.rb
@@ -2,8 +2,8 @@
 
 # NOTE: Do NOT require lutaml/model here. This file is autoloaded via
 # Lutaml::Xml::Schema::Xsd, and requiring lutaml/model creates a circular
-# dependency since lutaml/xml.rb requires lutaml/model. The adapter type
-# is already set by lutaml/xml.rb at the end.
+# dependency since lutaml/xml.rb requires lutaml/model. This file only sets
+# a fallback XML adapter when no adapter has been selected yet.
 
 unless defined?(Lutaml::Model::Config.xml_adapter_type)
   Lutaml::Model::Config.xml_adapter_type = Lutaml::Model::AdapterResolver.detect_xml_adapter

--- a/lib/lutaml/xml/schema/xsd.rb
+++ b/lib/lutaml/xml/schema/xsd.rb
@@ -5,8 +5,9 @@
 # dependency since lutaml/xml.rb requires lutaml/model. The adapter type
 # is already set by lutaml/xml.rb at the end.
 
-adapter = RUBY_ENGINE == "opal" ? :oga : :nokogiri
-Lutaml::Model::Config.xml_adapter_type = adapter unless defined?(Lutaml::Model::Config.xml_adapter_type)
+unless defined?(Lutaml::Model::Config.xml_adapter_type)
+  Lutaml::Model::Config.xml_adapter_type = Lutaml::Model::AdapterResolver.detect_xml_adapter
+end
 
 # Require the XsdNamespace class for XSD schema support
 require_relative "xsd_namespace"

--- a/spec/lutaml/xml/xml_spec.rb
+++ b/spec/lutaml/xml/xml_spec.rb
@@ -1,18 +1,34 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "open3"
 require "lutaml/xml"
 
 RSpec.describe Lutaml::Xml do
+  let(:lib_path) { File.expand_path("../../../lib", __dir__) }
+
+  def run_ruby(script)
+    stdout, stderr, status = Open3.capture3(
+      RbConfig.ruby, "-I#{lib_path}", "-e", script
+    )
+
+    [stdout + stderr, status]
+  end
+
   describe "standalone loading" do
-    let(:lib_path) { File.expand_path("../../../lib", __dir__) }
-
     it "lazy-loads the schema namespace from the XML entry point" do
-      # rubocop:disable Style/CommandLiteral
-      result = `#{RbConfig.ruby} -I#{lib_path} -e 'require "lutaml/xml"; abort "missing Schema autoload" unless Lutaml::Xml.autoload?(:Schema); abort "missing Xsd autoload" unless Lutaml::Xml::Schema.const_defined?(:Xsd, false); puts :ok' 2>&1`
-      # rubocop:enable Style/CommandLiteral
+      script = <<~RUBY
+        require "lutaml/xml"
+        abort "missing Schema autoload" unless Lutaml::Xml.autoload?(:Schema)
+        unless Lutaml::Xml::Schema.const_defined?(:Xsd, false)
+          abort "missing Xsd autoload"
+        end
+        puts :ok
+      RUBY
 
-      expect($?.success?).to be(true), result
+      result, status = run_ruby(script)
+
+      expect(status.success?).to be(true), result
       expect(result).to include("ok")
     end
   end
@@ -21,6 +37,44 @@ RSpec.describe Lutaml::Xml do
     it "matches native-only schema autoload availability" do
       expect(described_class::Schema.const_defined?(:Xsd, false))
         .to be(!Lutaml::Model::RuntimeCompatibility.opal?)
+    end
+
+    it "does not autoload schema constants when loaded under Opal" do
+      script = <<~'RUBY'
+        require "lutaml/model/runtime_compatibility"
+
+        module Lutaml
+          module Model
+            module RuntimeCompatibility
+              def self.opal?
+                true
+              end
+            end
+          end
+        end
+
+        require "lutaml/xml/schema"
+
+        schema_constants = %i[
+          Xsd XsdSchema RelaxngSchema Builder BuiltinTypes
+        ]
+
+        loaded_constants = schema_constants.select do |constant_name|
+          Lutaml::Xml::Schema.autoload?(constant_name) ||
+            Lutaml::Xml::Schema.const_defined?(constant_name, false)
+        end
+
+        if loaded_constants.any?
+          abort "loaded schema constants: #{loaded_constants.join(', ')}"
+        end
+
+        puts :ok
+      RUBY
+
+      result, status = run_ruby(script)
+
+      expect(status.success?).to be(true), result
+      expect(result).to include("ok")
     end
   end
 


### PR DESCRIPTION
Fixes runtime compatibility issues when lutaml-model is loaded through Opal-generated bundles.

This updates the loader/autoload path needed by downstream consumers such as OMML and plurimath-js, where direct MRI loading behavior does not match the bundled Opal runtime.
