### PR TITLE
spec: add default-namespace case for target_namespace_prefix

### DIFF
--- a/spec/lutaml/xml/schema/xsd/schema_mapping_spec.rb
+++ b/spec/lutaml/xml/schema/xsd/schema_mapping_spec.rb
@@ -32,6 +32,21 @@ RSpec.describe "Schema mapping integration" do
       expect(parsed.target_namespace_prefix).to eq("t")
       expect(parsed.element.first.target_prefix).to eq("t")
     end
+
+    it "captures nil prefix when target namespace is the default (unprefixed)" do
+      xsd_default_ns = <<~XSD
+        <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                   xmlns="http://example.com/default"
+                   targetNamespace="http://example.com/default">
+          <xs:element name="Root" type="xs:string"/>
+        </xs:schema>
+      XSD
+
+      parsed = Lutaml::Xml::Schema::Xsd.parse(xsd_default_ns)
+
+      expect(parsed.target_namespace).to eq("http://example.com/default")
+      expect(parsed.target_namespace_prefix).to be_nil
+    end
   end
 
   describe "parsing with exact string mappings" do


### PR DESCRIPTION
## Summary

Adds a missing edge case spec for the XSD `target_namespace_prefix` parsing fixed in `ded58ab`.

### What this tests

The existing spec only covers the prefixed case (`xmlns:t="http://example.com/test"`). This adds coverage for the default (unprefixed) namespace case where `target_namespace_prefix` should be nil.

### Why it matters

Before the fix in v0.8.7, `target_namespace_prefix` was **always nil** due to `custom_args[:namespaces]` never being populated by the mapping framework. The prefixed-namespace spec proves the fix works; this spec proves the nil case is intentional and correct — not a silent failure.