### PR TITLE
refactor: consolidate deep_dup in Mapping base class (OCP)

### DIFF
--- a/lib/lutaml/hash_format/adapter/mapping.rb
+++ b/lib/lutaml/hash_format/adapter/mapping.rb
@@ -8,10 +8,8 @@ module Lutaml
           super(:hash)
         end
 
-        def deep_dup
-          self.class.new.tap do |new_mapping|
-            new_mapping.mappings = duplicate_mappings
-          end
+        def dup_instance
+          self.class.new
         end
       end
     end

--- a/lib/lutaml/json/adapter/mapping.rb
+++ b/lib/lutaml/json/adapter/mapping.rb
@@ -8,10 +8,8 @@ module Lutaml
           super(:json)
         end
 
-        def deep_dup
-          self.class.new.tap do |new_mapping|
-            new_mapping.mappings = duplicate_mappings
-          end
+        def dup_instance
+          self.class.new
         end
       end
     end

--- a/lib/lutaml/jsonl/adapter/mapping.rb
+++ b/lib/lutaml/jsonl/adapter/mapping.rb
@@ -8,10 +8,8 @@ module Lutaml
           super(:jsonl)
         end
 
-        def deep_dup
-          self.class.new.tap do |new_mapping|
-            new_mapping.mappings = duplicate_mappings
-          end
+        def dup_instance
+          self.class.new
         end
       end
     end

--- a/lib/lutaml/key_value/adapter/hash/mapping.rb
+++ b/lib/lutaml/key_value/adapter/hash/mapping.rb
@@ -7,10 +7,8 @@ module Lutaml
             super(:hash)
           end
 
-          def deep_dup
-            self.class.new.tap do |new_mapping|
-              new_mapping.mappings = duplicate_mappings
-            end
+          def dup_instance
+            self.class.new
           end
         end
       end

--- a/lib/lutaml/key_value/adapter/json/mapping.rb
+++ b/lib/lutaml/key_value/adapter/json/mapping.rb
@@ -12,10 +12,8 @@ module Lutaml
             super(:json)
           end
 
-          def deep_dup
-            self.class.new.tap do |new_mapping|
-              new_mapping.mappings = duplicate_mappings
-            end
+          def dup_instance
+            self.class.new
           end
         end
       end

--- a/lib/lutaml/key_value/adapter/jsonl/mapping.rb
+++ b/lib/lutaml/key_value/adapter/jsonl/mapping.rb
@@ -7,10 +7,8 @@ module Lutaml
             super(:jsonl)
           end
 
-          def deep_dup
-            self.class.new.tap do |new_mapping|
-              new_mapping.mappings = duplicate_mappings
-            end
+          def dup_instance
+            self.class.new
           end
         end
       end

--- a/lib/lutaml/key_value/adapter/toml/mapping.rb
+++ b/lib/lutaml/key_value/adapter/toml/mapping.rb
@@ -7,10 +7,8 @@ module Lutaml
             super(:toml)
           end
 
-          def deep_dup
-            self.class.new.tap do |new_mapping|
-              new_mapping.mappings = duplicate_mappings
-            end
+          def dup_instance
+            self.class.new
           end
 
           def validate!(key, to, with, render_nil, render_empty)

--- a/lib/lutaml/key_value/adapter/yaml/mapping.rb
+++ b/lib/lutaml/key_value/adapter/yaml/mapping.rb
@@ -7,10 +7,8 @@ module Lutaml
             super(:yaml)
           end
 
-          def deep_dup
-            self.class.new.tap do |new_mapping|
-              new_mapping.mappings = duplicate_mappings
-            end
+          def dup_instance
+            self.class.new
           end
         end
       end

--- a/lib/lutaml/key_value/adapter/yamls/mapping.rb
+++ b/lib/lutaml/key_value/adapter/yamls/mapping.rb
@@ -7,10 +7,8 @@ module Lutaml
             super(:yaml)
           end
 
-          def deep_dup
-            self.class.new.tap do |new_mapping|
-              new_mapping.mappings = duplicate_mappings
-            end
+          def dup_instance
+            self.class.new
           end
         end
       end

--- a/lib/lutaml/key_value/mapping.rb
+++ b/lib/lutaml/key_value/mapping.rb
@@ -218,17 +218,17 @@ module Lutaml
       end
 
       # Writers for deep_dup in subclasses
-      attr_writer :mappings, :register_mappings
+      attr_writer :register_mappings
 
       def deep_dup
-        self.class.new(@format).tap do |new_mapping|
+        dup_instance.tap do |new_mapping|
           new_mapping.mappings = duplicate_mappings
           new_mapping.register_mappings = Lutaml::Model::Utils.deep_dup(@register_mappings)
         end
       end
 
-      def duplicate_mappings
-        Lutaml::Model::Utils.deep_dup(@mappings)
+      def dup_instance
+        self.class.new(@format)
       end
 
       def find_by_to(to)

--- a/lib/lutaml/model/mapping/mapping.rb
+++ b/lib/lutaml/model/mapping/mapping.rb
@@ -3,12 +3,24 @@ module Lutaml
     class Mapping
       include DeepDupable
 
+      attr_writer :mappings
+
       def initialize
         @mappings = []
         @listeners = {} # target => [Listener, ...]
         @parent_mapping = nil
         @importable_mappings = []
         @mappings_imported = ::Hash.new { |h, k| h[k] = false }
+      end
+
+      def deep_dup
+        duped = self.class.new
+        duped.mappings = duplicate_mappings
+        duped
+      end
+
+      def duplicate_mappings
+        Lutaml::Model::Utils.deep_dup(@mappings)
       end
 
       # Get listeners for a specific target (element name/key).

--- a/lib/lutaml/toml/adapter/mapping.rb
+++ b/lib/lutaml/toml/adapter/mapping.rb
@@ -8,10 +8,8 @@ module Lutaml
           super(:toml)
         end
 
-        def deep_dup
-          self.class.new.tap do |new_mapping|
-            new_mapping.mappings = duplicate_mappings
-          end
+        def dup_instance
+          self.class.new
         end
 
         def validate!(key, to, with, render_nil, render_empty)

--- a/lib/lutaml/yaml/adapter/mapping.rb
+++ b/lib/lutaml/yaml/adapter/mapping.rb
@@ -8,10 +8,8 @@ module Lutaml
           super(:yaml)
         end
 
-        def deep_dup
-          self.class.new.tap do |new_mapping|
-            new_mapping.mappings = duplicate_mappings
-          end
+        def dup_instance
+          self.class.new
         end
       end
     end

--- a/lib/lutaml/yamls/adapter/mapping.rb
+++ b/lib/lutaml/yamls/adapter/mapping.rb
@@ -4,7 +4,7 @@ module Lutaml
   module Yamls
     module Adapter
       class Mapping < Lutaml::KeyValue::Mapping
-        attr_reader :yamls_sequence
+        attr_accessor :yamls_sequence
 
         def initialize
           super(:yaml)
@@ -15,9 +15,13 @@ module Lutaml
           @yamls_sequence.instance_eval(&)
         end
 
+        def dup_instance
+          self.class.new
+        end
+
         def deep_dup
-          self.class.new.tap do |new_mapping|
-            new_mapping.mappings = duplicate_mappings
+          super.tap do |new_mapping|
+            new_mapping.yamls_sequence = @yamls_sequence&.dup
           end
         end
       end


### PR DESCRIPTION
## Summary

Consolidates duplicate `deep_dup` implementations across the Mapping class hierarchy using the Open/Closed Principle.

### Changes

**Base `Lutaml::Model::Mapping`** — provides the contract:
- `deep_dup` — creates a new instance and duplicates `@mappings`
- `duplicate_mappings` — shared utility for deep-copying the mappings collection
- `attr_writer :mappings` — allows subclasses to set duplicated state

**`Lutaml::KeyValue::Mapping`** — extends for its extra state:
- Overrides `deep_dup` to also handle `@register_mappings`
- Extracts construction to `dup_instance` so adapter subclasses can override without reimplementing the full `deep_dup`

**12 adapter subclasses** (Json, Yaml, Toml, Jsonl, Yamls, Hash, plus backward-compat KeyValue::Adapter versions):
- Replaced identical `deep_dup` implementations with a single `dup_instance` override
- Inherit `deep_dup` and `duplicate_mappings` from `KeyValue::Mapping`

**`Yamls::Adapter::Mapping`** — only adapter with extra state (`@yamls_sequence`):
- Overrides `dup_instance` for construction
- Overrides `deep_dup` via `super` to add `@yamls_sequence` handling

**Unchanged**: `Xml::Mapping`, `Rdf::Mapping`, `Liquid::Mapping`, `ValueXmlMapping` — these have fundamentally different state/construction and already have appropriate `deep_dup` implementations.

### Testing
All 2789 specs pass with 0 failures.