### PR TITLE
refactor: XML serialization pipeline improvements and DSL terminology cleanup

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -336,7 +336,7 @@ class TermiumExtract < Lutaml::Model::Serializable
   attribute :extract_language, ExtractLanguage, collection: true
 
   xml do
-    root "termium_extract"
+    element "termium_extract"
     map_attribute "language", to: :language
     map_element "extractLanguage", to: :extract_language
   end
@@ -496,7 +496,7 @@ model, the `import_model_mappings` method can be used (see
 
 === Serialization and transformation
 
-Models can be serialized to various formats (XML, JSON, YAML, TOML) or 
+Models can be serialized to various formats (XML, JSON, YAML, TOML) or
 transformed to other representations like Hash objects.
 
 ==== Basic serialization
@@ -853,7 +853,7 @@ class Event < Lutaml::Model::Serializable
   attribute :start_date, :date
 
   xml do
-    root "event"
+    element "event"
     map_element "startDate", to: :start_date
   end
 
@@ -908,7 +908,7 @@ class ProcessingTask < Lutaml::Model::Serializable
   attribute :processing_time, :duration
 
   xml do
-    root "task"
+    element "task"
     map_element "processingTime", to: :processing_time
   end
 end
@@ -938,7 +938,7 @@ class Resource < Lutaml::Model::Serializable
   attribute :schema_location, :uri
 
   xml do
-    root "resource"
+    element "resource"
     map_element "homepage", to: :homepage
     map_attribute "schemaLocation", to: :schema_location
   end
@@ -973,7 +973,7 @@ class Reference < Lutaml::Model::Serializable
   attribute :target, :qname
 
   xml do
-    root "reference"
+    element "reference"
     map_attribute "type", to: :ref_type
     map_element "target", to: :target
   end
@@ -1011,7 +1011,7 @@ class Attachment < Lutaml::Model::Serializable
   attribute :filename, :string
 
   xml do
-    root "attachment"
+    element "attachment"
     map_element "content", to: :content
     map_attribute "filename", to: :filename
   end
@@ -1052,7 +1052,7 @@ class Checksum < Lutaml::Model::Serializable
   attribute :algorithm, :string
 
   xml do
-    root "checksum"
+    element "checksum"
     map_element "value", to: :hash_value
     map_attribute "algorithm", to: :algorithm
   end
@@ -1114,7 +1114,7 @@ class Task < Lutaml::Model::Serializable
   attribute :priority, :symbol
 
   xml do
-    root "task"
+    element "task"
     map_element "status", to: :status
     map_element "priority", to: :priority
   end
@@ -1359,7 +1359,7 @@ class Address < Lutaml::Model::Serializable
 
   # Define how this complex object maps to different formats
   xml do
-    root "Address"
+    element "Address"
     map_element "Street", to: :street
     map_element "City", to: :city
     map_element "PostalCode", to: :postal_code
@@ -2603,7 +2603,7 @@ class ReferenceSet < Lutaml::Model::Serializable
   ]
 
   xml do
-    root "ReferenceSet"
+    element "ReferenceSet"
 
     map_element "reference", to: :references, polymorphic: {
       # This refers to the attribute in the polymorphic model, you need
@@ -2740,7 +2740,7 @@ class SomeModel < Lutaml::Model::Serializable
   attribute :coll, :string, collection: true
 
   xml do
-    root "some-model"
+    element "some-model"
     map_element 'collection', to: :coll
   end
 
@@ -2904,7 +2904,8 @@ class Person < Lutaml::Model::Serializable
   end
 
   xml do
-    root "Person", mixed: true
+    element "Person"
+    mixed_content
     sequence do
       map_element :FirstName, to: :first_name
       map_element :LastName, to: :last_name
@@ -2961,8 +2962,9 @@ This feature works both with XML and key-value formats.
 
 * The import order determines how elements and attributes are overwritten.
 
-* An importable model with XML serialization mappings requires setting the model's
-XML serialization configuration with the `no_root` directive.
+* An importable model with XML serialization mappings is a "type-only model" —
+  it has no `element` declaration in its `xml` block, meaning it can only be
+  used as an embedded type through a parent model.
 
 The model can be imported into another model using the following directives:
 
@@ -2972,11 +2974,11 @@ The model can be imported into another model using the following directives:
 
 `import_model_mappings`:: imports only mappings.
 
-NOTE: Models with `no_root` can only be parsed through parent models.
-Direct calling `NoRootModel.from_xml` will raise a `NoRootMappingError`.
+NOTE: Type-only models (no `element` declaration) can only be parsed through parent models.
+Directly calling `TypeOnlyModel.from_xml` will raise a `TypeOnlyMappingError`.
 
 NOTE: Namespaces are not currently supported in importable models.
-If `namespace` is defined with `no_root`, `NoRootNamespaceError` will be raised.
+If `namespace` is defined with the deprecated `no_root`, `TypeOnlyNamespaceError` will be raised.
 
 .Importing model components using an importable model
 [example]
@@ -2998,7 +3000,7 @@ class GroupOfItems < Lutaml::Model::Serializable
   attribute :code, :string
 
   xml do
-    no_root
+    # Type-only model - no element declaration needed
     sequence do
       map_element "name", to: :name
       map_element "type", to: :type
@@ -3014,7 +3016,7 @@ class ComplexType < Lutaml::Model::Serializable
   import_model_attributes GroupOfItems
 
   xml do
-    root "GroupOfItems"
+    element "GroupOfItems"
 
     map_attribute "tag", to: :tag
     map_content to: :content
@@ -3043,7 +3045,7 @@ end
 [source,ruby]
 ----
 > parsed = GroupOfItems.from_xml(xml)
-> # Lutaml::Model::NoRootMappingError: "GroupOfItems has `no_root`, it allowed only for reusable models"
+> # Lutaml::Model::TypeOnlyMappingError: "GroupOfItems is a type-only model (no element declared), ..."
 ----
 ====
 
@@ -3131,7 +3133,7 @@ class Address < Lutaml::Model::Serializable
   attribute :zip, :string
 
   xml do
-    no_root
+    # Type-only model - no element declaration needed
 
     map_element :street, to: :street
     map_element :city, to: :city
@@ -3144,7 +3146,7 @@ class Person < Lutaml::Model::Serializable
   import_model_attributes Address
 
   xml do
-    root "Person"
+    element "Person"
 
     map_element :name, to: :name
     sequence do
@@ -3200,7 +3202,7 @@ class ContactEmail < Lutaml::Model::Serializable
   attribute :email, :string
 
   xml do
-    no_root
+    # Type-only model - no element declaration needed
 
     map_element :email, to: :email
   end
@@ -3210,7 +3212,7 @@ class ContactPhone < Lutaml::Model::Serializable
   attribute :phone, :string
 
   xml do
-    no_root
+    # Type-only model - no element declaration needed
 
     map_element :phone, to: :phone
   end
@@ -3224,7 +3226,7 @@ class Person < Lutaml::Model::Serializable
   end
 
   xml do
-    root "Person"
+    element "Person"
 
     map_element :email, to: :email
     map_element :phone, to: :phone
@@ -3735,7 +3737,7 @@ class TitleDelimiterCollection < Lutaml::Model::Collection
   instances :items, :string
 
   xml do
-    root "titles"
+    element "titles"
     map_attribute "title", to: :items, delimiter: "; " <1>
   end
 end
@@ -3754,7 +3756,7 @@ class TitleCollection < Lutaml::Model::Collection
   instances :items, :string
 
   xml do
-    root "titles"
+    element "titles"
     map_attribute "title", to: :items, as_list: {
       import: ->(str) { str.split("; ") }, <1>
       export: ->(arr) { arr.join("; ") }, <2>
@@ -3892,7 +3894,6 @@ class TitleCollection < Lutaml::Model::Collection
   instances :titles, Title
 
   key_value do
-    no_root # default
     map_instances to: :titles
   end
 end
@@ -3972,7 +3973,6 @@ class TitleCollection < Lutaml::Model::Collection
   instances :titles, Title
 
   key_value do
-    no_root # default
     map_instances to: :titles
   end
 end
@@ -4067,11 +4067,11 @@ class MyCollection < Lutaml::Model::Collection
   instances :items, ModelType
 
   xml do
-    root "name-of-xml-container-element"
+    element "name-of-xml-container-element"
   end
 
   key_value do
-    root "name-of-key-value-container-element"
+    root "name-of-key-value-container-key"
   end
 end
 
@@ -4079,6 +4079,15 @@ class ModelType < Lutaml::Model::Serializable
   attribute :name, :string
 end
 ----
+
+In the `key_value` block:
+
+- `key "key-name"` sets the wrapper key for the collection in key-value formats (JSON, YAML, TOML).
+  The serialized output wraps all instances under this key (e.g., `{"titles": [...]}`).
+- Without a `key` call (the default), instances are serialized directly at the top level
+  (e.g., `["Item One", "Item Two"]`).
+
+NOTE: Key-value formats use `key` to set the wrapper key name, and `element` for XML element names.
 
 A named collection can alternatively be implemented as a non-collection model
 ("Model class with an attribute") that contains the collection of instances. In
@@ -4094,7 +4103,7 @@ class Title < Lutaml::Model::Serializable
   attribute :title, :string
 
   xml do
-    root "title"
+    element "title"
     map_content to: :title
   end
 end
@@ -4103,7 +4112,7 @@ class DirectTitleCollection < Lutaml::Model::Collection
   instances :items, Title
 
   xml do
-    root "titles"
+    element "titles"
     map_element "title", to: :items
   end
 
@@ -4229,7 +4238,7 @@ class Title < Lutaml::Model::Serializable
   attribute :title, :string
 
   xml do
-    root "title"
+    element "title"
     map_element "content", to: :title
   end
 
@@ -4242,12 +4251,12 @@ class TitleCollection < Lutaml::Model::Collection
   instances :items, Title
 
   xml do
-    root "titles"
+    element "titles"
     map_element 'title', to: :items
   end
 
   key_value do
-    root "titles"
+    element "titles"
     map_instances to: :items
   end
 end
@@ -4332,12 +4341,12 @@ class BibliographicItem < Lutaml::Model::Serializable
   attribute :title_parts, :string, collection: StringParts
 
   xml do
-    root "titles"
+    element "titles"
     map_element "title", to: :title_parts
   end
 
   key_value do
-    root "titles"
+    element "titles"
     map_instances to: :title_parts
   end
 
@@ -4413,7 +4422,7 @@ class TitleCollection < Lutaml::Model::Collection
   instances :items, Title
 
   xml do
-    root "title-group"
+    element "title-group"
     map_element "artifact", to: :items
   end
 end
@@ -4422,7 +4431,7 @@ class BibItem < Lutaml::Model::Serializable
   attribute :titles, TitleCollection
 
   xml do
-    root "bibitem"
+    element "bibitem"
     # This overrides the collection's root "title-group"
     map_element "titles", to: :titles
   end
@@ -4801,14 +4810,14 @@ Collection-level validations are applied to the entire collection as a unit. The
 ----
 class UniquePublicationCollection < Lutaml::Model::Collection
   instances :publications, Publication
-  
+
   # Ensure uniqueness of IDs across all publications
   validates_uniqueness_of :id, message: "Publication IDs must be unique"
-  
+
   # Ensure collection size constraints
   validates_min_count 2, message: "Must have at least 2 publications"
   validates_max_count 10, message: "Cannot have more than 10 publications"
-  
+
   # Ensure all publications have required fields
   validates_all_present :author, message: "All publications must have an author"
   validates_all_present :year
@@ -4824,7 +4833,7 @@ end
 ----
 class BusinessRuleCollection < Lutaml::Model::Collection
   instances :publications, Publication
-  
+
   # Custom validation: ensure publication years are sequential
   validate_collection do |publications, errors|
     years = publications.map(&:year).compact.sort
@@ -4835,7 +4844,7 @@ class BusinessRuleCollection < Lutaml::Model::Collection
       end
     end
   end
-  
+
   # Another custom validation: ensure category diversity
   validate_collection do |publications, errors|
     categories = publications.map(&:category).compact.uniq
@@ -4859,7 +4868,7 @@ class ComprehensiveCollection < Lutaml::Model::Collection
     validates :year, numericality: { greater_than: 1900 }
     validates :title, presence: true
   end
-  
+
   # Collection-level validations (for the collection as a whole)
   validates_uniqueness_of :id
   validates_min_count 1
@@ -5107,12 +5116,11 @@ class OrderedItemCollection < Lutaml::Model::Collection
   ordered by: :id, order: :desc
 
   xml do
-    root "items"
+    element "items"
     map_element "item", to: :items
   end
 
   key_value do
-    no_root
     map_instances to: :items
   end
 end
@@ -5141,7 +5149,7 @@ class ProcOrderedItemCollection < Lutaml::Model::Collection
   ordered by: ->(item) { [item.name.length, item.name] }, order: :asc
 
   xml do
-    root "items"
+    element "items"
     map_element "item", to: :items
   end
 end
@@ -5197,7 +5205,7 @@ class ReferenceSet < Lutaml::Model::Collection
   ]
 
   xml do
-    root "ReferenceSet"
+    element "ReferenceSet"
     map_instances to: :references, polymorphic: {
       attribute: "_class",
       class_map: {
@@ -5294,7 +5302,7 @@ class ReferenceSet < Lutaml::Model::Collection
   ]
 
   xml do
-    root "ReferenceSet"
+    element "ReferenceSet"
     map_instances to: :references, polymorphic: {
       attribute: "_class",
       class_map: {
@@ -6142,7 +6150,7 @@ class Document < Lutaml::Model::Serializable
   attribute :content, :string
 
   xml do
-    root "doc"
+    element "doc"
     map_attribute "lang", to: :lang
     map_attribute "space", to: :space
     map_attribute "id", to: :id
@@ -6302,7 +6310,8 @@ also supports the `mixed:` and `ordered:` options.
 In v0.8.0 onwards, these options are deprecated in favor of:
 
 * the `mixed_content` method replaces `mixed: true`;
-* the `sequence do` block replaces the `ordered: true` option
+* the `sequence do` block or `ordered method replaces the `ordered: true`
+option.
 ====
 
 Syntax:
@@ -6332,7 +6341,7 @@ class Paragraph < Lutaml::Model::Serializable
   attribute :italic, :string
 
   xml do
-    root 'p', mixed: true  # Enable mixed content
+    root 'p', mixed: true # Enable mixed content
     map_element 'bold', to: :bold
     map_element 'i', to: :italic
   end
@@ -6679,7 +6688,8 @@ To specify mixed content, the `mixed: true` option needs to be set at the
 [source,ruby]
 ----
 xml do
-  root 'xml_element_name', mixed: true
+  element 'xml_element_name'
+  mixed_content
 end
 ----
 
@@ -6693,7 +6703,8 @@ class Paragraph < Lutaml::Model::Serializable
   attribute :italic, :string
 
   xml do
-    root 'p', mixed: true
+    element 'p'
+    mixed_content
 
     map_element 'bold', to: :bold
     map_element 'i', to: :italic
@@ -6736,7 +6747,8 @@ Syntax:
 [source,ruby]
 ----
 xml do
-  root 'xml_element_name', ordered: true
+  element 'xml_element_name'
+  ordered
 end
 ----
 
@@ -6752,7 +6764,8 @@ class RootOrderedContent < Lutaml::Model::Serializable
   attribute :underline, :string
 
   xml do
-    root "RootOrderedContent", ordered: true
+    element "RootOrderedContent"
+    ordered
     map_element :bold, to: :bold
     map_element :italic, to: :italic
     map_element :underline, to: :underline
@@ -6791,7 +6804,7 @@ class RootOrderedContent < Lutaml::Model::Serializable
   attribute :underline, :string
 
   xml do
-    root "RootOrderedContent"
+    element "RootOrderedContent"
     map_element :bold, to: :bold
     map_element :italic, to: :italic
     map_element :underline, to: :underline
@@ -6875,7 +6888,7 @@ class Ceramic < Lutaml::Model::Serializable
   attribute :glaze, :string
 
   xml do
-    root 'Ceramic'
+    element "Ceramic"
     namespace CeramicXmlNamespace
     map_element 'Type', to: :type
     map_element 'Glaze', to: :glaze
@@ -6949,7 +6962,7 @@ class Properties < Lutaml::Model::Serializable
   attribute :template, :string
 
   xml do
-    root "Properties"
+    element "Properties"
     namespace AppNamespace
 
     # Force vt namespace to be declared even if unused
@@ -7128,7 +7141,7 @@ class Vcard < Lutaml::Model::Serializable
   attribute :created, DctermsCreatedType
 
   xml do
-    root "vCard"
+    element "vCard"
     namespace VcardNamespace
     namespace_scope [VcardNamespace, DcNamespace, DctermsNamespace]  # <1>
 
@@ -7192,7 +7205,7 @@ class Properties < Lutaml::Model::Serializable
   attribute :template, :string
 
   xml do
-    root "Properties"
+    element "Properties"
     namespace AppNamespace
 
     # Force vt namespace declaration even though unused
@@ -7250,7 +7263,7 @@ class CoreProperties < Lutaml::Model::Serializable
   attribute :title, :string
 
   xml do
-    root "coreProperties"
+    element "coreProperties"
     namespace CorePropertiesNamespace
 
     # Per-namespace declaration control
@@ -7467,7 +7480,7 @@ class Example < Lutaml::Model::Serializable
   attribute :name, :string
 
   xml do
-    root 'example'
+    element "example"
     map_element 'name', to: :name
   end
 end
@@ -7499,7 +7512,7 @@ class RecordDate < Lutaml::Model::Serializable
   attribute :content, :string
 
   xml do
-    root "recordDate"
+    element "recordDate"
     map_content to: :content
   end
 end
@@ -7508,7 +7521,7 @@ class OriginInfo < Lutaml::Model::Serializable
   attribute :date_issued, RecordDate, collection: true
 
   xml do
-    root "originInfo"
+    element "originInfo"
     map_element "dateIssued", to: :date_issued
   end
 end
@@ -7732,7 +7745,7 @@ class Example < Lutaml::Model::Serializable
   attribute :value, :integer
 
   xml do
-    root 'example'
+    element "example"
     map_attribute 'value', to: :value
   end
 end
@@ -7775,7 +7788,7 @@ class Attribute < Lutaml::Model::Serializable
   attribute :value, TechXmiIntegerType
 
   xml do
-    root 'example'
+    element "example"
     map_attribute 'value', to: :value
   end
 end
@@ -7935,7 +7948,7 @@ class Example < Lutaml::Model::Serializable
   attribute :description, :string
 
   xml do
-    root 'example'
+    element "example"
     map_content to: :description
   end
 end
@@ -8078,7 +8091,7 @@ class Example < Lutaml::Model::Serializable
   attribute :note, :string
 
   xml do
-    root 'example'
+    element "example"
     map_element :name, to: :name, cdata: true
     map_content to: :description, cdata: true
     map_element :title, to: :title, cdata: false
@@ -8140,7 +8153,7 @@ class RfcDoc < Lutaml::Model::Serializable
   attribute :pi_settings, :hash
 
   xml do
-    root "rfc"
+    element "rfc"
     map_element "title", to: :title
     map_processing_instruction "rfc", to: :pi_settings
   end
@@ -8174,7 +8187,7 @@ class RfcDoc < Lutaml::Model::Serializable
   attribute :rfc_pis, :string, collection: true
 
   xml do
-    root "rfc"
+    element "rfc"
     map_element "title", to: :title
     map_processing_instruction "rfc", to: :rfc_pis
   end
@@ -8265,7 +8278,7 @@ class KilnCollection < Lutaml::Model::Serializable
   attribute :kiln, Kiln, collection: 1..2
 
   xml do
-    root "collection"
+    element "collection"
     map_element "kiln", to: :kiln
   end
 end
@@ -8378,7 +8391,7 @@ class Ceramic < Lutaml::Model::Serializable
   attribute :color, :string
 
   xml do
-    root 'Ceramic'
+    element "Ceramic"
     namespace 'http://example.com/ceramic', 'cera'
     map_element 'Type', to: :type, namespace: :inherit
     map_element 'Glaze', to: :glaze
@@ -8456,7 +8469,7 @@ class Ceramic < Lutaml::Model::Serializable
   attribute :temperature, :integer
 
   xml do
-    root 'ceramic'
+    element "ceramic"
     map_element 'name', to: :name
     map_attribute 'temperature', to: :temperature
     map_content to: :description
@@ -8582,7 +8595,7 @@ class Contact < Lutaml::Model::Serializable
   attribute :email, EmailType
 
   xml do
-    root 'contact'
+    element "contact"
     map_element 'email', to: :email  # Uses EmailNamespace automatically
   end
 end
@@ -8670,7 +8683,7 @@ class Properties < Lutaml::Model::Serializable
   attribute :template, :string
 
   xml do
-    root "Properties"
+    element "Properties"
     namespace AppNamespace
     map_element "Template", to: :template
   end
@@ -9226,7 +9239,7 @@ class DctermsCreatedType < Lutaml::Model::Serializable
   attribute :type, XsiTypeType
 
   xml do
-    root 'created'
+    element "created"
     # This becomes xsi:type from XsiTypeType
     map_attribute 'type', to: :type
     map_content to: :value
@@ -9240,7 +9253,7 @@ class DctermsModifiedType < Lutaml::Model::Serializable
   attribute :type, XsiTypeType
 
   xml do
-    root 'modified'
+    element "modified"
     map_attribute 'type', to: :type
     map_content to: :value
   end
@@ -9258,7 +9271,7 @@ class CoreProperties < Lutaml::Model::Serializable
   attribute :modified, DctermsModifiedType
 
   xml do
-    root 'coreProperties'
+    element "coreProperties"
 
     # Type namespaces automatically applied
     map_element 'title', to: :title              # Becomes <dc:title>
@@ -9351,7 +9364,7 @@ class Model < Lutaml::Model::Serializable
   attribute :value, DefaultType
 
   xml do
-    root 'model'
+    element "model"
 
     # Case 1: Type namespace used (no explicit namespace)
     map_element 'value1', to: :value
@@ -9392,7 +9405,7 @@ class Product < Lutaml::Model::Serializable
   attribute :schema_type, XsiTypeType
 
   xml do
-    root 'product'
+    element "product"
     map_attribute 'id', to: :id              # Unqualified: id="..."
     map_attribute 'type', to: :schema_type   # Qualified: xsi:type="..."
   end
@@ -9592,7 +9605,7 @@ class JapaneseCeramic < Lutaml::Model::Serializable
   attribute :description, :string
 
   xml do
-    root 'JapaneseCeramic'
+    element "JapaneseCeramic"
     map_attribute 'glazeType', to: :glaze_type
     map_element 'description', to: :description
   end
@@ -9653,7 +9666,7 @@ class Ceramic < Lutaml::Model::Serializable
   attribute :temperature, :integer
 
   xml do
-    root 'ceramic'
+    element "ceramic"
     map_element 'potter', to: :potter
     map_content to: :description
   end
@@ -9704,7 +9717,7 @@ class JapaneseCeramic < Lutaml::Model::Serializable
   attribute :description, :string
 
   xml do
-    root 'JapaneseCeramic'
+    element "JapaneseCeramic"
     map_attribute 'glazeType', to: :glaze_type
     map_element 'description', to: :description
   end
@@ -10032,7 +10045,7 @@ class Settings < Lutaml::Model::Serializable
   attribute :chart_tracking, :boolean
 
   xml do
-    root "settings"
+    element "settings"
     namespace WNamespace
     namespace_scope [W14Namespace, W15Namespace]
 
@@ -11868,7 +11881,7 @@ class JapaneseCeramic < Lutaml::Model::Serializable
   attribute :description, :string
 
   xml do
-    root 'JapaneseCeramic'
+    element "JapaneseCeramic"
     map_attribute 'glazeType', to: :glaze_type
     map_element 'description', to: :description
   end
@@ -12029,7 +12042,7 @@ class Ceramic < Lutaml::Model::Serializable
 
   # Mapping-level transformation in XML format
   xml do
-    root "Ceramic"
+    element "Ceramic"
     map_attribute "glaze-type", to: :glaze_type, transform: {
       export: ->(value) { "Traditional #{value}" },
       import: ->(value) { value.gsub("Traditional ", "") }
@@ -12137,7 +12150,7 @@ class Ceramic < Lutaml::Model::Serializable
 
   # Mapping-level transformation in XML format
   xml do
-    root "Ceramic"
+    element "Ceramic"
     map_attribute "glaze-type", to: :glaze_type, transform: {
       export: ->(value) { "Traditional #{value}" },
       import: ->(value) { value.gsub("Traditional ", "") }
@@ -12357,7 +12370,7 @@ class CombinedTransformModel < Lutaml::Model::Serializable
   end
 
   xml do
-    root "CombinedTransformModel"
+    element "CombinedTransformModel"
     map_element "title", to: :title, transform: SuffixTransformer
   end
 end
@@ -12565,7 +12578,7 @@ class Glaze < Lutaml::Model::Serializable
   attribute :firing_time, :integer, default: -> { 60 }
 
   xml do
-    root "glaze"
+    element "glaze"
     map_element 'color', to: :color
     map_element 'opacity', to: :opacity, render_default: true
     map_attribute 'temperature', to: :temperature
@@ -12655,7 +12668,7 @@ class CustomModel < Lutaml::Model::Serializable
   end
 
   xml do
-    root "CustomModel"
+    element "CustomModel"
     map_element ["name", "custom-name"], with: { to: :name_to_xml, from: :name_from_xml }
     map_element ["color", "shade"], with: { to: :color_to_xml, from: :color_from_xml }
     map_attribute ["id", "identifier"], to: :id
@@ -14397,7 +14410,7 @@ class SomeModel < Lutaml::Model::Serializable
   attribute :coll, :string, collection: true
 
   xml do
-    root "some-model"
+    element "some-model"
     map_element 'collection', to: :coll, render_nil: :omit
   end
 
@@ -14436,7 +14449,7 @@ class SomeModel < Lutaml::Model::Serializable
   attribute :coll, :string, collection: true
 
   xml do
-    root "some-model"
+    element "some-model"
     map_element 'collection', to: :coll, render_nil: :as_nil
   end
 
@@ -14478,7 +14491,7 @@ class SomeModel < Lutaml::Model::Serializable
   attribute :coll, :string, collection: true
 
   xml do
-    root "some-model"
+    element "some-model"
     map_element 'collection', to: :coll, render_nil: :as_blank # <1>
   end
 
@@ -14575,7 +14588,7 @@ class SomeModel < Lutaml::Model::Serializable
   attribute :coll, :string, collection: true
 
   xml do
-    root "some-model"
+    element "some-model"
     map_element 'collection', to: :coll, render_empty: :omit
   end
 
@@ -14612,7 +14625,7 @@ class SomeModel < Lutaml::Model::Serializable
   attribute :coll, :string, collection: true
 
   xml do
-    root "some-model"
+    element "some-model"
     map_element 'collection', to: :coll, render_empty: :as_nil
   end
 
@@ -14654,7 +14667,7 @@ class SomeModel < Lutaml::Model::Serializable
   attribute :coll, :string, collection: true
 
   xml do
-    root "some-model"
+    element "some-model"
     map_element 'collection', to: :coll, render_empty: :as_blank # <1>
   end
 
@@ -14698,7 +14711,7 @@ class Tag < Lutaml::Model::Serializable
   attribute :text, :string
 
   xml do
-    root "Tag"
+    element "Tag"
 
     map_content to: :text
   end
@@ -14712,7 +14725,7 @@ class Tags < Lutaml::Model::Serializable
   attribute :tag, Tag, collection: true
 
   xml do
-    root "Tags"
+    element "Tags"
 
     map_element "Tag", to: :tag
   end
@@ -14726,7 +14739,7 @@ class Post < Lutaml::Model::Serializable
   attribute :tags, Tags, collection: true
 
   xml do
-    root "Post"
+    element "Post"
     map_element "Tags", to: :tags
   end
 

--- a/RELEASE_NOTES.adoc
+++ b/RELEASE_NOTES.adoc
@@ -26,7 +26,7 @@ The `namespace_scope` directive allows you to control WHERE namespace declaratio
 ----
 class Vcard < Lutaml::Model::Serializable
   xml do
-    root "vCard"
+    element "vCard"
     namespace VcardNamespace
 
     # Consolidate namespaces at root
@@ -145,7 +145,7 @@ class SomeModel < Lutaml::Model::Serializable
   attribute :coll, :string, collection: true
 
   xml do
-    root "some-model"
+    element "some-model"
     map_element 'collection', to: :coll
   end
 end
@@ -209,7 +209,7 @@ class SomeModel < Lutaml::Model::Serializable
   attribute :coll, :string, collection: true
 
   xml do
-    root "some-model"
+    element "some-model"
     map_element 'collection', to: :coll, render_nil: :omit
   end
 

--- a/benchmark/quick_benchmark.rb
+++ b/benchmark/quick_benchmark.rb
@@ -30,7 +30,7 @@ class Item < Lutaml::Model::Serializable
   attribute :value, :float
 
   xml do
-    root "item"
+    element "item"
     map_attribute "id", to: :id
     map_element "name", to: :name
     map_element "value", to: :value
@@ -47,7 +47,7 @@ class Container < Lutaml::Model::Serializable
   attribute :items, Item, collection: true
 
   xml do
-    root "container"
+    element "container"
     map_element "item", to: :items
   end
 

--- a/benchmark/serialization_benchmark.rb
+++ b/benchmark/serialization_benchmark.rb
@@ -49,7 +49,7 @@ class SimpleModel < Lutaml::Model::Serializable
   attribute :created_at, :date_time
 
   xml do
-    root "simple"
+    element "simple"
     map_attribute "id", to: :id
     map_element "name", to: :name
     map_element "active", to: :active
@@ -79,7 +79,7 @@ class AddressModel < Lutaml::Model::Serializable
   attribute :postal_code, :string
 
   xml do
-    root "address"
+    element "address"
     map_element "street", to: :street
     map_element "city", to: :city
     map_element "country", to: :country
@@ -106,7 +106,7 @@ class PersonModel < Lutaml::Model::Serializable
   attribute :tags, :string, collection: true
 
   xml do
-    root "person"
+    element "person"
     map_attribute "id", to: :id
     map_element "first_name", to: :first_name
     map_element "last_name", to: :last_name
@@ -136,7 +136,7 @@ class DepartmentModel < Lutaml::Model::Serializable
   attribute :employees, PersonModel, collection: true
 
   xml do
-    root "department"
+    element "department"
     map_element "name", to: :name
     map_element "code", to: :code
     map_element "employee", to: :employees

--- a/docs/_guides/advanced-mapping.adoc
+++ b/docs/_guides/advanced-mapping.adoc
@@ -47,7 +47,7 @@ class CustomModel < Lutaml::Model::Serializable
   end
 
   xml do
-    root "CustomModel"
+    element "CustomModel"
     map_element ["name", "custom-name"], with: { to: :name_to_xml, from: :name_from_xml }
     map_element ["color", "shade"], with: { to: :color_to_xml, from: :color_from_xml }
     map_attribute ["id", "identifier"], to: :id

--- a/docs/_guides/character-encoding.adoc
+++ b/docs/_guides/character-encoding.adoc
@@ -79,7 +79,7 @@ class JapaneseCeramic < Lutaml::Model::Serializable
   attribute :description, :string
 
   xml do
-    root 'JapaneseCeramic'
+    element "JapaneseCeramic"
     map_attribute 'glazeType', to: :glaze_type
     map_element 'description', to: :description
   end
@@ -140,7 +140,7 @@ class Ceramic < Lutaml::Model::Serializable
   attribute :temperature, :integer
 
   xml do
-    root 'ceramic'
+    element "ceramic"
     map_element 'potter', to: :potter
     map_content to: :description
   end
@@ -191,7 +191,7 @@ class JapaneseCeramic < Lutaml::Model::Serializable
   attribute :description, :string
 
   xml do
-    root 'JapaneseCeramic'
+    element "JapaneseCeramic"
     map_attribute 'glazeType', to: :glaze_type
     map_element 'description', to: :description
   end

--- a/docs/_guides/missing-values-handling.adoc
+++ b/docs/_guides/missing-values-handling.adoc
@@ -1246,7 +1246,7 @@ class SomeModel < Lutaml::Model::Serializable
   attribute :coll, :string, collection: true
 
   xml do
-    root "some-model"
+    element "some-model"
     map_element 'collection', to: :coll, render_nil: :omit
   end
 
@@ -1285,7 +1285,7 @@ class SomeModel < Lutaml::Model::Serializable
   attribute :coll, :string, collection: true
 
   xml do
-    root "some-model"
+    element "some-model"
     map_element 'collection', to: :coll, render_nil: :as_nil
   end
 
@@ -1327,7 +1327,7 @@ class SomeModel < Lutaml::Model::Serializable
   attribute :coll, :string, collection: true
 
   xml do
-    root "some-model"
+    element "some-model"
     map_element 'collection', to: :coll, render_nil: :as_blank # <1>
   end
 
@@ -1424,7 +1424,7 @@ class SomeModel < Lutaml::Model::Serializable
   attribute :coll, :string, collection: true
 
   xml do
-    root "some-model"
+    element "some-model"
     map_element 'collection', to: :coll, render_empty: :omit
   end
 
@@ -1461,7 +1461,7 @@ class SomeModel < Lutaml::Model::Serializable
   attribute :coll, :string, collection: true
 
   xml do
-    root "some-model"
+    element "some-model"
     map_element 'collection', to: :coll, render_empty: :as_nil
   end
 
@@ -1503,7 +1503,7 @@ class SomeModel < Lutaml::Model::Serializable
   attribute :coll, :string, collection: true
 
   xml do
-    root "some-model"
+    element "some-model"
     map_element 'collection', to: :coll, render_empty: :as_blank # <1>
   end
 

--- a/docs/_guides/ooxml-examples.adoc
+++ b/docs/_guides/ooxml-examples.adoc
@@ -101,7 +101,7 @@ class PersonName < Lutaml::Model::Serializable
   attribute :suffix, :string
 
   xml do
-    root "personName"
+    element "personName"
     map_element "givenName", to: :given_name
     map_element "surname", to: :surname
     map_attribute "prefix", to: :prefix
@@ -114,7 +114,7 @@ class Contact < Lutaml::Model::Serializable
   attribute :person_name, PersonName
 
   xml do
-    root "ContactInfo"
+    element "ContactInfo"
     map_element "personName", to: :person_name
   end
 end
@@ -233,7 +233,7 @@ class DctermsCreated < Lutaml::Model::Serializable
   attribute :type, XsiTypeType
 
   xml do
-    root "created"
+    element "created"
     namespace DctermsNamespace
     map_attribute "type", to: :type
     map_content to: :value
@@ -246,7 +246,7 @@ class DctermsModified < Lutaml::Model::Serializable
   attribute :type, XsiTypeType
 
   xml do
-    root "modified"
+    element "modified"
     namespace DctermsNamespace
     map_attribute "type", to: :type
     map_content to: :value
@@ -263,7 +263,7 @@ class CoreProperties < Lutaml::Model::Serializable
   attribute :modified, DctermsModified
 
   xml do
-    root "coreProperties"
+    element "coreProperties"
     map_element "title", to: :title
     map_element "creator", to: :creator
     map_element "lastModifiedBy", to: :last_modified_by
@@ -420,7 +420,7 @@ class Settings < Lutaml::Model::Serializable
   attribute :chart_tracking, :boolean
 
   xml do
-    root "settings"
+    element "settings"
     namespace WNamespace
     namespace_scope [W14Namespace, W15Namespace]
 
@@ -655,7 +655,7 @@ class Settings < Lutaml::Model::Serializable
   attribute :w15_doc_id, W15DocId
 
   xml do
-    root "settings"
+    element "settings"
     namespace WNamespace
     namespace_scope [W14Namespace, W15Namespace]
 

--- a/docs/_guides/opal.adoc
+++ b/docs/_guides/opal.adoc
@@ -172,7 +172,7 @@ class Person
   attribute :age, :integer
 
   xml do
-    root "person"
+    element "person"
     map_element "name", to: :name
     map_element "age", to: :age
   end

--- a/docs/_guides/value-transformations.adoc
+++ b/docs/_guides/value-transformations.adoc
@@ -275,7 +275,7 @@ class Event < Lutaml::Model::Serializable
   attribute :event_date, MultiFormatDate
 
   xml do
-    root "event"
+    element "event"
     map_element "eventDate", to: :event_date
   end
 
@@ -402,7 +402,7 @@ class Document < Lutaml::Model::Serializable
   }
 
   xml do
-    root "document"
+    element "document"
     map_element "pubDate", to: :publication_date
   end
 
@@ -505,7 +505,7 @@ class Document < Lutaml::Model::Serializable
 
   # XML wants YYYYMMDD
   xml do
-    root "document"
+    element "document"
     map_element "pubDate", to: :publication_date, transform: {
       export: ->(date) { date&.strftime("%Y%m%d") },
       import: ->(str) {
@@ -749,7 +749,7 @@ class Product < Lutaml::Model::Serializable
   end
 
   xml do
-    root "product"
+    element "product"
     map_element "name", to: :name, transform: {
       export: ->(value) { "XML:#{value}" },
       import: ->(value) { value.gsub("XML:", "") }
@@ -898,7 +898,7 @@ class Event < Lutaml::Model::Serializable
   attribute :name, :string
 
   xml do
-    root "event"
+    element "event"
     map_element "eventDate", to: :event_date
     map_element "name", to: :name
   end
@@ -1029,7 +1029,7 @@ class Schedule < Lutaml::Model::Serializable
   attribute :activity, :string
 
   xml do
-    root "schedule"
+    element "schedule"
     map_element "date", to: :week_date
     map_element "activity", to: :activity
   end
@@ -1100,7 +1100,7 @@ class BlogPost < Lutaml::Model::Serializable
 
   # XML API requires YYYYMMDD
   xml do
-    root "post"
+    element "post"
     map_element "publishDate", to: :published_on, transform: {
       export: ->(date) { date&.strftime("%Y%m%d") },
       import: ->(str) {

--- a/docs/_guides/xml-mapping.adoc
+++ b/docs/_guides/xml-mapping.adoc
@@ -174,7 +174,8 @@ class Paragraph < Lutaml::Model::Serializable
   attribute :italic, :string
 
   xml do
-    root 'p', mixed: true  # DEPRECATED - use mixed_content method instead
+    element 'p'
+    mixed_content  # DEPRECATED - use mixed_content method instead
     map_element 'bold', to: :bold
     map_element 'i', to: :italic
   end
@@ -206,19 +207,22 @@ end
 
 NOTE: Type-only models can only be parsed when embedded in parent models, not
 standalone. Attempting to call `Address.from_xml(xml)` will raise
-`NoRootMappingError`.
+`TypeOnlyMappingError`.
 
 // TODO: This understanding is wrong -- a type can declare attributes,
 // we need to fix this.
 
-The `no_root` method is deprecated.
+The modern pattern is to omit the `element` declaration entirely for
+type-only models. The `no_root` method is deprecated.
 
-Syntax:
-
+.Syntax for type-only models (modern pattern)
 [source,ruby]
 ----
-xml do
-  no_root
+class Address < Lutaml::Model::Serializable
+  xml do
+    # No element declaration - type-only model
+    map_element 'street', to: :street
+  end
 end
 ----
 
@@ -227,14 +231,14 @@ end
 ----
 class Address < Lutaml::Model::Serializable
   xml do
-    no_root  # DEPRECATED
+    no_root  # DEPRECATED - omit element declaration instead
     map_element 'street', to: :street
   end
 end
 ----
 
-When `no_root` is used, only `map_element` can be used because without a root
-element there cannot be attributes.
+When a model has no element declaration, only `map_element` can be used
+because without a root element there cannot be attributes.
 
 [example]
 ====
@@ -245,7 +249,7 @@ class NameAndCode < Lutaml::Model::Serializable
   attribute :code, :string
 
   xml do
-    no_root
+    # Type-only model - no element declaration needed
     map_element "code", to: :code
     map_element "name", to: :name
   end
@@ -450,7 +454,8 @@ To specify mixed content, the `mixed: true` option needs to be set at the
 [source,ruby]
 ----
 xml do
-  root 'xml_element_name', mixed: true
+  element 'xml_element_name'
+  mixed_content
 end
 ----
 
@@ -464,7 +469,8 @@ class Paragraph < Lutaml::Model::Serializable
   attribute :italic, :string
 
   xml do
-    root 'p', mixed: true
+    element 'p'
+    mixed_content
 
     map_element 'bold', to: :bold
     map_element 'i', to: :italic
@@ -655,7 +661,7 @@ class Example < Lutaml::Model::Serializable
   attribute :name, :string
 
   xml do
-    root 'example'
+    element "example"
     map_element 'name', to: :name
   end
 end
@@ -687,7 +693,7 @@ class RecordDate < Lutaml::Model::Serializable
   attribute :content, :string
 
   xml do
-    root "recordDate"
+    element "recordDate"
     map_content to: :content
   end
 end
@@ -696,7 +702,7 @@ class OriginInfo < Lutaml::Model::Serializable
   attribute :date_issued, RecordDate, collection: true
 
   xml do
-    root "originInfo"
+    element "originInfo"
     map_element "dateIssued", to: :date_issued
   end
 end
@@ -867,7 +873,7 @@ class Example < Lutaml::Model::Serializable
   attribute :value, :integer
 
   xml do
-    root 'example'
+    element "example"
     map_attribute 'value', to: :value
   end
 end
@@ -910,7 +916,7 @@ class Attribute < Lutaml::Model::Serializable
   attribute :value, TechXmiIntegerType
 
   xml do
-    root 'example'
+    element "example"
     map_attribute 'value', to: :value
   end
 end
@@ -1070,7 +1076,7 @@ class Example < Lutaml::Model::Serializable
   attribute :description, :string
 
   xml do
-    root 'example'
+    element "example"
     map_content to: :description
   end
 end
@@ -1213,7 +1219,7 @@ class Example < Lutaml::Model::Serializable
   attribute :note, :string
 
   xml do
-    root 'example'
+    element "example"
     map_element :name, to: :name, cdata: true
     map_content to: :description, cdata: true
     map_element :title, to: :title, cdata: false
@@ -1260,7 +1266,7 @@ changes.
 [source,ruby]
 ----
 xml do
-  root "rfc"
+  element "rfc"
   map_element "title", to: :title
   map_processing_instruction "rfc", to: :pi_settings
 end
@@ -1293,7 +1299,7 @@ to different attributes:
 [source,ruby]
 ----
 xml do
-  root "doc"
+  element "doc"
   map_processing_instruction "rfc", to: :rfc_pis
   map_processing_instruction "xml-stylesheet", to: :stylesheet_pis
 end
@@ -1309,7 +1315,7 @@ content string is stored as-is:
 attribute :rfc_pis, :string, collection: true
 
 xml do
-  root "rfc"
+  element "rfc"
   map_processing_instruction "rfc", to: :rfc_pis
 end
 ----
@@ -1341,7 +1347,7 @@ class Ceramic < Lutaml::Model::Serializable
   attribute :temperature, :integer
 
   xml do
-    root 'ceramic'
+    element "ceramic"
     map_element 'name', to: :name
     map_attribute 'temperature', to: :temperature
     map_content to: :description
@@ -1465,7 +1471,7 @@ class Contact < Lutaml::Model::Serializable
   attribute :email, EmailType
 
   xml do
-    root 'contact'
+    element "contact"
     map_element 'email', to: :email  # Uses EmailNamespace automatically
   end
 end
@@ -1553,7 +1559,7 @@ class Properties < Lutaml::Model::Serializable
   attribute :template, :string
 
   xml do
-    root "Properties"
+    element "Properties"
     namespace AppNamespace
     map_element "Template", to: :template
   end

--- a/docs/_guides/xml-namespace-qualification.adoc
+++ b/docs/_guides/xml-namespace-qualification.adoc
@@ -305,7 +305,7 @@ class Parent < Lutaml::Model::Serializable
 
   xml do
     namespace MyNamespace
-    root "parent"
+    element "parent"
     map_element "child", to: :value
   end
 end
@@ -340,7 +340,7 @@ class Parent < Lutaml::Model::Serializable
 
   xml do
     namespace MyNamespace
-    root "parent"
+    element "parent"
     map_element "child", to: :value
   end
 end
@@ -480,7 +480,7 @@ class Child < Lutaml::Model::Serializable
   attribute :value, :string
   xml do
     namespace NS
-    root "child"
+    element "child"
     map_element "value", to: :value
   end
 end
@@ -489,7 +489,7 @@ class Parent < Lutaml::Model::Serializable
   attribute :child, Child
   xml do
     namespace NS
-    root "parent"
+    element "parent"
     map_element "child", to: :child
   end
 end

--- a/docs/_guides/xml-namespaces.adoc
+++ b/docs/_guides/xml-namespaces.adoc
@@ -483,7 +483,7 @@ class Document < Lutaml::Model::Serializable
   attribute :content, :string
 
   xml do
-    root "doc"
+    element "doc"
     map_attribute "lang", to: :lang
     map_attribute "space", to: :space
     map_content to: :content
@@ -761,7 +761,7 @@ class Article < Lutaml::Model::Serializable
   attribute :content, :string
 
   xml do
-    root "article"
+    element "article"
     map_attribute "lang", to: :lang
     map_attribute "space", to: :space
     map_attribute "id", to: :id

--- a/docs/_guides/xml/namespace-presentation.adoc
+++ b/docs/_guides/xml/namespace-presentation.adoc
@@ -185,7 +185,7 @@ class NamespacedItem < Lutaml::Model::Serializable
   attribute :alt_name, SecondNamespacedName # SecondNamespace
 
   xml do
-    root "item"
+    element "item"
     namespace SecondNamespace  # Root uses SecondNamespace
     map_element "name", to: :name
     map_element "alt_name", to: :alt_name

--- a/docs/_guides/xml/namespace-semantics.adoc
+++ b/docs/_guides/xml/namespace-semantics.adoc
@@ -43,7 +43,7 @@ class NativeItem < Lutaml::Model::Serializable
   attribute :name, :string  # Native type with no inherent namespace
 
   xml do
-    root "first_item"
+    element "first_item"
     namespace FirstItemNamespace
     map_element "name", to: :name
   end
@@ -97,7 +97,7 @@ class NamespacedItem < Lutaml::Model::Serializable
   attribute :alt_name, SecondNamespacedName # Has SecondNamespace
 
   xml do
-    root "second_item"
+    element "second_item"
     namespace SecondNamespace
     map_element "name", to: :name
     map_element "alt_name", to: :alt_name
@@ -127,7 +127,7 @@ class NestedItem < Lutaml::Model::Serializable
   attribute :value, :string
 
   xml do
-    root "nested"
+    element "nested"
     namespace FirstNamespace
     map_element "value", to: :value
   end
@@ -137,7 +137,7 @@ class Container < Lutaml::Model::Serializable
   attribute :item, NestedItem
 
   xml do
-    root "container"
+    element "container"
     namespace SecondNamespace
     map_element "item", to: :item
   end
@@ -162,7 +162,7 @@ end
 [source,ruby]
 ----
 xml do
-  root "item"
+  element "item"
   namespace MyNamespace
   map_attribute "id", to: :id          # Unqualified (no namespace)
   map_element "name", to: :name         # Qualified (uses MyNamespace)
@@ -200,7 +200,7 @@ class Item < Lutaml::Model::Serializable
   attribute :value, :integer
 
   xml do
-    root "item"
+    element "item"
     namespace MyNamespace
     map_attribute "id", to: :id
     map_attribute "value", to: :value
@@ -280,7 +280,7 @@ class Spacing < Lutaml::Model::Serializable
   attribute :before, :integer
 
   xml do
-    root "spacing"
+    element "spacing"
     namespace WordProcessingML
     map_attribute "val", to: :val
     map_attribute "after", to: :after
@@ -330,7 +330,7 @@ class Item < Lutaml::Model::Serializable
   attribute :explicit, :string
 
   xml do
-    root "item"
+    element "item"
     namespace Namespace1
     map_attribute "normal", to: :normal           # Uses form_default (unqualified)
     map_attribute "explicit", to: :explicit, namespace: Namespace2  # Explicit wins
@@ -397,7 +397,7 @@ class NativeItemNames < Lutaml::Model::Serializable
   attribute :name, :string, collection: true
 
   xml do
-    root "item_names"
+    element "item_names"
     namespace FirstItemNamespace
     map_element "name", to: :name
   end
@@ -422,7 +422,7 @@ class NativeItemCollection < Lutaml::Model::Serializable
   attribute :items, NativeItem, collection: true
 
   xml do
-    root "items"
+    element "items"
     namespace FirstItemNamespace
     map_element "item", to: :items
   end
@@ -441,7 +441,7 @@ class Container < Lutaml::Model::Serializable
   attribute :items, BaseItem, collection: true, polymorphic: [TypeA, TypeB]
 
   xml do
-    root "container"
+    element "container"
     map_element "item", to: :items
   end
 end
@@ -557,7 +557,7 @@ class Child < Lutaml::Model::Serializable
   attribute :value, :string
 
   xml do
-    root "child"
+    element "child"
     # No namespace declared - will inherit from parent
     map_element "value", to: :value
   end
@@ -567,7 +567,7 @@ class Parent < Lutaml::Model::Serializable
   attribute :child, Child
 
   xml do
-    root "parent"
+    element "parent"
     namespace ParentNamespace
     map_element "child", to: :child
   end
@@ -594,7 +594,7 @@ class Wrapper < Lutaml::Model::Serializable
   attribute :items, NamespacedItem, collection: true
 
   xml do
-    root "wrapper"
+    element "wrapper"
     namespace WrapperNamespace
     map_element "item", to: :items
   end
@@ -635,7 +635,7 @@ class PlainItem < Lutaml::Model::Serializable
   attribute :name, :string
 
   xml do
-    root "item"
+    element "item"
     # No namespace declared
     map_element "name", to: :name
   end

--- a/docs/_guides/xml/type-namespaces.adoc
+++ b/docs/_guides/xml/type-namespaces.adoc
@@ -52,7 +52,7 @@ class Article < Lutaml::Model::Serializable
   attribute :creator, DcCreatorType
 
   xml do
-    root "article"
+    element "article"
     namespace ArticleNamespace
 
     map_element "title", to: :title
@@ -89,7 +89,7 @@ class Article < Lutaml::Model::Serializable
   attribute :title, DcTitleType
 
   xml do
-    root "article"
+    element "article"
     namespace ArticleNamespace
     map_element "title", to: :title
   end
@@ -145,7 +145,7 @@ class Article < Lutaml::Model::Serializable
   attribute :creator, DcCreatorType
 
   xml do
-    root "article"
+    element "article"
     namespace ArticleNamespace
     namespace_scope [ArticleNamespace, DublinCoreNamespace]  # <1>
 
@@ -247,7 +247,7 @@ class CoreProperties < Lutaml::Model::Serializable
   attribute :created, DctermsCreatedType
 
   xml do
-    root 'coreProperties'
+    element "coreProperties"
     namespace CorePropertiesNamespace
     namespace_scope [
       CorePropertiesNamespace,
@@ -303,7 +303,7 @@ class Product < Lutaml::Model::Serializable
   attribute :schema_type, XsiTypeType
 
   xml do
-    root 'product'
+    element "product"
     map_attribute 'type', to: :schema_type  # <1>
   end
 end
@@ -559,7 +559,7 @@ class BookMetadata < Lutaml::Model::Serializable
   attribute :date, DcDateType
 
   xml do
-    root "metadata"
+    element "metadata"
     namespace_scope [DublinCoreNamespace]
 
     map_element "title", to: :title
@@ -646,7 +646,7 @@ class Vcard < Lutaml::Model::Serializable
   attribute :version, :string
 
   xml do
-    root "vCard"
+    element "vCard"
     namespace VcardNamespace
     namespace_scope [
       VcardNamespace,
@@ -716,7 +716,7 @@ class Article < Lutaml::Model::Serializable
   attribute :title, CustomTitle  # Uses CustomTitle's namespace
 
   xml do
-    root "article"
+    element "article"
     map_element "title", to: :title
   end
 end
@@ -784,7 +784,7 @@ class Article < Lutaml::Model::Serializable
   attribute :keywords, :string, collection: true  # No namespace
 
   xml do
-    root "article"
+    element "article"
     namespace ArticleNamespace
     namespace_scope [ArticleNamespace, DublinCoreNamespace]
 

--- a/docs/_guides/xml_mappings/04_xml_namespace_class.adoc
+++ b/docs/_guides/xml_mappings/04_xml_namespace_class.adoc
@@ -430,7 +430,7 @@ class ProcessingTask < Lutaml::Model::Serializable
   attribute :processing_time, :duration
 
   xml do
-    root "task"
+    element "task"
     map_element "processingTime", to: :processing_time
   end
 end
@@ -465,7 +465,7 @@ class Resource < Lutaml::Model::Serializable
   attribute :schema_location, :uri
 
   xml do
-    root "resource"
+    element "resource"
     map_element "homepage", to: :homepage
     map_attribute "schemaLocation", to: :schema_location
   end
@@ -500,7 +500,7 @@ class Reference < Lutaml::Model::Serializable
   attribute :target, :qname
 
   xml do
-    root "reference"
+    element "reference"
     map_attribute "type", to: :ref_type
     map_element "target", to: :target
   end
@@ -538,7 +538,7 @@ class Attachment < Lutaml::Model::Serializable
   attribute :filename, :string
 
   xml do
-    root "attachment"
+    element "attachment"
     map_element "content", to: :content
     map_attribute "filename", to: :filename
   end
@@ -579,7 +579,7 @@ class Checksum < Lutaml::Model::Serializable
   attribute :algorithm, :string
 
   xml do
-    root "checksum"
+    element "checksum"
     map_element "value", to: :hash_value
     map_attribute "algorithm", to: :algorithm
   end
@@ -710,7 +710,7 @@ class Contact < Lutaml::Model::Serializable
   attribute :email, EmailType
 
   xml do
-    root 'contact'
+    element "contact"
     map_element 'email', to: :email  # Uses EmailNamespace automatically
   end
 end
@@ -744,7 +744,7 @@ class CustomModel < Lutaml::Model::Serializable
   attribute :value, :string
 
   xml do
-    root 'customElement'
+    element "customElement"
     map_element 'value', to: :value
   end
 end
@@ -789,7 +789,7 @@ class Document < Lutaml::Model::Serializable
   attribute :content, :string  # Regular attribute, no type namespace
 
   xml do
-    root 'document'
+    element "document"
 
     map_element 'title', to: :title      # Becomes <dc:title> from Type
     map_element 'creator', to: :creator  # Becomes <dc:creator> from Type
@@ -953,7 +953,7 @@ class DctermsCreatedType < Lutaml::Model::Serializable
   attribute :type, XsiTypeType
 
   xml do
-    root 'created'
+    element "created"
     # This becomes xsi:type from XsiTypeType
     map_attribute 'type', to: :type
     map_content to: :value
@@ -967,7 +967,7 @@ class DctermsModifiedType < Lutaml::Model::Serializable
   attribute :type, XsiTypeType
 
   xml do
-    root 'modified'
+    element "modified"
     map_attribute 'type', to: :type
     map_content to: :value
   end
@@ -985,7 +985,7 @@ class CoreProperties < Lutaml::Model::Serializable
   attribute :modified, DctermsModifiedType
 
   xml do
-    root 'coreProperties'
+    element "coreProperties"
 
     # Type namespaces automatically applied
     map_element 'title', to: :title              # Becomes <dc:title>
@@ -1078,7 +1078,7 @@ class Model < Lutaml::Model::Serializable
   attribute :value, DefaultType
 
   xml do
-    root 'model'
+    element "model"
 
     # Case 1: Type namespace used (no explicit namespace)
     map_element 'value1', to: :value
@@ -1119,7 +1119,7 @@ class Product < Lutaml::Model::Serializable
   attribute :schema_type, XsiTypeType
 
   xml do
-    root 'product'
+    element "product"
     map_attribute 'id', to: :id              # Unqualified: id="..."
     map_attribute 'type', to: :schema_type   # Qualified: xsi:type="..."
   end
@@ -1371,7 +1371,7 @@ class Document < Lutaml::Model::Serializable
   attribute :creator, DcCreatorType
 
   xml do
-    root 'document'
+    element "document"
     map_element 'title', to: :title
     map_element 'creator', to: :creator
   end
@@ -1401,7 +1401,7 @@ class Document < Lutaml::Model::Serializable
   attribute :creator, DcCreatorType
 
   xml do
-    root 'document'
+    element "document"
     map_element 'title', to: :title
     map_element 'creator', to: :creator
   end
@@ -1530,7 +1530,7 @@ class Vcard < Lutaml::Model::Serializable
   attribute :title, DcTitleType
 
   xml do
-    root "vCard"
+    element "vCard"
     namespace VcardNamespace
     namespace_scope [VcardNamespace, DcNamespace]  <1>
 
@@ -1612,7 +1612,7 @@ class Vcard < Lutaml::Model::Serializable
   attribute :created, DctermsCreatedType
 
   xml do
-    root "vCard"
+    element "vCard"
     namespace VcardNamespace
     namespace_scope [VcardNamespace, DcNamespace, DctermsNamespace]  <1>
 
@@ -1676,7 +1676,7 @@ class Vcard < Lutaml::Model::Serializable
   attribute :created, DctermsCreatedType
 
   xml do
-    root "vCard"
+    element "vCard"
     namespace VcardNamespace
     namespace_scope [VcardNamespace, DcNamespace]  <1>
 

--- a/docs/_guides/xml_mappings/05_common_patterns.adoc
+++ b/docs/_guides/xml_mappings/05_common_patterns.adoc
@@ -21,7 +21,7 @@ class Ceramic < Lutaml::Model::Serializable
   attribute :temperature, :integer
 
   xml do
-    root 'ceramic'
+    element "ceramic"
     map_element 'name', to: :name
     map_attribute 'temperature', to: :temperature
     map_content to: :description
@@ -58,7 +58,7 @@ class Glaze < Lutaml::Model::Serializable
   attribute :temperature, :integer
 
   xml do
-    root 'Glaze'
+    element "Glaze"
     map_element 'color', to: :color
     map_element 'temperature', to: :temperature
   end
@@ -69,7 +69,7 @@ class Ceramic < Lutaml::Model::Serializable
   attribute :glaze, Glaze
 
   xml do
-    root 'Ceramic'
+    element "Ceramic"
     map_element 'Type', to: :type
     map_element 'Glaze', to: :glaze
   end
@@ -102,7 +102,7 @@ class Ceramic < Lutaml::Model::Serializable
   attribute :glaze, :string
 
   xml do
-    root 'Ceramic'
+    element "Ceramic"
     namespace 'http://example.com/ceramic'
     map_element 'Type', to: :type
     map_element 'Glaze', to: :glaze
@@ -131,7 +131,7 @@ class Ceramic < Lutaml::Model::Serializable
   attribute :glaze, :string
 
   xml do
-    root 'Ceramic'
+    element "Ceramic"
     namespace 'http://example.com/ceramic', 'cer'
     map_element 'Type', to: :type
     map_element 'Glaze', to: :glaze
@@ -1146,7 +1146,7 @@ class Example < Lutaml::Model::Serializable
   attribute :note, :string
 
   xml do
-    root 'example'
+    element "example"
     map_element :name, to: :name, cdata: true
     map_content to: :description, cdata: true
     map_element :title, to: :title, cdata: false
@@ -1327,7 +1327,7 @@ class CeramicCollection < Lutaml::Model::Serializable
   attribute :items, Ceramic, collection: true
 
   xml do
-    root 'ceramics'
+    element "ceramics"
     map_element 'ceramic', to: :items
   end
 end
@@ -1354,7 +1354,7 @@ class TitleCollection < Lutaml::Model::Collection
   instances :items, :string
 
   xml do
-    root "titles"
+    element "titles"
     map_attribute "title", to: :items, delimiter: "; "
   end
 end
@@ -1387,7 +1387,7 @@ class JapaneseCeramic < Lutaml::Model::Serializable
   attribute :description, :string
 
   xml do
-    root 'JapaneseCeramic'
+    element "JapaneseCeramic"
     map_attribute 'glazeType', to: :glaze_type
     map_element 'description', to: :description
   end
@@ -1444,7 +1444,7 @@ class Address < Lutaml::Model::Serializable
   attribute :zip, :string
 
   xml do
-    no_root
+    # Type-only model - no element declaration needed
 
     map_element :street, to: :street
     map_element :city, to: :city
@@ -1457,7 +1457,7 @@ class Person < Lutaml::Model::Serializable
   import_model_attributes Address
 
   xml do
-    root "Person"
+    element "Person"
 
     map_element :name, to: :name
     sequence do
@@ -1617,14 +1617,14 @@ end
 # Use in document model
 class Document < Lutaml::Model::Serializable
   namespace DocumentNamespace
-  
+
   attribute :title, DcTitleType
   attribute :creator, DcCreatorType
   attribute :content, :string
 
   xml do
-    root 'document'
-    
+    element "document"
+
     map_element 'title', to: :title      # Uses DublinCoreNamespace
     map_element 'creator', to: :creator  # Uses DublinCoreNamespace
     map_element 'content', to: :content  # No type namespace
@@ -1704,7 +1704,7 @@ class Vcard < Lutaml::Model::Serializable
   attribute :created, DctermsCreatedType
 
   xml do
-    root "vCard"
+    element "vCard"
     namespace_scope [VcardNamespace, DcNamespace, DctermsNamespace]  <1>
 
     map_element "version", to: :version
@@ -1764,7 +1764,7 @@ class Ceramic < Lutaml::Model::Serializable
   attribute :color, :string
 
   xml do
-    root 'Ceramic'
+    element "Ceramic"
     namespace CeramicNamespace
     map_element 'Type', to: :type  # Inherits parent namespace (qualified)
     map_element 'Glaze', to: :glaze

--- a/docs/_guides/xml_mappings/06_migration_guide.adoc
+++ b/docs/_guides/xml_mappings/06_migration_guide.adoc
@@ -147,7 +147,7 @@ For models with complex namespace requirements:
 
 Replace `root()` with `element()` for clarity:
 
-1. Change `root 'element-name'` to `element 'element-name'`
+1. Change `element "element-name"` to `element 'element-name'`
 2. Move `mixed: true` to use `mixed_content` method
 3. Move `ordered: true` to use `ordered` method
 
@@ -476,7 +476,7 @@ end
 class DcTitleType < Lutaml::Model::Type::String
   namespace DublinCoreNamespace  # ⚠️ DEPRECATED
   xsd_type 'titleType'
-  
+
   def self.cast(value)
     super(value)
   end
@@ -484,7 +484,7 @@ end
 
 class Document < Lutaml::Model::Serializable
   attribute :title, DcTitleType
-  
+
   xml do
     root 'document'
     map_element 'title', to: :title
@@ -503,7 +503,7 @@ end
 class DcTitleType < Lutaml::Model::Type::String
   xml_namespace DublinCoreNamespace  # ✅ CURRENT
   xsd_type 'titleType'
-  
+
   def self.cast(value)
     super(value)
   end
@@ -511,7 +511,7 @@ end
 
 class Document < Lutaml::Model::Serializable
   attribute :title, DcTitleType
-  
+
   xml do
     root 'document'
     map_element 'title', to: :title

--- a/docs/_guides/xml_mappings/07_best_practices.adoc
+++ b/docs/_guides/xml_mappings/07_best_practices.adoc
@@ -46,14 +46,14 @@ end
 # Repeat namespace details in every model
 class Model1 < Lutaml::Model::Serializable
   xml do
-    root 'model1'
+    element "model1"
     namespace 'https://example.com/project/v1', 'proj'
   end
 end
 
 class Model2 < Lutaml::Model::Serializable
   xml do
-    root 'model2'
+    element "model2"
     namespace 'https://example.com/project/v1', 'proj'
   end
 end
@@ -134,7 +134,7 @@ class Document < Lutaml::Model::Serializable
   attribute :creator, DcCreatorType
 
   xml do
-    root 'document'
+    element "document"
     map_element 'title', to: :title      # dc:title automatically
     map_element 'creator', to: :creator  # dc:creator automatically
   end
@@ -145,7 +145,7 @@ class BookMetadata < Lutaml::Model::Serializable
   attribute :creator, DcCreatorType
 
   xml do
-    root 'book'
+    element "book"
     map_element 'title', to: :title      # dc:title automatically
     map_element 'creator', to: :creator  # dc:creator automatically
   end
@@ -162,7 +162,7 @@ class Document < Lutaml::Model::Serializable
   attribute :creator, :string
 
   xml do
-    root 'document'
+    element "document"
     # Repetitive and error-prone
     map_element 'title', to: :title,
       namespace: 'http://purl.org/dc/elements/1.1/', prefix: 'dc'
@@ -181,7 +181,7 @@ end
 # Consolidate frequently-used namespaces at root
 class Vcard < Lutaml::Model::Serializable
   xml do
-    root "vCard"
+    element "vCard"
     namespace VcardNamespace
     namespace_scope [VcardNamespace, DcNamespace, DctermsNamespace]
 
@@ -206,7 +206,7 @@ end
 # Without namespace_scope for multi-namespace documents
 class Vcard < Lutaml::Model::Serializable
   xml do
-    root "vCard"
+    element "vCard"
     namespace VcardNamespace
     # No namespace_scope
 
@@ -236,7 +236,7 @@ class Ceramic < Lutaml::Model::Serializable
     element 'ceramic'
     namespace CeramicNamespace
     # namespace_scope [CeramicNamespace]  # NOT NEEDED - only one namespace
-    
+
     map_element 'type', to: :type
     map_element 'glaze', to: :glaze
   end
@@ -250,7 +250,7 @@ end
 # Keep rarely-used namespaces local for clarity
 class Document < Lutaml::Model::Serializable
   xml do
-    root 'document'
+    element "document"
     namespace DocumentNamespace
     namespace_scope [DocumentNamespace]  # Only frequently used
 
@@ -284,7 +284,7 @@ end
 ----
 class Model < Lutaml::Model::Serializable
   xml do
-    root 'model'  # Backward compatible, still works
+    element "model"  # Backward compatible, still works
     map_element 'attr', to: :attr
   end
 end
@@ -441,7 +441,7 @@ end
 ----
 class RichText < Lutaml::Model::Serializable
   xml do
-    root 'text', mixed: true # DEPRECATED - use mixed_content instead
+    element "text", mixed: true # DEPRECATED - use mixed_content instead
     map_element 'b', to: :bold
   end
 end

--- a/docs/_migrations/0-8-0-namespace-restructuring.adoc
+++ b/docs/_migrations/0-8-0-namespace-restructuring.adoc
@@ -1359,7 +1359,7 @@ Version 0.8.0 unifies the `xml do` syntax for both model classes and custom Type
 class Person < Lutaml::Model::Serializable
   xml do
     namespace "http://example.com/ns", "p"  # Different syntax
-    root "person"
+    element "person"
   end
 end
 
@@ -1485,7 +1485,7 @@ Version 0.8.0 enforces **model-centric namespace definitions**. Namespaces are d
 ----
 class Parent < Lutaml::Model::Serializable
   xml do
-    root "parent"
+    element "parent"
     namespace "http://parent.com", "p"
 
     # ❌ Namespace on mapping - NO LONGER SUPPORTED

--- a/docs/_pages/attributes.adoc
+++ b/docs/_pages/attributes.adoc
@@ -808,7 +808,7 @@ class ReferenceSet < Lutaml::Model::Serializable
   ]
 
   xml do
-    root "ReferenceSet"
+    element "ReferenceSet"
 
     map_element "reference", to: :references, polymorphic: {
       # This refers to the attribute in the polymorphic model, you need
@@ -945,7 +945,7 @@ class SomeModel < Lutaml::Model::Serializable
   attribute :coll, :string, collection: true
 
   xml do
-    root "some-model"
+    element "some-model"
     map_element 'collection', to: :coll
   end
 

--- a/docs/_pages/collections.adoc
+++ b/docs/_pages/collections.adoc
@@ -145,7 +145,7 @@ class TitleDelimiterCollection < Lutaml::Model::Collection
   instances :items, :string
 
   xml do
-    root "titles"
+    element "titles"
     map_attribute "title", to: :items, delimiter: "; " <1>
   end
 end
@@ -164,7 +164,7 @@ class TitleCollection < Lutaml::Model::Collection
   instances :items, :string
 
   xml do
-    root "titles"
+    element "titles"
     map_attribute "title", to: :items, as_list: {
       import: ->(str) { str.split("; ") }, <1>
       export: ->(arr) { arr.join("; ") }, <2>
@@ -302,7 +302,6 @@ class TitleCollection < Lutaml::Model::Collection
   instances :titles, Title
 
   key_value do
-    no_root # default
     map_instances to: :titles
   end
 end
@@ -382,7 +381,6 @@ class TitleCollection < Lutaml::Model::Collection
   instances :titles, Title
 
   key_value do
-    no_root # default
     map_instances to: :titles
   end
 end
@@ -477,11 +475,11 @@ class MyCollection < Lutaml::Model::Collection
   instances :items, ModelType
 
   xml do
-    root "name-of-xml-container-element"
+    element "name-of-xml-container-element"
   end
 
   key_value do
-    root "name-of-key-value-container-element"
+    key "name-of-key-value-wrapper-key"
   end
 end
 
@@ -489,6 +487,15 @@ class ModelType < Lutaml::Model::Serializable
   attribute :name, :string
 end
 ----
+
+In the `key_value` block:
+
+- `key "key-name"` sets the wrapper key for the collection in key-value formats (JSON, YAML, TOML).
+  The serialized output wraps all instances under this key (e.g., `{"titles": [...]}`).
+- Without a `key` call (the default), instances are serialized directly at the top level
+  (e.g., `["Item One", "Item Two"]`).
+
+NOTE: Key-value formats use `key` to set the wrapper key name, and `element` for XML element names.
 
 A named collection can alternatively be implemented as a non-collection model
 ("Model class with an attribute") that contains the collection of instances. In
@@ -504,7 +511,7 @@ class Title < Lutaml::Model::Serializable
   attribute :title, :string
 
   xml do
-    root "title"
+    element "title"
     map_content to: :title
   end
 end
@@ -513,7 +520,7 @@ class DirectTitleCollection < Lutaml::Model::Collection
   instances :items, Title
 
   xml do
-    root "titles"
+    element "titles"
     map_element "title", to: :items
   end
 
@@ -639,7 +646,7 @@ class Title < Lutaml::Model::Serializable
   attribute :title, :string
 
   xml do
-    root "title"
+    element "title"
     map_element "content", to: :title
   end
 
@@ -652,12 +659,12 @@ class TitleCollection < Lutaml::Model::Collection
   instances :items, Title
 
   xml do
-    root "titles"
+    element "titles"
     map_element 'title', to: :items
   end
 
   key_value do
-    root "titles"
+    key "titles"
     map_instances to: :items
   end
 end
@@ -742,12 +749,12 @@ class BibliographicItem < Lutaml::Model::Serializable
   attribute :title_parts, :string, collection: StringParts
 
   xml do
-    root "titles"
+    element "titles"
     map_element "title", to: :title_parts
   end
 
   key_value do
-    root "titles"
+    key "titles"
     map_instances to: :title_parts
   end
 
@@ -829,7 +836,7 @@ class TitleCollection < Lutaml::Model::Collection
   instances :items, Title
 
   xml do
-    root "title-group"
+    element "title-group"
     map_element "artifact", to: :items
   end
 end
@@ -838,7 +845,7 @@ class BibItem < Lutaml::Model::Serializable
   attribute :titles, TitleCollection
 
   xml do
-    root "bibitem"
+    element "bibitem"
     # This overrides the collection's root "title-group"
     map_element "titles", to: :titles
   end
@@ -1367,12 +1374,11 @@ class OrderedItemCollection < Lutaml::Model::Collection
   ordered by: :id, order: :desc
 
   xml do
-    root "items"
+    element "items"
     map_element "item", to: :items
   end
 
   key_value do
-    no_root
     map_instances to: :items
   end
 end
@@ -1401,7 +1407,7 @@ class ProcOrderedItemCollection < Lutaml::Model::Collection
   ordered by: ->(item) { [item.name.length, item.name] }, order: :asc
 
   xml do
-    root "items"
+    element "items"
     map_element "item", to: :items
   end
 end
@@ -1543,7 +1549,7 @@ class ReferenceSet < Lutaml::Model::Collection
   ]
 
   xml do
-    root "ReferenceSet"
+    element "ReferenceSet"
     map_instances to: :references, polymorphic: {
       attribute: "_class",
       class_map: {
@@ -1640,7 +1646,7 @@ class ReferenceSet < Lutaml::Model::Collection
   ]
 
   xml do
-    root "ReferenceSet"
+    element "ReferenceSet"
     map_instances to: :references, polymorphic: {
       attribute: "_class",
       class_map: {

--- a/docs/_pages/consolidation-mapping.adoc
+++ b/docs/_pages/consolidation-mapping.adoc
@@ -76,7 +76,7 @@ class TitleCollection < Lutaml::Model::Collection
   organizes :per_lang, PerLangTitleGroup
 
   xml do
-    root "titles"
+    element "titles"
     map_instances to: :items
 
     consolidate_map by: :lang, to: :per_lang do
@@ -105,7 +105,7 @@ class IndividualTitle < Lutaml::Model::Serializable
   attribute :content, :string
 
   xml do
-    root "title"
+    element "title"
     map_attribute "lang", to: :lang
     map_attribute "type", to: :type_of_title
     map_content to: :content
@@ -127,7 +127,7 @@ class TitleCollection < Lutaml::Model::Collection
   organizes :per_lang, PerLangTitleGroup
 
   xml do
-    root "titles"
+    element "titles"
     map_instances to: :items
 
     consolidate_map by: :lang, to: :per_lang do
@@ -147,7 +147,7 @@ class Bibdata < Lutaml::Model::Serializable
   attribute :titles, IndividualTitle, collection: TitleCollection
 
   xml do
-    root "bibdata"
+    element "bibdata"
     map_element "title", to: :titles
   end
 end

--- a/docs/_pages/importable_models.adoc
+++ b/docs/_pages/importable_models.adoc
@@ -14,8 +14,9 @@ This feature works both with XML and key-value formats.
 
 * The import order determines how elements and attributes are overwritten.
 
-* An importable model with XML serialization mappings requires setting the model's
-XML serialization configuration with the `no_root` directive.
+* An importable model with XML serialization mappings is a "type-only model" —
+  it has no `element` declaration in its `xml` block, meaning it can only be
+  used as an embedded type through a parent model.
 
 The model can be imported into another model using the following directives:
 
@@ -25,11 +26,11 @@ The model can be imported into another model using the following directives:
 
 `import_model_mappings`:: imports only mappings.
 
-NOTE: Models with `no_root` can only be parsed through parent models.
-Direct calling `NoRootModel.from_xml` will raise a `NoRootMappingError`.
+NOTE: Type-only models (no `element` declaration) can only be parsed through parent models.
+Directly calling `TypeOnlyModel.from_xml` will raise a `TypeOnlyMappingError`.
 
 NOTE: Namespaces are not currently supported in importable models.
-If `namespace` is defined with `no_root`, `NoRootNamespaceError` will be raised.
+If `namespace` is defined with the deprecated `no_root`, `TypeOnlyNamespaceError` will be raised.
 
 .Importing model components using an importable model
 [example]
@@ -51,7 +52,7 @@ class GroupOfItems < Lutaml::Model::Serializable
   attribute :code, :string
 
   xml do
-    no_root
+    # Type-only model - no element declaration needed
     sequence do
       map_element "name", to: :name
       map_element "type", to: :type
@@ -67,7 +68,7 @@ class ComplexType < Lutaml::Model::Serializable
   import_model_attributes GroupOfItems
 
   xml do
-    root "GroupOfItems"
+    element "GroupOfItems"
 
     map_attribute "tag", to: :tag
     map_content to: :content
@@ -96,7 +97,7 @@ end
 [source,ruby]
 ----
 > parsed = GroupOfItems.from_xml(xml)
-> # Lutaml::Model::NoRootMappingError: "GroupOfItems has `no_root`, it allowed only for reusable models"
+> # Lutaml::Model::TypeOnlyMappingError: "GroupOfItems is a type-only model (no element declared), ..."
 ----
 ====
 
@@ -124,7 +125,7 @@ class Address < Lutaml::Model::Serializable
   attribute :zip, :string
 
   xml do
-    no_root
+    # Type-only model - no element declaration needed
 
     map_element :street, to: :street
     map_element :city, to: :city
@@ -137,7 +138,7 @@ class Person < Lutaml::Model::Serializable
   import_model_attributes Address
 
   xml do
-    root "Person"
+    element "Person"
 
     map_element :name, to: :name
     sequence do
@@ -193,7 +194,7 @@ class ContactEmail < Lutaml::Model::Serializable
   attribute :email, :string
 
   xml do
-    no_root
+    # Type-only model - no element declaration needed
 
     map_element :email, to: :email
   end
@@ -203,7 +204,7 @@ class ContactPhone < Lutaml::Model::Serializable
   attribute :phone, :string
 
   xml do
-    no_root
+    # Type-only model - no element declaration needed
 
     map_element :phone, to: :phone
   end
@@ -217,7 +218,7 @@ class Person < Lutaml::Model::Serializable
   end
 
   xml do
-    root "Person"
+    element "Person"
 
     map_element :email, to: :email
     map_element :phone, to: :phone

--- a/docs/_pages/quick-start.adoc
+++ b/docs/_pages/quick-start.adoc
@@ -56,7 +56,7 @@ class Person < Lutaml::Model::Serializable
   attribute :age, :integer
 
   xml do
-    root "person"
+    element "person"
     map_element "name", to: :name
     map_element "age", to: :age
   end

--- a/docs/_pages/value_types.adoc
+++ b/docs/_pages/value_types.adoc
@@ -92,7 +92,7 @@ class Event < Lutaml::Model::Serializable
   attribute :start_date, :date
 
   xml do
-    root "event"
+    element "event"
     map_element "startDate", to: :start_date
   end
 
@@ -150,7 +150,7 @@ class ProcessingTask < Lutaml::Model::Serializable
   attribute :processing_time, :duration
 
   xml do
-    root "task"
+    element "task"
     map_element "processingTime", to: :processing_time
   end
 end
@@ -180,7 +180,7 @@ class Resource < Lutaml::Model::Serializable
   attribute :schema_location, :uri
 
   xml do
-    root "resource"
+    element "resource"
     map_element "homepage", to: :homepage
     map_attribute "schemaLocation", to: :schema_location
   end
@@ -215,7 +215,7 @@ class Reference < Lutaml::Model::Serializable
   attribute :target, :qname
 
   xml do
-    root "reference"
+    element "reference"
     map_attribute "type", to: :ref_type
     map_element "target", to: :target
   end
@@ -253,7 +253,7 @@ class Attachment < Lutaml::Model::Serializable
   attribute :filename, :string
 
   xml do
-    root "attachment"
+    element "attachment"
     map_element "content", to: :content
     map_attribute "filename", to: :filename
   end
@@ -294,7 +294,7 @@ class Checksum < Lutaml::Model::Serializable
   attribute :algorithm, :string
 
   xml do
-    root "checksum"
+    element "checksum"
     map_element "value", to: :hash_value
     map_attribute "algorithm", to: :algorithm
   end
@@ -360,7 +360,7 @@ class Article < Lutaml::Model::Serializable
   attribute :title, :string
 
   xml do
-    root "article"
+    element "article"
     map_attribute "lang", to: :lang
     map_attribute "space", to: :space
     map_attribute "id", to: :id
@@ -486,7 +486,7 @@ class Task < Lutaml::Model::Serializable
   attribute :priority, :symbol
 
   xml do
-    root "task"
+    element "task"
     map_element "status", to: :status
     map_element "priority", to: :priority
   end
@@ -731,7 +731,7 @@ class Address < Lutaml::Model::Serializable
 
   # Define how this complex object maps to different formats
   xml do
-    root "Address"
+    element "Address"
     map_element "Street", to: :street
     map_element "City", to: :city
     map_element "PostalCode", to: :postal_code
@@ -1051,7 +1051,7 @@ end
 class Ceramic < Lutaml::Model::Serializable
   attribute :kiln_firing_time, HighPrecisionDateTime
   xml do
-    root 'ceramic'
+    element "ceramic"
     map_element 'kilnFiringTime', to: :kiln_firing_time
     # ...
   end

--- a/docs/_references/custom_registers.adoc
+++ b/docs/_references/custom_registers.adoc
@@ -449,7 +449,7 @@ module Mml
     attribute :mrow, Mrow
 
     xml do
-      root "math"
+      element "math"
     end
   end
 end
@@ -545,7 +545,7 @@ class MyDocument < Lutaml::Model::Serializable
   attribute :math, Mml::V2::Math  # Has lutaml_default_register = :mml_v2
 
   xml do
-    root "document"
+    element "document"
     map_element "math", to: :math
   end
 end
@@ -639,7 +639,7 @@ module Mml
     attribute :mi_value, :string
 
     xml do
-      root "mmultiscripts"
+      element "mmultiscripts"
       map_element "mi", to: :mi_value
     end
   end
@@ -648,7 +648,7 @@ module Mml
     attribute :mmultiscripts_value, Mmultiscripts, collection: true
 
     xml do
-      root "math"
+      element "math"
       map_element "mmultiscripts", to: :mmultiscripts_value
     end
   end
@@ -665,7 +665,7 @@ class MyDocument < Lutaml::Model::Serializable
   attribute :math, Mml::Math
 
   xml do
-    root "document"
+    element "document"
     map_attribute "id", to: :id
     map_element "math", to: :math
   end
@@ -704,7 +704,7 @@ class MyDocument < Lutaml::Model::Serializable
   attribute :math, Mml::V2::Math  # Has lutaml_default_register = :mml_v2
 
   xml do
-    root "document"
+    element "document"
     map_element "math", to: :math
   end
 end
@@ -776,7 +776,7 @@ class Article < Lutaml::Model::Serializable
   attribute :formula, Mml::V2::Math
 
   xml do
-    root "article"
+    element "article"
     map_element "math", to: :formula
   end
 end

--- a/docs/_references/format-independent-features.adoc
+++ b/docs/_references/format-independent-features.adoc
@@ -126,7 +126,7 @@ class Ceramic < Lutaml::Model::Serializable
 
   # Mapping-level transformation in XML format
   xml do
-    root "Ceramic"
+    element "Ceramic"
     map_attribute "glaze-type", to: :glaze_type, transform: {
       export: ->(value) { "Traditional #{value}" },
       import: ->(value) { value.gsub("Traditional ", "") }
@@ -234,7 +234,7 @@ class Ceramic < Lutaml::Model::Serializable
 
   # Mapping-level transformation in XML format
   xml do
-    root "Ceramic"
+    element "Ceramic"
     map_attribute "glaze-type", to: :glaze_type, transform: {
       export: ->(value) { "Traditional #{value}" },
       import: ->(value) { value.gsub("Traditional ", "") }
@@ -454,7 +454,7 @@ class CombinedTransformModel < Lutaml::Model::Serializable
   end
 
   xml do
-    root "CombinedTransformModel"
+    element "CombinedTransformModel"
     map_element "title", to: :title, transform: SuffixTransformer
   end
 end
@@ -662,7 +662,7 @@ class Glaze < Lutaml::Model::Serializable
   attribute :firing_time, :integer, default: -> { 60 }
 
   xml do
-    root "glaze"
+    element "glaze"
     map_element 'color', to: :color
     map_element 'opacity', to: :opacity, render_default: true
     map_attribute 'temperature', to: :temperature

--- a/docs/_references/instance-serialization.adoc
+++ b/docs/_references/instance-serialization.adoc
@@ -31,7 +31,7 @@ class JapaneseCeramic < Lutaml::Model::Serializable
   attribute :description, :string
 
   xml do
-    root 'JapaneseCeramic'
+    element "JapaneseCeramic"
     map_attribute 'glazeType', to: :glaze_type
     map_element 'description', to: :description
   end

--- a/docs/_references/parent-root-context.adoc
+++ b/docs/_references/parent-root-context.adoc
@@ -34,7 +34,7 @@ class Tag < Lutaml::Model::Serializable
   attribute :text, :string
 
   xml do
-    root "Tag"
+    element "Tag"
 
     map_content to: :text
   end
@@ -48,7 +48,7 @@ class Tags < Lutaml::Model::Serializable
   attribute :tag, Tag, collection: true
 
   xml do
-    root "Tags"
+    element "Tags"
 
     map_element "Tag", to: :tag
   end
@@ -62,7 +62,7 @@ class Post < Lutaml::Model::Serializable
   attribute :tags, Tags, collection: true
 
   xml do
-    root "Post"
+    element "Post"
     map_element "Tags", to: :tags
   end
 

--- a/docs/_tutorials/basic-model-definition.adoc
+++ b/docs/_tutorials/basic-model-definition.adoc
@@ -121,7 +121,7 @@ class Kiln < Lutaml::Model::Serializable
   attribute :temperature, :integer
 
   xml do
-    root 'kiln'
+    element "kiln"
     map_element 'brand', to: :brand
     map_element 'capacity', to: :capacity
     map_element 'temperature', to: :temperature

--- a/docs/_tutorials/first-xml-serialization.adoc
+++ b/docs/_tutorials/first-xml-serialization.adoc
@@ -74,7 +74,7 @@ class Example < Lutaml::Model::Serializable
   attribute :name, :string
 
   xml do
-    root 'example'
+    element "example"
     map_element 'name', to: :name
   end
 end
@@ -116,7 +116,7 @@ class Example < Lutaml::Model::Serializable
   attribute :value, :integer
 
   xml do
-    root 'example'
+    element "example"
     map_attribute 'value', to: :value
   end
 end
@@ -158,7 +158,7 @@ class Example < Lutaml::Model::Serializable
   attribute :description, :string
 
   xml do
-    root 'example'
+    element "example"
     map_content to: :description
   end
 end
@@ -192,7 +192,7 @@ class Ceramic < Lutaml::Model::Serializable
   attribute :temperature, :integer
 
   xml do
-    root 'ceramic'
+    element "ceramic"
     map_element 'name', to: :name
     map_attribute 'temperature', to: :temperature
     map_content to: :description

--- a/docs/_tutorials/lutaml-xml-architecture.adoc
+++ b/docs/_tutorials/lutaml-xml-architecture.adoc
@@ -576,7 +576,7 @@ end
 ```ruby
 class PurchaseOrder < Lutaml::Model::Serializable
   xml do
-    root "purchaseOrder"                    # Root element name
+    element "purchaseOrder"                    # Root element name
     namespace PoNamespace                    # Model namespace
 
     map_element "shipTo", to: :ship_to       # Map element
@@ -654,7 +654,7 @@ class Book < Lutaml::Model::Serializable
   attribute :author, Person
 
   xml do
-    root "Book"
+    element "Book"
     namespace BookNamespace
     map_element "title", to: :title
     map_element "author", to: :author
@@ -979,7 +979,7 @@ class PurchaseOrder < Lutaml::Model::Serializable
   attribute :comment, :string
 
   xml do
-    root "purchaseOrder"
+    element "purchaseOrder"
     namespace PoNamespace
     map_element "comment", to: :comment
   end
@@ -1062,7 +1062,7 @@ class Document < Lutaml::Model::Serializable
   attribute :title, DcTitleType
 
   xml do
-    root "document"
+    element "document"
     map_element "title", to: :title
   end
 end

--- a/docs/_tutorials/validation-basics.adoc
+++ b/docs/_tutorials/validation-basics.adoc
@@ -152,7 +152,7 @@ class Contact < Lutaml::Model::Serializable
   end
 
   xml do
-    root "contact"
+    element "contact"
     map_element "email", to: :email
     map_element "phone", to: :phone
   end

--- a/docs/_tutorials/working-with-collections.adoc
+++ b/docs/_tutorials/working-with-collections.adoc
@@ -39,7 +39,7 @@ class Studio < Lutaml::Model::Serializable
   attribute :potters, :string, collection: true
 
   xml do
-    root 'studio'
+    element "studio"
     map_element 'name', to: :name
     map_element 'potter', to: :potters
   end
@@ -142,7 +142,7 @@ class PotterCollection < Lutaml::Model::Collection
   instances :potters, Potter
 
   json do
-    root "potters"
+    key "potters"
     map_instances to: :potters
   end
 end

--- a/docs/_tutorials/xml-namespaces-basics.adoc
+++ b/docs/_tutorials/xml-namespaces-basics.adoc
@@ -70,7 +70,7 @@ class Ceramic < Lutaml::Model::Serializable
   attribute :glaze, :string
 
   xml do
-    root 'Ceramic'
+    element "Ceramic"
     namespace CeramicNamespace
 
     map_element 'Type', to: :type

--- a/docs/_tutorials/xml-schema-primer-style-guide.adoc
+++ b/docs/_tutorials/xml-schema-primer-style-guide.adoc
@@ -46,7 +46,7 @@ class UsAddress < Lutaml::Model::Serializable
   attribute :zip, :decimal
 
   xml do
-    root "USAddress"
+    element "USAddress"
     map_element "name", to: :name
     map_element "street", to: :street
     map_element "city", to: :city
@@ -81,7 +81,7 @@ class PurchaseOrder < Lutaml::Model::Serializable
   attribute :comment, :string
 
   xml do
-    root "purchaseOrder"
+    element "purchaseOrder"
     map_element "shipTo", to: :ship_to
     map_element "billTo", to: :bill_to
     map_element "comment", to: :comment
@@ -123,7 +123,7 @@ class PurchaseOrder < Lutaml::Model::Serializable
   attribute :ship_to, UsAddress
 
   xml do
-    root "purchaseOrder"
+    element "purchaseOrder"
     map_attribute "orderDate", to: :order_date
     map_element "shipTo", to: :ship_to
   end
@@ -157,7 +157,7 @@ class Item < Lutaml::Model::Serializable
   attribute :us_price, :decimal
 
   xml do
-    root "Item"
+    element "Item"
     map_element "productName", to: :product_name
     map_element "quantity", to: :quantity
     map_element "USPrice", to: :us_price
@@ -168,7 +168,7 @@ class PurchaseOrder < Lutaml::Model::Serializable
   attribute :items, Item, collection: true
 
   xml do
-    root "purchaseOrder"
+    element "purchaseOrder"
     map_element "items", to: :items
   end
 end
@@ -239,7 +239,7 @@ class PurchaseOrder < Lutaml::Model::Serializable
   attribute :bill_to, UsAddress
 
   xml do
-    root "purchaseOrder"
+    element "purchaseOrder"
     namespace PoNamespace
 
     map_element "shipTo", to: :ship_to
@@ -288,7 +288,7 @@ class PurchaseOrder < Lutaml::Model::Serializable
   attribute :ship_to, UsAddress
 
   xml do
-    root "purchaseOrder"
+    element "purchaseOrder"
     namespace PoNamespace
 
     map_element "shipTo", to: :ship_to
@@ -350,7 +350,7 @@ class PurchaseOrder < Lutaml::Model::Serializable
   attribute :order_date, :string
 
   xml do
-    root "purchaseOrder"
+    element "purchaseOrder"
     namespace PoNamespace
 
     map_attribute "orderDate", to: :order_date
@@ -418,7 +418,7 @@ class PurchaseOrder < Lutaml::Model::Serializable
   attribute :comment, :string  # This one will be unqualified
 
   xml do
-    root "purchaseOrder"
+    element "purchaseOrder"
     namespace PoNamespace
 
     map_element "shipTo", to: :ship_to
@@ -489,7 +489,7 @@ class Document < Lutaml::Model::Serializable
   attribute :title, DcTitleType  # Automatically uses DcNamespace
 
   xml do
-    root "document"
+    element "document"
     map_element "title", to: :title
   end
 end
@@ -542,7 +542,7 @@ class Metadata < Lutaml::Model::Serializable
   attribute :created, DctermsCreatedType
 
   xml do
-    root "metadata"
+    element "metadata"
     map_element "title", to: :title
     map_element "created", to: :created
   end
@@ -586,7 +586,7 @@ class Document < Lutaml::Model::Serializable
   attribute :title, DcTitleType
 
   xml do
-    root "document"
+    element "document"
     namespace ModelNamespace  # Model namespace
     map_element "title", to: :title  # Uses Type namespace (DcNamespace)
   end
@@ -620,7 +620,7 @@ class Document < Lutaml::Model::Serializable
   attribute :title, DcTitleType
 
   xml do
-    root "document"
+    element "document"
     map_element "title", to: :title, namespace: OverrideNamespace
   end
 end
@@ -659,7 +659,7 @@ class Document < Lutaml::Model::Serializable
   attribute :schema_type, XsiTypeType
 
   xml do
-    root "document"
+    element "document"
     map_attribute "name", to: :name
     map_attribute "type", to: :schema_type
   end
@@ -701,7 +701,7 @@ class PurchaseOrder < Lutaml::Model::Serializable
   attribute :ship_to, UsAddress
 
   xml do
-    root "purchaseOrder"
+    element "purchaseOrder"
     namespace PoNamespace
     map_element "shipTo", to: :ship_to
   end
@@ -749,7 +749,7 @@ The `namespace_scope` directive consolidates multiple namespace declarations at 
 ----
 class Document < Lutaml::Model::Serializable
   xml do
-    root "document"
+    element "document"
     namespace RootNamespace
 
     # Hoist multiple namespaces to root
@@ -794,7 +794,7 @@ class Vcard < Lutaml::Model::Serializable
   attribute :title, DcTitleType
 
   xml do
-    root "vCard"
+    element "vCard"
     namespace VcardNamespace
 
     # Hoist DcNamespace to root
@@ -882,7 +882,7 @@ class Address < Lutaml::Model::Serializable
   attribute :city, :string
 
   xml do
-    root "Address"
+    element "Address"
     map_element "street", to: :street
     map_element "city", to: :city
   end
@@ -893,7 +893,7 @@ class Person < Lutaml::Model::Serializable
   attribute :address, Address
 
   xml do
-    root "Person"
+    element "Person"
     map_element "name", to: :name
     map_element "address", to: :address
   end
@@ -934,7 +934,7 @@ class Person < Lutaml::Model::Serializable
   attribute :work_address, AddressType
 
   xml do
-    root "Person"
+    element "Person"
     map_element "homeAddress", to: :home_address
     map_element "workAddress", to: :work_address
   end
@@ -975,7 +975,7 @@ class Item < Lutaml::Model::Serializable
   attribute :price, Price
 
   xml do
-    root "Item"
+    element "Item"
     map_element "name", to: :name
     map_attribute "price", to: :price
   end
@@ -1017,7 +1017,7 @@ class Product < Lutaml::Model::Serializable
   attribute :release_date, :date
 
   xml do
-    root "Product"
+    element "Product"
     map_element "name", to: :name
     map_element "price", to: :price
     map_element "quantity", to: :quantity
@@ -1055,7 +1055,7 @@ class Item < Lutaml::Model::Serializable
   attribute :price, UsPriceType
 
   xml do
-    root "Item"
+    element "Item"
     map_element "USPrice", to: :price
   end
 end
@@ -1106,7 +1106,7 @@ class Address < Lutaml::Model::Serializable
   attribute :city, :string
 
   xml do
-    root "Address"
+    element "Address"
     map_element "name", to: :name
     map_element "street", to: :street
     map_element "city", to: :city
@@ -1118,7 +1118,7 @@ class InternationalAddress < Address
   attribute :country, :string
 
   xml do
-    root "InternationalAddress"
+    element "InternationalAddress"
     map_element *Address.mappings  # Inherit mappings
     map_element "country", to: :country
   end
@@ -1140,7 +1140,7 @@ class Shipment < Lutaml::Model::Serializable
   attribute :address, Address
 
   xml do
-    root "Shipment"
+    element "Shipment"
     namespace_scope [XsiNamespace]
     map_element "address", to: :address
   end
@@ -1231,7 +1231,7 @@ class UsAddress < Lutaml::Model::Serializable
   attribute :zip, :decimal
 
   xml do
-    root "USAddress"
+    element "USAddress"
     map_element "name", to: :name
     map_element "street", to: :street
     map_element "city", to: :city
@@ -1247,7 +1247,7 @@ class Item < Lutaml::Model::Serializable
   attribute :comment, :string
 
   xml do
-    root "Item"
+    element "Item"
     map_element "productName", to: :product_name
     map_element "quantity", to: :quantity
     map_element "USPrice", to: :us_price
@@ -1264,7 +1264,7 @@ class PurchaseOrder < Lutaml::Model::Serializable
   attribute :created, DctermsCreatedType
 
   xml do
-    root "purchaseOrder"
+    element "purchaseOrder"
     namespace PoNamespace
 
     namespace_scope [

--- a/docs/cli_compare.adoc
+++ b/docs/cli_compare.adoc
@@ -69,7 +69,7 @@ class TermiumExtract < Lutaml::Model::Serializable
   attribute :extract_language, ExtractLanguage, collection: true
 
   xml do
-    root "termium_extract"
+    element "termium_extract"
     namespace "http://termium.tpsgc-pwgsc.gc.ca/schemas/2012/06/Termium", "ns2"
 
     map_attribute "language", to: :language

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -56,7 +56,7 @@ class Person < Lutaml::Model::Serializable
   attribute :age, :integer
 
   xml do
-    root "person"
+    element "person"
     map_element "name", to: :name
     map_element "age", to: :age
   end

--- a/docs/namespace-management.adoc
+++ b/docs/namespace-management.adoc
@@ -110,10 +110,10 @@ IMPORTANT: `namespace_scope` grants **ELIGIBILITY** to hoist namespaces to the r
 ----
 xml do
   namespace RootNamespace
-  
+
   # Simple list (all use :auto mode)
   namespace_scope [Namespace1, Namespace2, Namespace3]
-  
+
   # Per-namespace control with hash format
   namespace_scope [
     { namespace: Namespace1, declare: :always },
@@ -169,7 +169,7 @@ class Vcard < Lutaml::Model::Serializable
   attribute :email, :string
 
   xml do
-    root "vCard"
+    element "vCard"
     namespace VcardNamespace
 
     map_element "version", to: :version
@@ -244,7 +244,7 @@ class Contact < Lutaml::Model::Serializable
   attribute :note, DcTitleType
 
   xml do
-    root "contact"
+    element "contact"
 
     map_element "title", to: :title
     map_element "note", to: :note
@@ -255,7 +255,7 @@ class Vcard < Lutaml::Model::Serializable
   attribute :contact, Contact
 
   xml do
-    root "vCard"
+    element "vCard"
     namespace VcardNamespace
 
     map_element "contact", to: :contact
@@ -300,7 +300,7 @@ class Vcard < Lutaml::Model::Serializable
   attribute :contact, Contact
 
   xml do
-    root "vCard"
+    element "vCard"
     namespace VcardNamespace
 
     # Hoist DcNamespace to root
@@ -395,7 +395,7 @@ class Metadata < Lutaml::Model::Serializable
   attribute :format, XsiTypeType
 
   xml do
-    root "metadata"
+    element "metadata"
 
     map_element "title", to: :title
     map_element "creator", to: :creator
@@ -411,7 +411,7 @@ class Vcard < Lutaml::Model::Serializable
   attribute :metadata, Metadata
 
   xml do
-    root "vCard"
+    element "vCard"
     namespace VcardNamespace
 
     # Consolidate all namespaces at root
@@ -483,7 +483,7 @@ class Vcard < Lutaml::Model::Serializable
   # No DcTitleType attributes used
 
   xml do
-    root "vCard"
+    element "vCard"
     namespace VcardNamespace
 
     # Try to hoist unused DcNamespace
@@ -630,7 +630,7 @@ class Parent < Lutaml::Model::Serializable
   attribute :child_value, :string
 
   xml do
-    root "parent"
+    element "parent"
     namespace ParentNamespace
 
     map_element "child", to: :child_value
@@ -826,7 +826,7 @@ class Document < Lutaml::Model::Serializable
   attribute :title, DcTitleType  # Automatically uses DcNamespace
 
   xml do
-    root "document"
+    element "document"
     namespace DocumentNamespace
 
     map_element "title", to: :title  # Becomes <dc:title>
@@ -845,7 +845,7 @@ Simplest case—all elements in one namespace:
 ----
 class Document < Lutaml::Model::Serializable
   xml do
-    root "document"
+    element "document"
     namespace DocumentNamespace
     # No namespace_scope needed
   end
@@ -863,7 +863,7 @@ class Document < Lutaml::Model::Serializable
   attribute :created, DctermsCreatedType  # DctermsNamespace
 
   xml do
-    root "document"
+    element "document"
     namespace DocumentNamespace
     # No namespace_scope - Type namespaces hoist locally
   end
@@ -881,7 +881,7 @@ class Document < Lutaml::Model::Serializable
   attribute :created, DctermsCreatedType
 
   xml do
-    root "document"
+    element "document"
     namespace DocumentNamespace
 
     # Hoist all Type namespaces to root

--- a/lib/lutaml/key_value/mapping.rb
+++ b/lib/lutaml/key_value/mapping.rb
@@ -21,20 +21,45 @@ module Lutaml
         @finalized
       end
 
+      # Set the wrapper key for key-value serialization (JSON, YAML, TOML).
+      #
+      # When set, serialized output wraps all instances under this key
+      # (e.g., `key "items"` produces `{"items": [...]}`).
+      # When not called (or called with nil), instances are serialized directly
+      # at the top level (e.g., `[...]`).
+      #
+      # @param name [String, nil] the wrapper key name
+      def key(name = nil)
+        @key = name
+      end
+
+      def key_name
+        @key
+      end
+
+      # @deprecated Use {#key} instead. In key-value formats, the wrapper is a key, not a root.
       def root(name = nil)
-        @root = name
+        @key = name
       end
 
+      # @deprecated Omit key call instead. Not calling key means no wrapper key.
       def no_root
-        @root = nil
+        @key = nil
       end
 
+      # Returns true when no wrapper key is set (instances serialized at top level).
+      def no_key?
+        @key.nil?
+      end
+
+      # @deprecated Use {#no_key?} instead.
       def no_root?
-        @root.nil?
+        no_key?
       end
 
+      # @deprecated Use {#key_name} instead.
       def root_name
-        @root
+        @key
       end
 
       def map(
@@ -104,7 +129,7 @@ module Lutaml
 
       def map_instances(to:, polymorphic: {})
         @instance = to
-        map(root_name || to, to: to, polymorphic: polymorphic)
+        map(key_name || to, to: to, polymorphic: polymorphic)
         map_to_instance
       end
 
@@ -125,7 +150,7 @@ module Lutaml
       def map_to_instance
         return if !instance_mapping?
 
-        mapping_name = name_for_mapping(nil, root_name || @instance)
+        mapping_name = name_for_mapping(nil, key_name || @instance)
         @mappings[mapping_name].child_mappings = @key_mapping.merge(@value_mapping)
       end
 

--- a/lib/lutaml/model.rb
+++ b/lib/lutaml/model.rb
@@ -149,6 +149,7 @@ module Lutaml
              "#{__dir__}/model/error/incorrect_sequence_error"
     autoload :ChoiceUpperBoundError,
              "#{__dir__}/model/error/choice_upper_bound_error"
+    autoload :TypeOnlyMappingError, "#{__dir__}/model/error/type_only_mapping_error"
     autoload :NoRootMappingError, "#{__dir__}/model/error/no_root_mapping_error"
     autoload :ImportModelWithRootError,
              "#{__dir__}/model/error/import_model_with_root_error"
@@ -160,6 +161,8 @@ module Lutaml
              "#{__dir__}/model/error/choice_lower_bound_error"
     autoload :NoMappingFoundError,
              "#{__dir__}/model/error/no_mapping_found_error"
+    autoload :TypeOnlyNamespaceError,
+             "#{__dir__}/model/error/type_only_namespace_error"
     autoload :NoRootNamespaceError,
              "#{__dir__}/model/error/no_root_namespace_error"
     autoload :PolymorphicError, "#{__dir__}/model/error/polymorphic_error"

--- a/lib/lutaml/model/collection.rb
+++ b/lib/lutaml/model/collection.rb
@@ -310,8 +310,8 @@ module Lutaml
         def to(format, instance, options = {})
           mappings = mappings_for(format)
 
-          if mappings.no_root? && collection_no_root_to?(format)
-            collection_no_root_to(format, mappings, instance, options)
+          if mappings.no_root? && collection_unwrapped_to?(format)
+            collection_unwrapped_to(format, mappings, instance, options)
           else
             super(format, instance, options.merge(collection: true))
           end
@@ -322,7 +322,7 @@ module Lutaml
           data = super
 
           if !collection_structured_format?(format) && mappings.no_root? && !mappings.root_mapping
-            unwrap_no_root_data(data)
+            unwrap_unwrapped_data(data)
           else
             data
           end
@@ -332,7 +332,7 @@ module Lutaml
           mappings = mappings_for(format)
 
           if collection_structured_format?(format) && mappings.no_root?
-            data = wrap_no_root_input(format, mappings, data)
+            data = wrap_unwrapped_input(format, mappings, data)
           end
 
           super(format, data, options.merge(from_collection: true))
@@ -355,21 +355,21 @@ module Lutaml
           false
         end
 
-        # Hook: returns true if this format handles no_root serialization specially.
+        # Hook: returns true if this format handles unwrapped serialization specially.
         # XML overrides to return true for :xml format.
-        def collection_no_root_to?(_format)
+        def collection_unwrapped_to?(_format)
           false
         end
 
-        # Hook for structured-format no_root serialization (e.g., XML).
+        # Hook for unwrapped serialization (e.g., XML).
         # XML overrides to serialize each mapping separately.
-        def collection_no_root_to(_format, _mappings, _instance, _options)
+        def collection_unwrapped_to(_format, _mappings, _instance, _options)
           raise NotImplementedError
         end
 
-        # Hook for structured-format no_root input wrapping (e.g., XML).
+        # Hook for wrapping unwrapped input (e.g., XML).
         # XML overrides to wrap raw data in a fake root tag.
-        def wrap_no_root_input(_format, _mappings, data)
+        def wrap_unwrapped_input(_format, _mappings, data)
           data
         end
 
@@ -379,7 +379,7 @@ module Lutaml
 
         private
 
-        def unwrap_no_root_data(data)
+        def unwrap_unwrapped_data(data)
           # Convert KeyValueElement to Hash if needed
           hash = data.is_a?(Hash) ? data : data.to_hash
           # Handle "__root__" wrapper for key-value formats (created by transformation)

--- a/lib/lutaml/model/error/no_root_mapping_error.rb
+++ b/lib/lutaml/model/error/no_root_mapping_error.rb
@@ -1,9 +1,10 @@
+# frozen_string_literal: true
+
+require_relative "type_only_mapping_error"
+
 module Lutaml
   module Model
-    class NoRootMappingError < Error
-      def initialize(model)
-        super("#{model} has `no_root`, it allowed only for reusable models")
-      end
-    end
+    # @deprecated Use {TypeOnlyMappingError} instead.
+    NoRootMappingError = TypeOnlyMappingError
   end
 end

--- a/lib/lutaml/model/error/no_root_namespace_error.rb
+++ b/lib/lutaml/model/error/no_root_namespace_error.rb
@@ -1,9 +1,10 @@
+# frozen_string_literal: true
+
+require_relative "type_only_namespace_error"
+
 module Lutaml
   module Model
-    class NoRootNamespaceError < Error
-      def to_s
-        "Cannot assign namespace to `no_root`"
-      end
-    end
+    # @deprecated Use {TypeOnlyNamespaceError} instead.
+    NoRootNamespaceError = TypeOnlyNamespaceError
   end
 end

--- a/lib/lutaml/model/error/type_only_mapping_error.rb
+++ b/lib/lutaml/model/error/type_only_mapping_error.rb
@@ -1,0 +1,13 @@
+module Lutaml
+  module Model
+    class TypeOnlyMappingError < Error
+      def initialize(model)
+        super("#{model} is a type-only model (no element declared), " \
+              "it can only be used as an embedded type through a parent model.")
+      end
+    end
+
+    # @deprecated Use {TypeOnlyMappingError} instead.
+    NoRootMappingError = TypeOnlyMappingError
+  end
+end

--- a/lib/lutaml/model/error/type_only_namespace_error.rb
+++ b/lib/lutaml/model/error/type_only_namespace_error.rb
@@ -1,0 +1,12 @@
+module Lutaml
+  module Model
+    class TypeOnlyNamespaceError < Error
+      def to_s
+        "Cannot assign namespace to a type-only model (no element declared)."
+      end
+    end
+
+    # @deprecated Use {TypeOnlyNamespaceError} instead.
+    NoRootNamespaceError = TypeOnlyNamespaceError
+  end
+end

--- a/lib/lutaml/xml.rb
+++ b/lib/lutaml/xml.rb
@@ -228,7 +228,7 @@ end
 Lutaml::Model::Attribute.format_specific_warn_names.push(:element_order,
                                                          :schema_location, :encoding, :doctype, :ordered?, :mixed?)
 
-# Prepend XML-specific Collection overrides (no_root handling for XML)
+# Prepend XML-specific Collection overrides (unwrapped collection handling for XML)
 require_relative "xml/serialization/collection_ext"
 Lutaml::Model::Collection.singleton_class.prepend(
   Lutaml::Xml::Serialization::CollectionExt,

--- a/lib/lutaml/xml.rb
+++ b/lib/lutaml/xml.rb
@@ -134,7 +134,6 @@ module Lutaml
     autoload :ElementPrefixResolver, "#{__dir__}/xml/element_prefix_resolver"
     autoload :FormatChooser, "#{__dir__}/xml/format_chooser"
     autoload :HoistingAlgorithm, "#{__dir__}/xml/hoisting_algorithm"
-    autoload :HoistingAlgorithm, "#{__dir__}/xml/hoisting_algorithm"
     autoload :NamespaceInheritanceResolver,
              "#{__dir__}/xml/namespace_inheritance_resolver"
     autoload :NamespaceScopeConfig, "#{__dir__}/xml/namespace_scope_config"

--- a/lib/lutaml/xml/adapter.rb
+++ b/lib/lutaml/xml/adapter.rb
@@ -7,6 +7,10 @@ module Lutaml
       autoload :AdapterHelpers, "#{__dir__}/adapter/adapter_helpers"
       autoload :BaseAdapter, "#{__dir__}/adapter/base_adapter"
       autoload :NamespaceData, "#{__dir__}/adapter/namespace_data"
+      autoload :XmlParser, "#{__dir__}/adapter/xml_parser"
+      autoload :XmlSerializer, "#{__dir__}/adapter/xml_serializer"
+      autoload :PlanBasedBuilder, "#{__dir__}/adapter/plan_based_builder"
+      autoload :NamespaceUriCollector, "#{__dir__}/adapter/namespace_uri_collector"
       autoload :OgaAdapter, "#{__dir__}/adapter/oga_adapter"
       Lutaml::Model::RuntimeCompatibility.autoload_native(
         self,

--- a/lib/lutaml/xml/adapter/base_adapter.rb
+++ b/lib/lutaml/xml/adapter/base_adapter.rb
@@ -1,14 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../document"
-require_relative "../declaration_handler"
-require_relative "../doctype_extractor"
-require_relative "../polymorphic_value_handler"
-require_relative "xml_parser"
-require_relative "xml_serializer"
-require_relative "plan_based_builder"
-require_relative "namespace_uri_collector"
-
 module Lutaml
   module Xml
     module Adapter

--- a/lib/lutaml/xml/adapter/nokogiri_adapter.rb
+++ b/lib/lutaml/xml/adapter/nokogiri_adapter.rb
@@ -2,7 +2,6 @@
 
 require "moxml"
 require "moxml/adapter/nokogiri"
-require_relative "base_adapter"
 
 module Lutaml
   module Xml

--- a/lib/lutaml/xml/adapter/oga_adapter.rb
+++ b/lib/lutaml/xml/adapter/oga_adapter.rb
@@ -2,7 +2,6 @@
 
 require "oga"
 require "moxml/adapter/oga"
-require_relative "base_adapter"
 
 module Lutaml
   module Xml

--- a/lib/lutaml/xml/adapter/ox_adapter.rb
+++ b/lib/lutaml/xml/adapter/ox_adapter.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "moxml/adapter/ox"
-require_relative "base_adapter"
 
 module Lutaml
   module Xml

--- a/lib/lutaml/xml/adapter/rexml_adapter.rb
+++ b/lib/lutaml/xml/adapter/rexml_adapter.rb
@@ -3,7 +3,6 @@
 require "rexml/document"
 require "moxml"
 require "moxml/adapter/rexml"
-require_relative "base_adapter"
 
 module Lutaml
   module Xml

--- a/lib/lutaml/xml/adapter/xml_serializer.rb
+++ b/lib/lutaml/xml/adapter/xml_serializer.rb
@@ -49,6 +49,35 @@ module Lutaml
           encoding = determine_encoding(options)
           builder_options = {}
           builder_options[:encoding] = encoding if encoding
+          builder_options[:line_ending] = options[:line_ending] if options.key?(:line_ending)
+          builder_options[:indent] = options[:indent] if options.key?(:indent)
+
+          # Pass doctype to builder for document-level insertion
+          doctype_to_use = options[:doctype] || @doctype
+          if doctype_to_use && !options[:omit_doctype]
+            builder_options[:doctype] = doctype_to_use
+          end
+
+          # Pass declaration info to builder
+          if should_include_declaration?(options)
+            builder_options[:include_declaration] = true
+            builder_options[:xml_declaration] = @xml_declaration || {}
+            if options.key?(:standalone)
+              if options[:standalone] == :preserve
+                # Keep original standalone from parsed declaration (may be nil)
+              else
+                builder_options[:xml_declaration][:standalone] = standalone_value(options[:standalone])
+              end
+            end
+            if options[:declaration].is_a?(String)
+              builder_options[:xml_declaration][:version] = options[:declaration]
+            elsif options[:declaration] == true
+              builder_options[:xml_declaration][:version] = "1.0"
+            end
+            builder_options[:xml_declaration][:encoding] = encoding if options.key?(:encoding) && encoding
+          elsif options[:encoding] && !options[:encoding].nil?
+            builder_options[:force_declaration] = true
+          end
 
           builder = self.class::BUILDER_CLASS.build(builder_options) do |xml|
             if root.is_a?(self.class::PARSED_ELEMENT_CLASS)
@@ -58,7 +87,7 @@ module Lutaml
             end
           end
 
-          finalize_adapter_xml(builder.to_xml, encoding, options)
+          builder.to_xml
         end
 
         def build_serializable_xml(xml, options)
@@ -94,6 +123,14 @@ module Lutaml
         end
 
         private
+
+        def standalone_value(value)
+          case value
+          when true then "yes"
+          when false then "no"
+          else value.to_s
+          end
+        end
 
         def transformable_xml_element(options)
           return root if root.is_a?(Lutaml::Xml::DataModel::XmlElement)
@@ -183,27 +220,8 @@ module Lutaml
           options_with_original_ns
         end
 
-        def finalize_adapter_xml(xml_data, encoding, options)
-          result = ""
-          if (options[:encoding] && !options[:encoding].nil?) ||
-              should_include_declaration?(options)
-            result += generate_declaration(options)
-          end
-
-          doctype_to_use = options[:doctype] || @doctype
-          if doctype_to_use && !options[:omit_doctype]
-            result += generate_doctype_declaration(doctype_to_use)
-          end
-
-          result += xml_data
-          if encoding && result.encoding.to_s.upcase != encoding.to_s.upcase
-            result = result.encode(encoding)
-          end
-          result
-        end
-
         def text_content_for_xml(value)
-          ::Moxml::Adapter::Base.preprocess_entities(value.to_s)
+          ::Moxml.preprocess_entities(value.to_s)
         end
 
         def build_plan_node(xml, xml_element, element_node, plan: nil,
@@ -212,7 +230,9 @@ module Lutaml
           attributes = {}
 
           original_ns_uris = plan&.original_namespace_uris || {}
-          element_node.hoisted_declarations.each do |key, uri|
+          element_node.hoisted_declarations.sort_by do |prefix, _uri|
+            prefix.nil? ? "" : prefix.to_s
+          end.each do |key, uri|
             next if uri == "http://www.w3.org/XML/1998/namespace"
 
             effective_uri = if self.class.fpi?(uri)

--- a/lib/lutaml/xml/builder.rb
+++ b/lib/lutaml/xml/builder.rb
@@ -4,6 +4,7 @@ module Lutaml
   module Xml
     # Builder module for XML generation
     module Builder
+      autoload :Base, "#{__dir__}/builder/base"
       autoload :Oga, "#{__dir__}/builder/oga"
       Lutaml::Model::RuntimeCompatibility.autoload_native(
         self,

--- a/lib/lutaml/xml/builder/base.rb
+++ b/lib/lutaml/xml/builder/base.rb
@@ -7,15 +7,63 @@ module Lutaml
     module Builder
       # Base builder for XML construction using moxml.
       # All adapter-specific builders inherit from this class.
+      #
+      # The builder creates XML documents through moxml's document model.
+      # Declaration, doctype, indentation, and line endings are handled
+      # by moxml — no manual string assembly.
       class Base
         def self.build(options = {})
           context = Moxml.new(moxml_backend)
           if Lutaml::Model::RuntimeCompatibility.opal?
             context.config.namespace_validation_mode = :lenient
           end
+
+          encoding_value = options.delete(:encoding)
+          context.config.default_indent = options.delete(:indent) if options.key?(:indent)
+          context.config.default_line_ending = options.delete(:line_ending) if options.key?(:line_ending)
+
           doc = context.create_document
+
+          # Capture doctype — added after root to avoid Ox incompatibility
+          doctype = options.delete(:doctype)
+
           instance = new(doc, context, options)
+          instance.encoding = encoding_value if encoding_value
           yield(instance) if block_given?
+
+          # Add doctype before root (after build block sets root)
+          if doctype && doc.root
+            dt = doc.create_doctype(
+              doctype[:name],
+              doctype[:public_id],
+              doctype[:system_id],
+            )
+            doc.add_child(dt)
+          end
+
+          # Handle declaration — configure it on the document so moxml
+          # serializes it natively (works across all adapters)
+          xml_decl = options.delete(:xml_declaration) || {}
+          include_decl = options.delete(:include_declaration)
+          force_decl = options.delete(:force_declaration)
+
+          if include_decl
+            version = xml_decl[:version] || "1.0"
+            encoding = xml_decl[:encoding]
+            encoding ||= "UTF-8" unless xml_decl[:had_declaration]
+            standalone = xml_decl[:standalone]
+            decl = doc.create_declaration(version, encoding, standalone)
+            doc.add_child(decl)
+            instance.declaration_mode = :default
+          elsif force_decl
+            decl_encoding = encoding_value || "UTF-8"
+            decl = doc.create_declaration("1.0", decl_encoding, nil)
+            doc.add_child(decl)
+            instance.declaration_mode = :default
+          else
+            instance.declaration_mode = :none
+          end
+
           instance
         end
 
@@ -24,13 +72,15 @@ module Lutaml
           nil
         end
 
-        attr_reader :doc, :encoding
+        attr_reader :doc
+        attr_accessor :encoding, :declaration_mode
 
         def initialize(doc, context, options = {})
           @doc = doc
           @context = context
           @encoding = options[:encoding]
           @current_stack = [doc]
+          @declaration_mode = :none
         end
 
         def current_element
@@ -116,33 +166,15 @@ module Lutaml
           add_cdata(current_element, content)
         end
 
-        def to_s
+        def to_xml
           return "" unless @doc.root
 
-          # Serialize full document content (including PIs before root)
-          # Check if there are any nodes before the root element
-          doc_children = @doc.children
-          has_pi_or_comment = doc_children.any? do |child|
-            child.is_a?(Moxml::ProcessingInstruction) || child.is_a?(Moxml::Comment)
-          end
+          result = if @declaration_mode == :none && !has_document_level_nodes?
+                     @doc.root.to_xml(declaration: false, expand_empty: false)
+                   else
+                     @doc.to_xml(declaration: @declaration_mode == :default, expand_empty: false)
+                   end
 
-          if has_pi_or_comment
-            # Serialize each top-level node individually
-            parts = doc_children.map do |child|
-              if child == @doc.root
-                child.to_xml(declaration: false, expand_empty: false)
-              else
-                child.to_xml
-              end
-            end
-            parts.join("\n")
-          else
-            @doc.root.to_xml(declaration: false, expand_empty: false)
-          end
-        end
-
-        def to_xml
-          result = to_s
           result = result.encode(encoding) if encoding && result.encoding.to_s != encoding
           result
         end
@@ -157,6 +189,13 @@ module Lutaml
         end
 
         private
+
+        def has_document_level_nodes?
+          @doc.children.any? do |child|
+            child != @doc.root &&
+              !child.is_a?(Moxml::Text)
+          end
+        end
 
         def resolve_target(element)
           element.is_a?(self.class) || element.is_a?(Base) ? element.current_element : element

--- a/lib/lutaml/xml/builder/nokogiri.rb
+++ b/lib/lutaml/xml/builder/nokogiri.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "base"
-
 module Lutaml
   module Xml
     module Builder

--- a/lib/lutaml/xml/builder/oga.rb
+++ b/lib/lutaml/xml/builder/oga.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "base"
-
 module Lutaml
   module Xml
     module Builder

--- a/lib/lutaml/xml/builder/ox.rb
+++ b/lib/lutaml/xml/builder/ox.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "base"
-
 module Lutaml
   module Xml
     module Builder

--- a/lib/lutaml/xml/builder/rexml.rb
+++ b/lib/lutaml/xml/builder/rexml.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "base"
-
 module Lutaml
   module Xml
     module Builder

--- a/lib/lutaml/xml/configurable.rb
+++ b/lib/lutaml/xml/configurable.rb
@@ -13,7 +13,7 @@ module Lutaml
     #     include Lutaml::Xml::Configurable
     #
     #     xml do
-    #       root 'MyModel'
+    #       element "MyModel"
     #       namespace MyNamespace
     #     end
     #   end
@@ -51,7 +51,7 @@ module Lutaml
         #
         #   @example Configuration with block
         #     xml do
-        #       root 'MyModel'
+        #       element "MyModel"
         #       namespace MyNamespace
         #       map_element 'name', to: :name
         #     end

--- a/lib/lutaml/xml/declaration_handler.rb
+++ b/lib/lutaml/xml/declaration_handler.rb
@@ -1,10 +1,9 @@
 module Lutaml
   module Xml
-    # DeclarationHandler provides XML declaration and DOCTYPE handling
-    # for all XML adapter implementations.
+    # DeclarationHandler provides XML declaration extraction from input XML.
     #
-    # This module implements Issue #1: XML Declaration Preservation
-    # across Nokogiri, Oga, and Ox adapters.
+    # Extraction methods detect and parse XML declarations from input strings.
+    # Generation is handled by moxml's document model — no manual string assembly.
     module DeclarationHandler
       # Extract XML declaration information from input string
       #
@@ -92,125 +91,24 @@ module Lutaml
       # @param xml_declaration [Hash] extracted declaration info from input
       # @return [Boolean] true if declaration should be included
       def should_include_declaration?(options, xml_declaration = nil)
-        # Use instance variable if not provided (for adapter instance methods)
         xml_declaration ||= @xml_declaration
 
         if options.key?(:declaration)
           case options[:declaration]
           when false
-            # Explicit false: omit declaration
             false
           when true
-            # Explicit true: force include
             true
           when :preserve
-            # Preserve mode: include if input had one
             xml_declaration&.dig(:had_declaration) || false
           when String
-            # Custom version string: include
             true
           else
-            # Default: preserve from input
             xml_declaration&.dig(:had_declaration) || false
           end
         else
-          # No declaration option provided: default behavior is preserve from input
           xml_declaration&.dig(:had_declaration) || false
         end
-      end
-
-      # Generate XML declaration string
-      #
-      # Uses stored declaration info if available, otherwise uses defaults.
-      # Supports custom version strings, encoding, and standalone options.
-      #
-      # @param options [Hash] serialization options
-      #   - :declaration => String for custom version, true for default
-      #   - :encoding => String or true for UTF-8
-      #   - :standalone => String ("yes"/"no"), true ("yes"), false ("no"), :preserve
-      # @param xml_declaration [Hash] extracted declaration info from input
-      # @return [String] the XML declaration (includes trailing newline)
-      def generate_declaration(options, xml_declaration = nil)
-        # Use instance variable if not provided (for adapter instance methods)
-        xml_declaration ||= @xml_declaration
-
-        # Determine version
-        # When declaration: true (force), use default 1.0 not input version
-        # When declaration: "1.x" (custom), use that string
-        # When preserving (no option or :preserve), use input version or default
-        version = if options[:declaration].is_a?(String)
-                    # Custom version string
-                    options[:declaration]
-                  elsif options[:declaration] == true
-                    # Force with default version
-                    "1.0"
-                  elsif xml_declaration&.dig(:version)
-                    # Preserve from input
-                    xml_declaration[:version]
-                  else
-                    # Default fallback
-                    "1.0"
-                  end
-
-        # Determine encoding
-        # Priority: explicit encoding option > input encoding > none
-        encoding = if options[:encoding].is_a?(String)
-                     options[:encoding]
-                   elsif options[:encoding] == true
-                     "UTF-8"
-                   elsif xml_declaration&.dig(:encoding)
-                     xml_declaration[:encoding]
-                   end
-
-        # Determine standalone
-        # Priority: explicit standalone option > input standalone > none
-        # Supported values: "yes", "no", true ("yes"), false ("no"), :preserve
-        standalone = if options.key?(:standalone)
-                       case options[:standalone]
-                       when String
-                         options[:standalone]
-                       when true
-                         "yes"
-                       when false
-                         "no"
-                       when :preserve
-                         xml_declaration&.dig(:standalone)
-                       end
-                     elsif xml_declaration&.dig(:standalone)
-                       xml_declaration[:standalone]
-                     end
-
-        declaration = "<?xml version=\"#{version}\""
-        declaration += " encoding=\"#{encoding}\"" if encoding
-        declaration += " standalone=\"#{standalone}\"" if standalone
-        declaration += "?>\n"
-        declaration
-      end
-
-      # Generate DOCTYPE declaration from doctype hash
-      #
-      # Supports both PUBLIC and SYSTEM DTDs.
-      # Format: <!DOCTYPE name PUBLIC "public_id" "system_id">
-      #         <!DOCTYPE name SYSTEM "system_id">
-      #
-      # @param doctype [Hash] the doctype information
-      #   - :name => root element name
-      #   - :public_id => public identifier (optional)
-      #   - :system_id => system identifier (optional)
-      # @return [String, nil] the DOCTYPE declaration or nil if no doctype
-      def generate_doctype_declaration(doctype)
-        return nil unless doctype
-
-        parts = ["<!DOCTYPE #{doctype[:name]}"]
-
-        if doctype[:public_id]
-          parts << %(PUBLIC "#{doctype[:public_id]}")
-          parts << %("#{doctype[:system_id]}") if doctype[:system_id]
-        elsif doctype[:system_id]
-          parts << %(SYSTEM "#{doctype[:system_id]}")
-        end
-
-        "#{parts.join(' ')}>\n"
       end
     end
   end

--- a/lib/lutaml/xml/mapping.rb
+++ b/lib/lutaml/xml/mapping.rb
@@ -350,11 +350,11 @@ module Lutaml
       #   namespace :blank
       #
       # @raise [ArgumentError] if invalid arguments provided
-      # @raise [Lutaml::Model::NoRootNamespaceError] if explicitly marked as no_root
+      # @raise [Lutaml::Model::TypeOnlyNamespaceError] if explicitly marked as no_root
       def namespace(ns_class_or_symbol, _deprecated_prefix = nil)
         # Only raise error for explicitly marked no_root (using deprecated method)
         # Type-only models (no element declared) CAN have namespaces
-        raise Lutaml::Model::NoRootNamespaceError if @no_root
+        raise Lutaml::Model::TypeOnlyNamespaceError if @no_root
 
         # Warn if prefix parameter is provided
         if _deprecated_prefix
@@ -784,7 +784,7 @@ module Lutaml
       #
       # @example
       #   xml do
-      #     root "rfc"
+      #     element "rfc"
       #     map_processing_instruction "rfc", to: :pi_settings
       #   end
       #

--- a/lib/lutaml/xml/schema/xsd/documentation.rb
+++ b/lib/lutaml/xml/schema/xsd/documentation.rb
@@ -10,7 +10,7 @@ module Lutaml
           attribute :content, :string
 
           xml do
-            root "documentation"
+            element "documentation"
             namespace Lutaml::Xml::Schema::XsdNamespace
 
             map_all to: :content

--- a/lib/lutaml/xml/serialization/collection_ext.rb
+++ b/lib/lutaml/xml/serialization/collection_ext.rb
@@ -6,7 +6,7 @@ module Lutaml
       # XML-specific overrides for Collection class methods.
       #
       # Prepended into Collection's singleton class when XML is loaded.
-      # Provides XML-specific no_root handling for collections.
+      # Provides XML-specific unwrapped collection handling.
       module CollectionExt
         # XML is a structured (tree-based) format
         def collection_structured_format?(format)
@@ -15,15 +15,15 @@ module Lutaml
           true
         end
 
-        # XML handles no_root serialization specially
-        def collection_no_root_to?(format)
+        # XML handles unwrapped serialization specially
+        def collection_unwrapped_to?(format)
           return super unless format == :xml
 
           true
         end
 
-        # XML no_root serialization: serialize each mapping separately
-        def collection_no_root_to(format, mappings, instance, options)
+        # XML unwrapped serialization: serialize each mapping separately
+        def collection_unwrapped_to(format, mappings, instance, options)
           return super unless format == :xml
 
           mappings.mappings.map do |mapping|
@@ -31,8 +31,8 @@ module Lutaml
           end.join("\n")
         end
 
-        # XML no_root: wrap raw XML in a fake root tag before parsing
-        def wrap_no_root_input(format, mappings, data)
+        # XML unwrapped: wrap raw XML in a fake root tag before parsing
+        def wrap_unwrapped_input(format, mappings, data)
           return super unless format == :xml
 
           tag_name = mappings.find_by_to!(instance_name).name

--- a/lib/lutaml/xml/serialization/format_conversion.rb
+++ b/lib/lutaml/xml/serialization/format_conversion.rb
@@ -94,7 +94,7 @@ module Lutaml
           return super unless format == :xml
 
           valid = root?(register) || options[:from_collection]
-          raise Lutaml::Model::NoRootMappingError.new(self) unless valid
+          raise Lutaml::Model::TypeOnlyMappingError.new(self) unless valid
 
           options[:encoding] = doc.encoding
           if doc.is_a?(Lutaml::Xml::Document) && doc.doctype

--- a/lib/lutaml/xml/serialization/instance_methods.rb
+++ b/lib/lutaml/xml/serialization/instance_methods.rb
@@ -204,7 +204,7 @@ module Lutaml
           return super unless format == :xml
           return if options[:collection] || self.class.root?(lutaml_register)
 
-          raise Lutaml::Model::NoRootMappingError.new(self.class)
+          raise Lutaml::Model::TypeOnlyMappingError.new(self.class)
         end
 
         # XML-specific instance options preparation

--- a/lib/tasks/memory_profile.rb
+++ b/lib/tasks/memory_profile.rb
@@ -18,7 +18,7 @@ class Address < Lutaml::Model::Serializable
   attribute :country, :string
 
   xml do
-    root "address"
+    element "address"
     map_element "street", to: :street
     map_element "city", to: :city
     map_element "zip", to: :zip
@@ -37,7 +37,7 @@ class Person < Lutaml::Model::Serializable
   attribute :tags, :string, collection: true
 
   xml do
-    root "person"
+    element "person"
     map_attribute "id", to: :id
     map_element "first_name", to: :first_name
     map_element "last_name", to: :last_name

--- a/lib/tasks/performance_benchmark.rb
+++ b/lib/tasks/performance_benchmark.rb
@@ -21,7 +21,7 @@ module Lutaml
           attribute :created_at, :date_time
 
           xml do
-            root "simple"
+            element "simple"
             map_attribute "id", to: :id
             map_element "name", to: :name
             map_element "active", to: :active
@@ -46,7 +46,7 @@ module Lutaml
           attribute :country, :string
 
           xml do
-            root "address"
+            element "address"
             map_element "street", to: :street
             map_element "city", to: :city
             map_element "zip", to: :zip
@@ -73,7 +73,7 @@ module Lutaml
           attribute :tags, :string, collection: true
 
           xml do
-            root "person"
+            element "person"
             map_attribute "id", to: :id
             map_element "first_name", to: :first_name
             map_element "last_name", to: :last_name
@@ -103,7 +103,7 @@ module Lutaml
           attribute :price, :float
 
           xml do
-            root "item"
+            element "item"
             map_attribute "product_id", to: :product_id
             map_element "quantity", to: :quantity
             map_element "price", to: :price
@@ -118,7 +118,7 @@ module Lutaml
           attribute :status, :string
 
           xml do
-            root "order"
+            element "order"
             map_attribute "id", to: :id
             map_element "customer", to: :customer
             map_element "item", to: :items

--- a/spec/lutaml/key_value/transformation/rule_compiler_spec.rb
+++ b/spec/lutaml/key_value/transformation/rule_compiler_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Lutaml::KeyValue::Transformation::RuleCompiler do
       attribute :active, :boolean
 
       json do
-        root "person"
+        key "person"
         map "name", to: :name
         map "age", to: :age
         map "active", to: :active

--- a/spec/lutaml/key_value/transformation/value_serializer_spec.rb
+++ b/spec/lutaml/key_value/transformation/value_serializer_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe Lutaml::KeyValue::Transformation::ValueSerializer do
         Class.new(Lutaml::Model::Serializable) do
           attribute :name, :string
           json do
-            root "nested"
+            key "nested"
             map "name", to: :name
           end
         end

--- a/spec/lutaml/model/attribute_collection_spec.rb
+++ b/spec/lutaml/model/attribute_collection_spec.rb
@@ -19,7 +19,7 @@ module AttributeCollection
     end
 
     key_value do
-      root "titles"
+      key "titles"
       map_instances to: :title_parts
     end
 

--- a/spec/lutaml/model/cli_spec.rb
+++ b/spec/lutaml/model/cli_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Lutaml::Model::Cli do
         attribute :extract_language, ExtractLanguage, collection: true
 
         xml do
-          root "termium_extract"
+          element "termium_extract"
           namespace TermiumNamespace
 
           map_attribute "language", to: :language, namespace: nil

--- a/spec/lutaml/model/collection_spec.rb
+++ b/spec/lutaml/model/collection_spec.rb
@@ -156,7 +156,7 @@ class PolyAnimalCollectionAny < Lutaml::Model::Collection
   end
 
   key_value do
-    root "zoo"
+    key "zoo"
     map_instances to: :animals, polymorphic: {
       attribute: "type",
       class_map: {

--- a/spec/lutaml/model/collection_validation_spec.rb
+++ b/spec/lutaml/model/collection_validation_spec.rb
@@ -10,7 +10,7 @@ module CollectionValidationTests
     attribute :category, :string
 
     xml do
-      root "publication"
+      element "publication"
       map_attribute "id", to: :id
       map_element "title", to: :title
       map_element "year", to: :year
@@ -33,7 +33,7 @@ module CollectionValidationTests
     validates_uniqueness_of :id, message: "Publication IDs must be unique"
 
     xml do
-      root "publications"
+      element "publications"
       map_element "publication", to: :publications
     end
 
@@ -49,7 +49,7 @@ module CollectionValidationTests
     validates_max_count 5, message: "Cannot have more than 5 publications"
 
     xml do
-      root "publications"
+      element "publications"
       map_element "publication", to: :publications
     end
 
@@ -66,7 +66,7 @@ module CollectionValidationTests
     validates_all_present :year, message: "All publications must have a year"
 
     xml do
-      root "publications"
+      element "publications"
       map_element "publication", to: :publications
     end
 
@@ -102,7 +102,7 @@ module CollectionValidationTests
     end
 
     xml do
-      root "publications"
+      element "publications"
       map_element "publication", to: :publications
     end
 
@@ -122,7 +122,7 @@ module CollectionValidationTests
     validates_min_count 1                                    # Collection-level validation
 
     xml do
-      root "publications"
+      element "publications"
       map_element "publication", to: :publications
     end
 

--- a/spec/lutaml/model/consolidation_spec.rb
+++ b/spec/lutaml/model/consolidation_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Consolidation Mapping" do
         attribute :content, :string
 
         xml do
-          root "title"
+          element "title"
           map_attribute "lang", to: :lang
           map_attribute "type", to: :type_of_title
           map_content to: :content
@@ -40,7 +40,7 @@ RSpec.describe "Consolidation Mapping" do
         organizes :per_lang, ConPerLangGroup
 
         xml do
-          root "titles"
+          element "titles"
           map_instances to: :items
           consolidate_map by: :lang, to: :per_lang do
             gather :lang, to: :lang
@@ -59,7 +59,7 @@ RSpec.describe "Consolidation Mapping" do
         attribute :titles, ConTitle, collection: ConTitleCollection
 
         xml do
-          root "bibdata"
+          element "bibdata"
           map_element "title", to: :titles
         end
       end)
@@ -141,7 +141,7 @@ RSpec.describe "Consolidation Mapping" do
         attribute :content, :string
 
         xml do
-          root "title"
+          element "title"
           map_attribute "lang", to: :lang
           map_attribute "type", to: :type_of_title
           map_content to: :content
@@ -159,7 +159,7 @@ RSpec.describe "Consolidation Mapping" do
         organizes :per_type, ConPerTypeGroup
 
         xml do
-          root "titles"
+          element "titles"
           map_instances to: :items
           consolidate_map by: :type_of_title, to: :per_type do
             gather :type_of_title, to: :type_of_title
@@ -175,7 +175,7 @@ RSpec.describe "Consolidation Mapping" do
         attribute :titles, ConTitle2, collection: ConTitleCollection2
 
         xml do
-          root "bibdata"
+          element "bibdata"
           map_element "title", to: :titles
         end
       end)
@@ -247,7 +247,7 @@ RSpec.describe "Consolidation Mapping" do
         organizes :entries, group_class
 
         xml do
-          root "test"
+          element "test"
           consolidate_map by: :lang, to: :entries do
             gather :lang, to: :lang
             dispatch_by :type do
@@ -276,7 +276,7 @@ RSpec.describe "Consolidation Mapping" do
         organizes :entries, entry_class
 
         xml do
-          root "test"
+          element "test"
           consolidate_map by: :pattern, to: :entries do
             map_element "member", to: :name
             map_element "member_key", to: :key

--- a/spec/lutaml/model/custom_collection_spec.rb
+++ b/spec/lutaml/model/custom_collection_spec.rb
@@ -66,7 +66,7 @@ module CustomCollection
     end
 
     key_value do
-      root "items"
+      key "items"
       map_instances to: :items
     end
   end
@@ -138,7 +138,7 @@ module CustomCollection
     end
 
     key_value do
-      root "items"
+      key "items"
       map "items", to: :items, value_map: {
         from: { empty: :empty, omitted: :omitted, nil: :nil },
         to: { empty: :empty, omitted: :omitted, nil: :nil },
@@ -205,7 +205,7 @@ module CustomCollection
     end
 
     key_value do
-      root "items"
+      key "items"
 
       map_instances to: :items
     end

--- a/spec/lutaml/model/default_register_spec.rb
+++ b/spec/lutaml/model/default_register_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe "lutaml_default_register" do
           attribute :value, :string
 
           xml do
-            root "test"
+            element "test"
             map_element "value", to: :value
           end
         end
@@ -105,7 +105,7 @@ RSpec.describe "lutaml_default_register" do
           attribute :name, :string
 
           xml do
-            root "regular"
+            element "regular"
           end
         end
 
@@ -135,7 +135,7 @@ RSpec.describe "lutaml_default_register" do
           attribute :name, :string
 
           xml do
-            root "test"
+            element "test"
             map_element "name", to: :name
           end
         end
@@ -160,7 +160,7 @@ RSpec.describe "lutaml_default_register" do
           attribute :name, :string
 
           xml do
-            root "regular"
+            element "regular"
           end
         end
 
@@ -180,7 +180,7 @@ RSpec.describe "lutaml_default_register" do
           attribute :value, :string
 
           xml do
-            root "child"
+            element "child"
             map_element "value", to: :value
           end
         end
@@ -195,7 +195,7 @@ RSpec.describe "lutaml_default_register" do
           attribute :child, child_klass
 
           xml do
-            root "parent"
+            element "parent"
             map_element "child", to: :child
           end
         end
@@ -258,7 +258,7 @@ RSpec.describe "lutaml_default_register" do
         attribute :value, :string
 
         xml do
-          root "math"
+          element "math"
           map_element "value", to: :value
         end
       end
@@ -267,7 +267,7 @@ RSpec.describe "lutaml_default_register" do
         attribute :value, :string
 
         xml do
-          root "math"
+          element "math"
           map_element "value", to: :value
         end
       end
@@ -432,7 +432,7 @@ RSpec.describe "lutaml_default_register" do
         attribute :mmultiscripts_value, :mmultiscripts, collection: true
 
         xml do
-          root "math"
+          element "math"
           map_element "mmultiscripts", to: :mmultiscripts_value
         end
       end
@@ -445,7 +445,7 @@ RSpec.describe "lutaml_default_register" do
         attribute :math, math_class
 
         xml do
-          root "doc"
+          element "doc"
           map_element "math", to: :math
         end
       end
@@ -477,7 +477,7 @@ RSpec.describe "lutaml_default_register" do
         attribute :mi_value, :string
 
         xml do
-          root "mmultiscripts"
+          element "mmultiscripts"
           map_element "mi", to: :mi_value
         end
       end
@@ -490,7 +490,7 @@ RSpec.describe "lutaml_default_register" do
         attribute :mmultiscripts_value, mmultiscripts_class, collection: true
 
         xml do
-          root "math"
+          element "math"
           map_element "mmultiscripts", to: :mmultiscripts_value
         end
       end
@@ -504,7 +504,7 @@ RSpec.describe "lutaml_default_register" do
         attribute :math, math_class
 
         xml do
-          root "doc"
+          element "doc"
           map_attribute "id", to: :id
           map_element "math", to: :math
         end
@@ -563,7 +563,7 @@ RSpec.describe "lutaml_default_register" do
         attribute :value, :string
 
         xml do
-          root "mi"
+          element "mi"
           map_content to: :value
         end
       end
@@ -573,7 +573,7 @@ RSpec.describe "lutaml_default_register" do
         attribute :value, :string
 
         xml do
-          root "mi"
+          element "mi"
           map_content to: :value
         end
       end
@@ -588,7 +588,7 @@ RSpec.describe "lutaml_default_register" do
         attribute :mi_value, standard_mi, collection: true
 
         xml do
-          root "math"
+          element "math"
           map_element "mi", to: :mi_value
         end
       end
@@ -626,7 +626,7 @@ RSpec.describe "lutaml_default_register" do
         attribute :value, :string
 
         xml do
-          root "mi"
+          element "mi"
           map_content to: :value
         end
       end
@@ -728,7 +728,7 @@ RSpec.describe "lutaml_default_register" do
         attribute :value, :string
 
         xml do
-          root "inner"
+          element "inner"
           map_content to: :value
         end
       end
@@ -746,7 +746,7 @@ RSpec.describe "lutaml_default_register" do
         attribute :inner, :inner_element
 
         xml do
-          root "child"
+          element "child"
           map_element "inner", to: :inner
         end
       end
@@ -756,7 +756,7 @@ RSpec.describe "lutaml_default_register" do
         attribute :child_elem, child_class
 
         xml do
-          root "parent"
+          element "parent"
           map_element "child", to: :child_elem
         end
       end
@@ -774,7 +774,7 @@ RSpec.describe "lutaml_default_register" do
         attribute :content, :string
 
         xml do
-          root "item"
+          element "item"
           map_content to: :content
         end
       end
@@ -790,7 +790,7 @@ RSpec.describe "lutaml_default_register" do
         attribute :items, :inner_element, collection: true
 
         xml do
-          root "items"
+          element "items"
           map_element "item", to: :items
         end
       end
@@ -799,7 +799,7 @@ RSpec.describe "lutaml_default_register" do
         attribute :container, child_class
 
         xml do
-          root "doc"
+          element "doc"
           map_element "items", to: :container
         end
       end

--- a/spec/lutaml/model/delegation_spec.rb
+++ b/spec/lutaml/model/delegation_spec.rb
@@ -266,23 +266,16 @@ RSpec.describe Delegation do
     expect(xml_data).not_to include("<?xml")
   end
 
-  it "provides XML declaration with default version" \
+  it "provides XML declaration with default version and encoding" \
      "if declaration: true option provided" do
     xml_data = delegation.to_xml(pretty: true, declaration: true)
-    expect(xml_data).to include('<?xml version="1.0"?>')
+    expect(xml_data).to include('<?xml version="1.0" encoding="UTF-8"?>')
   end
 
   it "provides XML declaration with specified version" \
      "if declaration: '1.1' option provided" do
     xml_data = delegation.to_xml(pretty: true, declaration: "1.1")
-    expect(xml_data).to include('<?xml version="1.1"?>')
-  end
-
-  it "provides XML declaration without encoding" \
-     "if encoding option not provided" do
-    xml_data = delegation.to_xml(pretty: true, declaration: true)
-    expect(xml_data).to include('<?xml version="1.0"?>')
-    expect(xml_data).not_to include("encoding=")
+    expect(xml_data).to include('<?xml version="1.1" encoding="UTF-8"?>')
   end
 
   it "provides XML declaration with UTF-8 encoding" \

--- a/spec/lutaml/model/derived_attribute_serialization_spec.rb
+++ b/spec/lutaml/model/derived_attribute_serialization_spec.rb
@@ -7,7 +7,7 @@ module DerivedAttributeSerializationSpec
     attribute :computed_val, :string, method: :computed_value
 
     xml do
-      root "parent"
+      element "parent"
       map_attribute "computed-val", to: :computed_val, render_default: true
     end
 

--- a/spec/lutaml/model/dynamic_attribute_spec.rb
+++ b/spec/lutaml/model/dynamic_attribute_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "Dynamic attribute addition after register imports" do
       attribute :name, :string
 
       xml do
-        root "BaseModel"
+        element "BaseModel"
         namespace DynAttrTestNamespace
         map_element "Name", to: :name
       end
@@ -44,7 +44,7 @@ RSpec.describe "Dynamic attribute addition after register imports" do
       attribute :code, :string
 
       xml do
-        root "ExtensionModel"
+        element "ExtensionModel"
         namespace DynAttrTestNamespace
         map_element "Code", to: :code
       end

--- a/spec/lutaml/model/enum_spec.rb
+++ b/spec/lutaml/model/enum_spec.rb
@@ -14,7 +14,7 @@ module EnumSpec
     attribute :char, :string
 
     xml do
-      root "test"
+      element "test"
       map_attribute "align", to: :align
       map_attribute "char", to: :char
     end

--- a/spec/lutaml/model/group_spec.rb
+++ b/spec/lutaml/model/group_spec.rb
@@ -213,7 +213,7 @@ module GroupSpec
 end
 
 RSpec.describe "Group" do
-  context "when serializing and deserializing import model having no_root" do
+  context "when serializing and deserializing imported type-only models" do
     let(:xml) do
       # W3C Rule: Namespaces can be declared at point of use (local) or at root (hoisted).
       # Implementation prefers default format for cleaner output when creating new instances.
@@ -262,28 +262,28 @@ RSpec.describe "Group" do
     end
   end
 
-  context "with no_root" do
+  context "with type-only model (no element declared)" do
     let(:mapper) { GroupSpec::CeramicCollection }
 
-    it "raises error if root-less class used directly for parsing" do
+    it "raises error if type-only class used directly for parsing" do
       xml = <<~XML
         <type>Data</type>
         <name>Smith</name>
       XML
 
       expect { GroupSpec::Ceramic.from_xml(xml) }.to raise_error(
-        Lutaml::Model::NoRootMappingError,
-        "GroupSpec::Ceramic has `no_root`, it allowed only for reusable models",
+        Lutaml::Model::TypeOnlyMappingError,
+        /type-only model/,
       )
     end
 
-    context "deserializing XML" do
+    context "serializing XML" do
       let(:ceramic) { GroupSpec::Ceramic.new(type: "Data", name: "Starc") }
 
-      it "raises error for root_less class" do
+      it "raises error for type-only class" do
         expect { ceramic.to_xml }.to raise_error(
-          Lutaml::Model::NoRootMappingError,
-          "GroupSpec::Ceramic has `no_root`, it allowed only for reusable models",
+          Lutaml::Model::TypeOnlyMappingError,
+          /type-only model/,
         )
       end
     end
@@ -553,7 +553,7 @@ RSpec.describe "Group" do
                          "Cannot import a model `GroupSpec::GroupWithRoot` with a root element")
     end
 
-    it "raises error if namespace is defined with no_root" do
+    it "raises error if namespace is defined with deprecated no_root" do
       expect do
         Class.new(Lutaml::Model::Serializable) do
           xml do
@@ -561,8 +561,8 @@ RSpec.describe "Group" do
             namespace XmiNamespace
           end
         end
-      end.to raise_error(Lutaml::Model::NoRootNamespaceError,
-                         "Cannot assign namespace to `no_root`")
+      end.to raise_error(Lutaml::Model::TypeOnlyNamespaceError,
+                         /type-only model/)
     end
   end
 

--- a/spec/lutaml/model/lazy_collection_spec.rb
+++ b/spec/lutaml/model/lazy_collection_spec.rb
@@ -10,7 +10,7 @@ module LazyCollectionTests
     attribute :name, :string
 
     xml do
-      root "multi"
+      element "multi"
       map_element "name", to: :name
       map_element "item_a", to: :items_a
       map_element "item_b", to: :items_b
@@ -23,7 +23,7 @@ module LazyCollectionTests
     attribute :name, :string
 
     xml do
-      root "tagged"
+      element "tagged"
       map_element "name", to: :name
       map_element "tag", to: :tags
     end
@@ -33,7 +33,7 @@ module LazyCollectionTests
     attribute :value, :string
 
     xml do
-      root "child"
+      element "child"
       map_element "value", to: :value
     end
   end
@@ -47,7 +47,7 @@ module LazyCollectionTests
     attribute :name, :string
 
     xml do
-      root "parent"
+      element "parent"
       map_element "name", to: :name
       map_element "child1", to: :col_1
       map_element "child2", to: :col_2

--- a/spec/lutaml/model/mixed_content_spec.rb
+++ b/spec/lutaml/model/mixed_content_spec.rb
@@ -257,7 +257,7 @@ module MixedContentSpec
     attribute :mathvariant, :string
 
     xml do
-      root "mi"
+      element "mi"
       mixed_content
       map_content to: :value
       map_attribute "mathvariant", to: :mathvariant
@@ -269,7 +269,7 @@ module MixedContentSpec
     attribute :bold, :string
 
     xml do
-      root "p"
+      element "p"
       mixed_content
       map_content to: :content
       map_element "b", to: :bold

--- a/spec/lutaml/model/namespace_versioning_spec.rb
+++ b/spec/lutaml/model/namespace_versioning_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe Lutaml::Model::ModelTreeImporter do
           attribute :value, :integer
 
           xml do
-            root "Simple"
+            element "Simple"
             map_element "name", to: :name
             map_element "value", to: :value
           end
@@ -322,7 +322,7 @@ RSpec.describe "Context Propagation for Mixed Schema Types" do
       attribute :custom_field, :custom_type_for_context
 
       xml do
-        root "Child"
+        element "Child"
         map_element "CustomField", to: :custom_field
       end
     end
@@ -341,7 +341,7 @@ RSpec.describe "Context Propagation for Mixed Schema Types" do
         attribute :child, child_klass
 
         xml do
-          root "Parent"
+          element "Parent"
           map_element "Child", to: :child
         end
       end
@@ -369,7 +369,7 @@ RSpec.describe "Context Propagation for Mixed Schema Types" do
         attribute :children, child_klass, collection: true
 
         xml do
-          root "Parent"
+          element "Parent"
           map_element "Child", to: :children
         end
       end

--- a/spec/lutaml/model/processing_instruction_spec.rb
+++ b/spec/lutaml/model/processing_instruction_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "Processing Instructions" do
         attribute :pi_settings, :hash
 
         xml do
-          root "rfc"
+          element "rfc"
           map_element "title", to: :title
           map_processing_instruction "rfc", to: :pi_settings
         end
@@ -57,7 +57,7 @@ RSpec.describe "Processing Instructions" do
         attribute :pi_settings, :hash
 
         xml do
-          root "rfc"
+          element "rfc"
           map_element "title", to: :title
           map_processing_instruction "rfc", to: :pi_settings
         end
@@ -76,7 +76,7 @@ RSpec.describe "Processing Instructions" do
         attribute :pi_settings, :hash
 
         xml do
-          root "rfc"
+          element "rfc"
           map_element "title", to: :title
           map_processing_instruction "rfc", to: :pi_settings
         end
@@ -96,7 +96,7 @@ RSpec.describe "Processing Instructions" do
         attribute :xml_pis, :hash
 
         xml do
-          root "doc"
+          element "doc"
           map_element "title", to: :title
           map_processing_instruction "rfc", to: :rfc_pis
           map_processing_instruction "xml-stylesheet", to: :xml_pis
@@ -120,7 +120,7 @@ RSpec.describe "Processing Instructions" do
         attribute :pi_settings, :hash
 
         xml do
-          root "rfc"
+          element "rfc"
           map_element "title", to: :title
           map_processing_instruction "rfc", to: :pi_settings
         end
@@ -143,7 +143,7 @@ RSpec.describe "Processing Instructions" do
         attribute :title, :string
 
         xml do
-          root "doc"
+          element "doc"
           map_element "title", to: :title
         end
       end
@@ -238,7 +238,7 @@ RSpec.describe "Processing Instructions" do
           attribute :pi_settings, :hash
 
           xml do
-            root "rfc"
+            element "rfc"
             map_element "title", to: :title
             map_processing_instruction "rfc", to: :pi_settings
           end
@@ -266,7 +266,7 @@ RSpec.describe "Processing Instructions" do
           attribute :pi_settings, :hash
 
           xml do
-            root "rfc"
+            element "rfc"
             map_element "title", to: :title
             map_processing_instruction "rfc", to: :pi_settings
           end
@@ -284,7 +284,7 @@ RSpec.describe "Processing Instructions" do
           attribute :stylesheet_pis, :hash
 
           xml do
-            root "doc"
+            element "doc"
             map_element "title", to: :title
             map_processing_instruction "rfc", to: :rfc_pis
             map_processing_instruction "xml-stylesheet", to: :stylesheet_pis
@@ -312,7 +312,7 @@ RSpec.describe "Processing Instructions" do
           attribute :db_pis, :hash
 
           xml do
-            root "book"
+            element "book"
             map_element "title", to: :title
             map_processing_instruction "db", to: :db_pis
           end
@@ -333,7 +333,7 @@ RSpec.describe "Processing Instructions" do
           attribute :rfc_pis, :string, collection: true
 
           xml do
-            root "rfc"
+            element "rfc"
             map_element "title", to: :title
             map_processing_instruction "rfc", to: :rfc_pis
           end

--- a/spec/lutaml/model/register_methods_spec.rb
+++ b/spec/lutaml/model/register_methods_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Register-specific attribute methods" do
       attribute :name, :string
 
       xml do
-        root "Base"
+        element "Base"
         map_element "Name", to: :name
       end
     end
@@ -25,7 +25,7 @@ RSpec.describe "Register-specific attribute methods" do
       attribute :priority, :integer
 
       xml do
-        root "Extension"
+        element "Extension"
         map_element "Version", to: :version
         map_element "Priority", to: :priority
       end

--- a/spec/lutaml/model/render_empty_spec.rb
+++ b/spec/lutaml/model/render_empty_spec.rb
@@ -80,7 +80,7 @@ module RenderEmptySpec
     attribute :page, :string
 
     xml do
-      root "doc"
+      element "doc"
       map_attribute "code", to: :code
       map_attribute "page", to: :page,
                             value_map: { to: { empty: :empty } }

--- a/spec/lutaml/model/serialize_perf_guard_spec.rb
+++ b/spec/lutaml/model/serialize_perf_guard_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Lazy nil deserialization state guard specs" do
       attribute :tags, :string, collection: true
 
       xml do
-        root "model"
+        element "model"
         map_element "name", to: :name
         map_attribute "age", to: :age
         map_element "tag", to: :tags

--- a/spec/lutaml/model/transform_dynamic_attributes_spec.rb
+++ b/spec/lutaml/model/transform_dynamic_attributes_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Transform with dynamically added attributes" do
       attribute :name, :string
 
       xml do
-        root "test"
+        element "test"
         map_element "name", to: :name
       end
 

--- a/spec/lutaml/model/transformation_builder_spec.rb
+++ b/spec/lutaml/model/transformation_builder_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Lutaml::Xml::TransformationBuilder do
         attribute :name, :string
 
         xml do
-          root "person"
+          element "person"
           map_element "name", to: :name
         end
       end
@@ -222,7 +222,7 @@ RSpec.describe "TransformationRegistry Builder Pattern" do
         attribute :name, :string
 
         xml do
-          root "person"
+          element "person"
           map_element "name", to: :name
         end
 

--- a/spec/lutaml/model/xml_decoupling_spec.rb
+++ b/spec/lutaml/model/xml_decoupling_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe "XML decoupling from core model" do
       end
 
       xml do
-        root "item"
+        element "item"
         map_element "title", to: :title
         map_element "count", to: :count
       end
@@ -328,8 +328,8 @@ RSpec.describe "XML decoupling from core model" do
       expect(Lutaml::Model::Collection).to respond_to(:collection_structured_format?)
     end
 
-    it "Collection has collection_no_root_to? hook" do
-      expect(Lutaml::Model::Collection).to respond_to(:collection_no_root_to?)
+    it "Collection has collection_unwrapped_to? hook" do
+      expect(Lutaml::Model::Collection).to respond_to(:collection_unwrapped_to?)
     end
 
     it "collection_structured_format? returns true for XML" do

--- a/spec/lutaml/model/xsd_patterns_spec.rb
+++ b/spec/lutaml/model/xsd_patterns_spec.rb
@@ -196,7 +196,7 @@ RSpec.describe "XSD Three Pattern Architecture" do
       expect(xsd1).to include('<complexType name="TestType">')
     end
 
-    it "xsd_type does NOT auto-set no_root (NO MAGIC)" do
+    it "xsd_type does NOT auto-set type-only (NO MAGIC)" do
       klass = Class.new(Lutaml::Model::Serializable) do
         attribute :name, :string
 
@@ -208,9 +208,8 @@ RSpec.describe "XSD Three Pattern Architecture" do
       end
 
       mapping = klass.mappings_for(:xml)
-      # NO MAGIC: xsd_type doesn't set @no_root
-      expect(mapping.instance_variable_get(:@no_root)).to be_nil
       # Model is a root model because element is declared
+      expect(mapping.no_element?).to be false
       expect(mapping.no_root?).to be false
       # Type name is still set
       expect(mapping.type_name_value).to eq("TestType")

--- a/spec/lutaml/xml/adapter/order_spec.rb
+++ b/spec/lutaml/xml/adapter/order_spec.rb
@@ -11,7 +11,7 @@ module XmlAdapterSharedFeaturesSpec
     attribute :foo, :string
 
     xml do
-      root "root"
+      element "root"
       map_element "foo", to: :foo
     end
   end

--- a/spec/lutaml/xml/clear_parse_state_spec.rb
+++ b/spec/lutaml/xml/clear_parse_state_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "#clear_xml_parse_state!" do
       attribute :count, :integer
 
       xml do
-        root "root"
+        element "root"
         namespace ns
         map_element "item", to: :item
         map_attribute "count", to: :count

--- a/spec/lutaml/xml/content_model_validation_spec.rb
+++ b/spec/lutaml/xml/content_model_validation_spec.rb
@@ -32,7 +32,8 @@ RSpec.describe "Content model validation" do
           attribute :content, :string
 
           xml do
-            root "test", ordered: true
+            element "test"
+            ordered
             map_content to: :content
           end
 
@@ -85,7 +86,8 @@ RSpec.describe "Content model validation" do
           attribute :content, :string, collection: true
 
           xml do
-            root "test", mixed: true
+            element "test"
+            mixed_content
             map_content to: :content
           end
 

--- a/spec/lutaml/xml/doubly_defined_namespace_spec.rb
+++ b/spec/lutaml/xml/doubly_defined_namespace_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Doubly-defined namespace prefixes" do
       attribute :item, :string
 
       xml do
-        root "root"
+        element "root"
         namespace ns
         map_element "item", to: :item
       end
@@ -171,7 +171,7 @@ RSpec.describe "Doubly-defined namespace prefixes" do
         attribute :name, :string
 
         xml do
-          root "Inner"
+          element "Inner"
           namespace ns
           map_element "name", to: :name
         end
@@ -185,7 +185,7 @@ RSpec.describe "Doubly-defined namespace prefixes" do
         attribute :child, ic
 
         xml do
-          root "Outer"
+          element "Outer"
           namespace ns
           map_element "Inner", to: :child
         end
@@ -269,7 +269,7 @@ RSpec.describe "Doubly-defined namespace prefixes" do
         attribute :value, :string
 
         xml do
-          root "child"
+          element "child"
           namespace ns
           map_content to: :value
         end
@@ -284,7 +284,7 @@ RSpec.describe "Doubly-defined namespace prefixes" do
         attribute :child, cm
 
         xml do
-          root "parent"
+          element "parent"
           namespace ns
           map_element "name", to: :name
           map_element "child", to: :child

--- a/spec/lutaml/xml/enhanced_mapping_spec.rb
+++ b/spec/lutaml/xml/enhanced_mapping_spec.rb
@@ -54,8 +54,9 @@ RSpec.describe "Enhanced XML Mapping Features" do
         expect(mapping.root?).to be false
       end
 
-      it "has no_root? return true for type-only models" do
+      it "has no_element? return true for type-only models" do
         mapping = model_class.mappings_for(:xml)
+        expect(mapping.no_element?).to be true
         expect(mapping.no_root?).to be true
       end
     end

--- a/spec/lutaml/xml/entity_fragmentation_spec.rb
+++ b/spec/lutaml/xml/entity_fragmentation_spec.rb
@@ -10,7 +10,7 @@ module EntityFragmentationSpec
     attribute :content, :string
 
     xml do
-      root "t"
+      element "t"
       namespace OfficeMathNamespace
       map_content to: :content
     end
@@ -20,7 +20,7 @@ module EntityFragmentationSpec
     attribute :t, MathT
 
     xml do
-      root "r"
+      element "r"
       namespace OfficeMathNamespace
       map_element :t, to: :t
     end
@@ -30,7 +30,7 @@ module EntityFragmentationSpec
     attribute :r, MathR
 
     xml do
-      root "oMathPara"
+      element "oMathPara"
       namespace OfficeMathNamespace
       map_element :r, to: :r
     end
@@ -219,7 +219,7 @@ RSpec.shared_examples "XML entity preservation" do |adapter_name|
           element "paragraph"
           mixed_content
 
-          map_content to: :content, mixed: true
+          map_content to: :content
           map_element "em", to: :emphasis
         end
       end
@@ -496,7 +496,7 @@ RSpec.describe "XML Entity Fragmentation Issue #5" do
           attribute :content, :string
 
           xml do
-            root "text"
+            element "text"
             map_content to: :content
           end
         end

--- a/spec/lutaml/xml/indent_spec.rb
+++ b/spec/lutaml/xml/indent_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Indent configuration" do
+  before do
+    item_class = Class.new do
+      include Lutaml::Model::Serialize
+
+      attribute :name, :string
+
+      xml do
+        element "item"
+        map_element "name", to: :name
+      end
+    end
+
+    stub_const("IndentItem", item_class)
+
+    test_class = Class.new do
+      include Lutaml::Model::Serialize
+
+      attribute :title, :string
+      attribute :items, IndentItem, collection: true
+
+      xml do
+        element "container"
+        map_element "title", to: :title
+        map_element "item", to: :items
+      end
+    end
+
+    stub_const("IndentContainer", test_class)
+  end
+
+  let(:model) do
+    IndentContainer.new(
+      title: "Test",
+      items: [IndentItem.new(name: "a"), IndentItem.new(name: "b")],
+    )
+  end
+
+  it "uses default indent of 2 spaces" do
+    xml = model.to_xml
+    expect(xml).to include("  <title>Test</title>")
+    expect(xml).to include("  <item>")
+  end
+
+  it "produces compact output with indent: 0" do
+    xml = model.to_xml(indent: 0)
+    expect(xml).not_to include("\n  ")
+    expect(xml).not_to include("\n    ")
+  end
+
+  it "uses 4-space indent when indent: 4" do
+    xml = model.to_xml(indent: 4)
+    expect(xml).to include("    <title>Test</title>")
+    expect(xml).to include("    <item>")
+  end
+
+  it "nests consistently at multiple levels with indent: 4" do
+    nested_class = Class.new do
+      include Lutaml::Model::Serialize
+
+      attribute :label, :string
+      attribute :child, IndentItem
+
+      xml do
+        element "nested"
+        map_element "label", to: :label
+        map_element "item", to: :child
+      end
+    end
+
+    stub_const("IndentNested", nested_class)
+
+    container = Class.new do
+      include Lutaml::Model::Serialize
+
+      attribute :nested, IndentNested
+
+      xml do
+        element "root"
+        map_element "nested", to: :nested
+      end
+    end
+
+    stub_const("IndentRoot", container)
+
+    instance = IndentRoot.new(
+      nested: IndentNested.new(
+        label: "outer",
+        child: IndentItem.new(name: "inner"),
+      ),
+    )
+
+    xml = instance.to_xml(indent: 4)
+    expect(xml).to include("    <nested>")
+    expect(xml).to include("        <label>outer</label>")
+    expect(xml).to include("        <item>")
+    expect(xml).to include("            <name>inner</name>")
+  end
+
+  it "preserves text content without extra whitespace" do
+    xml = model.to_xml
+    expect(xml).to include("<title>Test</title>")
+    expect(xml).to include("<name>a</name>")
+  end
+end

--- a/spec/lutaml/xml/line_ending_spec.rb
+++ b/spec/lutaml/xml/line_ending_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Line ending configuration" do
+  before do
+    test_class = Class.new do
+      include Lutaml::Model::Serialize
+
+      attribute :title, :string
+      attribute :body, :string
+
+      xml do
+        element "article"
+        map_element "title", to: :title
+        map_element "body", to: :body
+      end
+    end
+
+    stub_const("LineEndingArticle", test_class)
+  end
+
+  let(:model) { LineEndingArticle.new(title: "Test", body: "Content") }
+
+  it "uses LF (\\n) line endings by default" do
+    xml = model.to_xml
+    expect(xml).not_to include("\r\n")
+  end
+
+  it "produces CRLF when line_ending: CRLF is specified" do
+    xml = model.to_xml(line_ending: "\r\n")
+    lines = xml.split("\n", -1)
+    crlf_count = lines.count { |l| l.end_with?("\r") }
+    expect(crlf_count).to be > 0
+  end
+
+  it "applies line endings consistently across declaration and body" do
+    xml = model.to_xml(line_ending: "\r\n", declaration: true)
+    expect(xml.lines).to all(end_with("\r\n"))
+  end
+
+  it "preserves LF in round-trip" do
+    xml_in = "<article><title>Test</title><body>Content</body></article>"
+    parsed = LineEndingArticle.from_xml(xml_in)
+    xml_out = parsed.to_xml
+    expect(xml_out).not_to include("\r\n")
+  end
+
+  it "does not produce mixed line endings" do
+    xml = model.to_xml(line_ending: "\r\n")
+    crlf_positions = []
+    lf_only_positions = []
+    xml.each_char.with_index do |c, i|
+      next unless c == "\n"
+
+      prev = i > 0 ? xml[i - 1] : nil
+      if prev == "\r"
+        crlf_positions << i
+      else
+        lf_only_positions << i
+      end
+    end
+    # Either all newlines are CRLF or none are — no mixing
+    expect(lf_only_positions).to be_empty, "Mixed line endings found"
+  end
+end

--- a/spec/lutaml/xml/mapping_finalization_guard_spec.rb
+++ b/spec/lutaml/xml/mapping_finalization_guard_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Mapping finalization cache guard specs" do
       attribute :age, :integer
 
       xml do
-        root "person"
+        element "person"
         map_element "name", to: :name
         map_attribute "age", to: :age
       end
@@ -52,7 +52,7 @@ RSpec.describe "Mapping finalization cache guard specs" do
         attribute :email, :string
 
         xml do
-          root "person"
+          element "person"
           map_element "email", to: :email
         end
 

--- a/spec/lutaml/xml/model_transform_guard_spec.rb
+++ b/spec/lutaml/xml/model_transform_guard_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "ModelTransform name conversion guard specs" do
       attribute :ns_attr, :string
 
       xml do
-        root "root"
+        element "root"
         map_element "name", to: :name
         map_attribute "ex:attr", to: :ns_attr
       end
@@ -53,7 +53,7 @@ RSpec.describe "ModelTransform name conversion guard specs" do
         attribute :value, :string
 
         xml do
-          root "nested"
+          element "nested"
           map_content to: :value
         end
 
@@ -66,7 +66,7 @@ RSpec.describe "ModelTransform name conversion guard specs" do
         attribute :child, nested_class
 
         xml do
-          root "parent"
+          element "parent"
           map_element "child", to: :child
         end
 
@@ -104,7 +104,7 @@ RSpec.describe "ModelTransform name conversion guard specs" do
         attribute :b, :string
 
         xml do
-          root "root"
+          element "root"
           map_attribute "ns:a", to: :a
           map_attribute "ns:b", to: :b
         end

--- a/spec/lutaml/xml/namespace_alias_spec.rb
+++ b/spec/lutaml/xml/namespace_alias_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe "Namespace alias support" do
         attribute :item, :string
 
         xml do
-          root "root"
+          element "root"
           namespace ns
           map_element "item", to: :item
         end
@@ -170,7 +170,7 @@ RSpec.describe "Namespace alias support" do
         attribute :name, :string
 
         xml do
-          root "Inner"
+          element "Inner"
           namespace ns
           map_element "name", to: :name
         end
@@ -184,7 +184,7 @@ RSpec.describe "Namespace alias support" do
         attribute :child, ic
 
         xml do
-          root "Outer"
+          element "Outer"
           namespace ns
           map_element "Inner", to: :child
         end
@@ -236,7 +236,7 @@ RSpec.describe "Namespace alias support" do
         attribute :child_name, :string
 
         xml do
-          root "Parent"
+          element "Parent"
           namespace pns
           map_element "childName", to: :child_name
           namespace cns

--- a/spec/lutaml/xml/namespace_aware_parsing_spec.rb
+++ b/spec/lutaml/xml/namespace_aware_parsing_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "Namespace-Aware XML Parsing" do
 
       xml do
         namespace ns
-        root "Model"
+        element "Model"
         map_element "Name", to: :name
         map_element "Version", to: :version
       end
@@ -49,7 +49,7 @@ RSpec.describe "Namespace-Aware XML Parsing" do
 
       xml do
         namespace ns
-        root "Model"
+        element "Model"
         map_element "Title", to: :title
         map_element "Version", to: :version
       end
@@ -63,7 +63,7 @@ RSpec.describe "Namespace-Aware XML Parsing" do
 
       xml do
         namespace ns
-        root "Common"
+        element "Common"
         map_element "Id", to: :id
       end
     end

--- a/spec/lutaml/xml/namespace_bound_element_roundtrip_spec.rb
+++ b/spec/lutaml/xml/namespace_bound_element_roundtrip_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe "Namespace-Aware Round-Trip Serialization" do
       attribute :write_protection, :boolean
 
       xml do
-        root "settings"
+        element "settings"
         namespace w_ns
         namespace_scope [w14_ns, w15_ns]
 
@@ -364,7 +364,7 @@ RSpec.describe "Namespace-Aware Round-Trip Serialization" do
         attribute :author, :string
 
         xml do
-          root "document"
+          element "document"
           namespace simple_ns
 
           map_element "title", to: :title

--- a/spec/lutaml/xml/namespace_format_preservation_spec.rb
+++ b/spec/lutaml/xml/namespace_format_preservation_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Namespace format preservation" do
       attribute :name, :string
 
       xml do
-        root "TestModel"
+        element "TestModel"
         namespace ns
         map_element "name", to: :name
       end

--- a/spec/lutaml/xml/namespace_inheritance_spec.rb
+++ b/spec/lutaml/xml/namespace_inheritance_spec.rb
@@ -234,7 +234,7 @@ RSpec.describe "XML namespace inheritance" do
       # - Child's parent_ns_attr is in PARENT namespace (different from child) → MUST have prefix
       # - Child's child_ns_attr is in CHILD namespace (same as child) → NO prefix (unqualified)
       expected = <<~XML.chomp
-        <parent:parent xmlns:parent="http://example.com/parent" xmlns:child="http://example.com/child" child:child_ns_attr="value">
+        <parent:parent xmlns:child="http://example.com/child" xmlns:parent="http://example.com/parent" child:child_ns_attr="value">
           <child:child parent:parent_ns_attr="value" child_ns_attr="value">test</child:child>
         </parent:parent>
       XML
@@ -926,7 +926,7 @@ RSpec.describe "XML namespace inheritance" do
       # have NO prefix (inherit from element's namespace context)
       # Type namespace (child_ns_attr) is declared on root for efficiency
       expected = <<~XML.chomp
-        <parent:collection xmlns:parent="http://example.com/parent" xmlns:child="http://example.com/child">
+        <parent:collection xmlns:child="http://example.com/child" xmlns:parent="http://example.com/parent">
           <parent:item parent_ns_attr="value1" child:child_ns_attr="value1">first</parent:item>
           <parent:item parent_ns_attr="value2" child:child_ns_attr="value2">second</parent:item>
           <parent:item parent_ns_attr="value3" child:child_ns_attr="value3">third</parent:item>
@@ -953,7 +953,7 @@ RSpec.describe "XML namespace inheritance" do
       # W3C attributeFormDefault="unqualified": attributes in same namespace as element
       # have NO prefix (inherit from element's namespace context)
       expected = <<~XML.chomp
-        <parent:collection xmlns:parent="http://example.com/parent" xmlns:child="http://example.com/child">
+        <parent:collection xmlns:child="http://example.com/child" xmlns:parent="http://example.com/parent">
           <parent:item parent_ns_attr="value1" child:child_ns_attr="value1">first</parent:item>
           <parent:item parent_ns_attr="value2" child:child_ns_attr="value2">second</parent:item>
           <parent:item parent_ns_attr="value3" child:child_ns_attr="value3">third</parent:item>

--- a/spec/lutaml/xml/namespace_preservation_spec.rb
+++ b/spec/lutaml/xml/namespace_preservation_spec.rb
@@ -256,7 +256,7 @@ RSpec.describe "Namespace Preservation Issue #3" do
         attribute :title, :string
 
         xml do
-          root "article"
+          element "article"
           namespace article_ns
           map_element "title", to: :title
         end
@@ -299,7 +299,7 @@ RSpec.describe "Namespace Preservation Issue #3" do
         attribute :title, :string
 
         xml do
-          root "article"
+          element "article"
           namespace article_ns
           map_element "title", to: :title
         end
@@ -340,7 +340,7 @@ RSpec.describe "Namespace Preservation Issue #3" do
         attribute :exterior, :string
 
         xml do
-          root "Polygon"
+          element "Polygon"
           namespace gml_ns
           map_element "exterior", to: :exterior
         end
@@ -383,7 +383,7 @@ RSpec.describe "Namespace Preservation Issue #3" do
         attribute :content, :string
 
         xml do
-          root "child"
+          element "child"
           namespace child_ns
           map_content to: :content
         end
@@ -399,7 +399,7 @@ RSpec.describe "Namespace Preservation Issue #3" do
         attribute :child, child_class
 
         xml do
-          root "parent"
+          element "parent"
           map_element "title", to: :title
           map_element "child", to: :child
         end

--- a/spec/lutaml/xml/opal_xml_spec.rb
+++ b/spec/lutaml/xml/opal_xml_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "XML with REXML under Opal", if: RUBY_ENGINE == "opal" do
 
       attribute :name, :string
       xml do
-        root "person"
+        element "person"
         map_element "name", to: :name
       end
     end
@@ -30,7 +30,7 @@ RSpec.describe "XML with REXML under Opal", if: RUBY_ENGINE == "opal" do
       attribute :id, :string
       attribute :value, :string
       xml do
-        root "item"
+        element "item"
         map_attribute "id", to: :id
         map_element "value", to: :value
       end
@@ -47,7 +47,7 @@ RSpec.describe "XML with REXML under Opal", if: RUBY_ENGINE == "opal" do
 
       attribute :city, :string
       xml do
-        root "address"
+        element "address"
         map_element "city", to: :city
       end
     end
@@ -58,7 +58,7 @@ RSpec.describe "XML with REXML under Opal", if: RUBY_ENGINE == "opal" do
       attribute :name, :string
       attribute :address, address
       xml do
-        root "person"
+        element "person"
         map_element "name", to: :name
         map_element "address", to: :address
       end
@@ -75,7 +75,7 @@ RSpec.describe "XML with REXML under Opal", if: RUBY_ENGINE == "opal" do
 
       attribute :items, :string, collection: true
       xml do
-        root "list"
+        element "list"
         map_element "item", to: :items
       end
     end
@@ -90,7 +90,7 @@ RSpec.describe "XML with REXML under Opal", if: RUBY_ENGINE == "opal" do
 
       attribute :content, :string, collection: true
       xml do
-        root "p"
+        element "p"
         mixed_content
         map_content to: :content
       end
@@ -107,7 +107,7 @@ RSpec.describe "XML with REXML under Opal", if: RUBY_ENGINE == "opal" do
       attribute :title, :string
       attribute :count, :integer
       xml do
-        root "item"
+        element "item"
         map_element "title", to: :title
         map_element "count", to: :count
       end
@@ -131,7 +131,7 @@ RSpec.describe "XML with REXML under Opal", if: RUBY_ENGINE == "opal" do
       model plain_model
       attribute :data, :string
       xml do
-        root "data"
+        element "data"
         map_element "data", to: :data
       end
     end

--- a/spec/lutaml/xml/pipeline_integration_spec.rb
+++ b/spec/lutaml/xml/pipeline_integration_spec.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Full serialization pipeline" do
+  before do
+    item_class = Class.new do
+      include Lutaml::Model::Serialize
+
+      attribute :name, :string
+      attribute :value, :string
+
+      xml do
+        element "item"
+        map_element "name", to: :name
+        map_element "value", to: :value
+      end
+    end
+
+    stub_const("PipeItem", item_class)
+
+    doc_class = Class.new do
+      include Lutaml::Model::Serialize
+
+      attribute :title, :string
+      attribute :items, PipeItem, collection: true
+
+      xml do
+        element "document"
+        map_element "title", to: :title
+        map_element "item", to: :items
+      end
+    end
+
+    stub_const("PipeDoc", doc_class)
+  end
+
+  let(:model) do
+    PipeDoc.new(
+      title: "Test",
+      items: [
+        PipeItem.new(name: "a", value: "1"),
+        PipeItem.new(name: "b", value: "2"),
+      ],
+    )
+  end
+
+  it "produces identical output for identical models across multiple runs" do
+    first = model.to_xml
+    second = model.to_xml
+    expect(first).to eq(second)
+  end
+
+  it "handles declaration + doctype + content together" do
+    xml = model.to_xml(
+      declaration: true,
+      doctype: { name: "document", system_id: "doc.dtd" },
+    )
+
+    expect(xml).to start_with("<?xml")
+    expect(xml).to include("<!DOCTYPE document SYSTEM \"doc.dtd\">")
+    expect(xml).to include("<title>Test</title>")
+    expect(xml).to include("<name>a</name>")
+  end
+
+  it "CRLF + indent=4 + declaration produces correct output" do
+    xml = model.to_xml(
+      line_ending: "\r\n",
+      indent: 4,
+      declaration: true,
+    )
+
+    expect(xml.lines).to all(end_with("\r\n"))
+    expect(xml).to include("    <title>Test</title>")
+    expect(xml).to include("<?xml")
+  end
+
+  it "round-trips complex XML with all features preserved" do
+    input = <<~XML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <document>
+        <title>Original</title>
+        <item>
+          <name>x</name>
+          <value>42</value>
+        </item>
+      </document>
+    XML
+
+    parsed = PipeDoc.from_xml(input)
+    expect(parsed.title).to eq("Original")
+    expect(parsed.items.length).to eq(1)
+    expect(parsed.items.first.name).to eq("x")
+    expect(parsed.items.first.value).to eq("42")
+
+    output = parsed.to_xml(declaration: true)
+    expect(output).to start_with("<?xml")
+    expect(output).to include("<title>Original</title>")
+    expect(output).to include("<name>x</name>")
+  end
+
+  it "round-trip preserves namespace declarations" do
+    ns = Class.new(Lutaml::Xml::W3c::XmlNamespace) do
+      uri "http://example.com/ns"
+      prefix_default "ex"
+    end
+
+    stub_const("PipeNs", ns)
+
+    ns_child = Class.new do
+      include Lutaml::Model::Serialize
+
+      attribute :content, :string
+
+      xml do
+        element "child"
+        namespace PipeNs
+        map_element "content", to: :content
+      end
+    end
+
+    stub_const("PipeNsChild", ns_child)
+
+    ns_parent = Class.new do
+      include Lutaml::Model::Serialize
+
+      attribute :child, PipeNsChild
+
+      xml do
+        element "parent"
+        map_element "child", to: :child
+      end
+    end
+
+    stub_const("PipeNsParent", ns_parent)
+
+    instance = PipeNsParent.new(child: PipeNsChild.new(content: "data"))
+    xml = instance.to_xml
+
+    expect(xml).to include("xmlns")
+
+    parsed = PipeNsParent.from_xml(xml)
+    expect(parsed.child.content).to eq("data")
+  end
+end

--- a/spec/lutaml/xml/schema_primer_spec.rb
+++ b/spec/lutaml/xml/schema_primer_spec.rb
@@ -44,7 +44,7 @@ module XmlSchemaPrimerFeaturesSpec
     attribute :work_address, AddressType
 
     xml do
-      root "Person"
+      element "Person"
       map_element "homeAddress", to: :home_address
       map_element "workAddress", to: :work_address
     end
@@ -69,7 +69,7 @@ module XmlSchemaPrimerFeaturesSpec
     attribute :ship_to, UsAddress
 
     xml do
-      root "purchaseOrder"
+      element "purchaseOrder"
       namespace PoNamespace
       map_element "shipTo", to: :ship_to
     end
@@ -85,7 +85,7 @@ module XmlSchemaPrimerFeaturesSpec
     attribute :comment, :string
 
     xml do
-      root "purchaseOrder"
+      element "purchaseOrder"
       namespace PoNamespaceQualified
 
       map_element "shipTo", to: :ship_to
@@ -103,7 +103,7 @@ module XmlSchemaPrimerFeaturesSpec
     attribute :comment, :string
 
     xml do
-      root "purchaseOrder"
+      element "purchaseOrder"
       namespace PoNamespacePrefixed
 
       map_element "shipTo", to: :ship_to
@@ -129,7 +129,7 @@ module XmlSchemaPrimerFeaturesSpec
     attribute :notes, :string
 
     xml do
-      root "supplier"
+      element "supplier"
       namespace MixedNamespace
 
       map_element "contact", to: :contact

--- a/spec/lutaml/xml/transformation_spec.rb
+++ b/spec/lutaml/xml/transformation_spec.rb
@@ -10,7 +10,7 @@ module TransformationSpecModels
     attribute :value, :integer
 
     xml do
-      root "SimpleModel"
+      element "SimpleModel"
       map_element "name", to: :name
       map_element "value", to: :value
     end
@@ -21,7 +21,7 @@ module TransformationSpecModels
     attribute :type, :string
 
     xml do
-      root "Model"
+      element "Model"
       map_attribute "id", to: :id
       map_attribute "type", to: :type
     end
@@ -31,7 +31,7 @@ module TransformationSpecModels
     attribute :text, :string
 
     xml do
-      root "Model"
+      element "Model"
       map_content to: :text
     end
   end
@@ -41,7 +41,7 @@ module TransformationSpecModels
     attribute :email, :string
 
     xml do
-      root "Contact"
+      element "Contact"
       map_element "name", to: :name
       map_element "email", to: :email
     end
@@ -52,7 +52,7 @@ module TransformationSpecModels
     attribute :name, :string
 
     xml do
-      root "Person"
+      element "Person"
       map_attribute "id", to: :id
       map_element "name", to: :name
     end
@@ -62,7 +62,7 @@ module TransformationSpecModels
     attribute :content, :string
 
     xml do
-      root "Note"
+      element "Note"
       map_content to: :content
     end
   end
@@ -72,7 +72,7 @@ module TransformationSpecModels
     attribute :city, :string
 
     xml do
-      root "Address"
+      element "Address"
       map_element "street", to: :street
       map_element "city", to: :city
     end
@@ -83,7 +83,7 @@ module TransformationSpecModels
     attribute :address, TransformationSpecModels::Address
 
     xml do
-      root "Person"
+      element "Person"
       map_element "name", to: :name
       map_element "Address", to: :address
     end
@@ -93,7 +93,7 @@ module TransformationSpecModels
     attribute :title, :string
 
     xml do
-      root "Book"
+      element "Book"
       map_element "title", to: :title
     end
   end
@@ -103,7 +103,7 @@ module TransformationSpecModels
     attribute :book, TransformationSpecModels::Book
 
     xml do
-      root "Library"
+      element "Library"
       map_element "name", to: :name
       map_element "Book", to: :book
     end
@@ -113,7 +113,7 @@ module TransformationSpecModels
     attribute :tags, :string, collection: true
 
     xml do
-      root "TagList"
+      element "TagList"
       map_element "tag", to: :tags
     end
   end
@@ -123,7 +123,7 @@ module TransformationSpecModels
     attribute :price, :float
 
     xml do
-      root "Item"
+      element "Item"
       map_element "name", to: :name
       map_element "price", to: :price
     end
@@ -133,7 +133,7 @@ module TransformationSpecModels
     attribute :items, TransformationSpecModels::Item, collection: true
 
     xml do
-      root "Cart"
+      element "Cart"
       map_element "Item", to: :items
     end
   end
@@ -149,7 +149,7 @@ module TransformationSpecModels
     attribute :value, :string
 
     xml do
-      root "Model"
+      element "Model"
       namespace TestNs::MyNamespace
       map_element "value", to: :value
     end
@@ -171,7 +171,7 @@ module TransformationSpecModels
     attribute :value, :string
 
     xml do
-      root "Child"
+      element "Child"
       namespace NsTest::Ns2
       map_element "value", to: :value
     end
@@ -182,7 +182,7 @@ module TransformationSpecModels
     attribute :child, TransformationSpecModels::Child
 
     xml do
-      root "Parent"
+      element "Parent"
       namespace NsTest::Ns1
       map_element "name", to: :name
       map_element "Child", to: :child
@@ -195,7 +195,7 @@ module TransformationSpecModels
     }
 
     xml do
-      root "Model"
+      element "Model"
       map_element "name", to: :name
     end
   end
@@ -204,7 +204,7 @@ module TransformationSpecModels
     attribute :status, :string, default: -> { "active" }
 
     xml do
-      root "Model"
+      element "Model"
       map_element "status", to: :status, render_default: false
     end
   end
@@ -213,7 +213,7 @@ module TransformationSpecModels
     attribute :optional, :string
 
     xml do
-      root "Model"
+      element "Model"
       map_element "optional", to: :optional, render_nil: true
     end
   end
@@ -222,7 +222,7 @@ module TransformationSpecModels
     attribute :value, :string
 
     xml do
-      root "Model"
+      element "Model"
       map_element "value", to: :value
     end
   end

--- a/spec/lutaml/xml/type_namespace/collector_spec.rb
+++ b/spec/lutaml/xml/type_namespace/collector_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Lutaml::Xml::TypeNamespace::Collector do
       attribute :author, :string
 
       xml do
-        root "document"
+        element "document"
         map_element "title", to: :title
         map_element "author", to: :author
       end

--- a/spec/lutaml/xml/type_namespace/planner_spec.rb
+++ b/spec/lutaml/xml/type_namespace/planner_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Lutaml::Xml::TypeNamespace::Planner do
       attribute :author, :string
 
       xml do
-        root "document"
+        element "document"
         map_element "title", to: :title
         map_element "author", to: :author
       end
@@ -155,7 +155,7 @@ RSpec.describe Lutaml::Xml::TypeNamespace::Planner do
           attribute :title, type
 
           xml do
-            root "document"
+            element "document"
             map_element "title", to: :title
           end
         end
@@ -183,7 +183,7 @@ RSpec.describe Lutaml::Xml::TypeNamespace::Planner do
           attribute :title, :string
 
           xml do
-            root "document"
+            element "document"
             map_element "title", to: :title
           end
         end


### PR DESCRIPTION
## Summary

This PR combines two related improvements to the XML serialization pipeline:

### 1. Model-driven XML pipeline via moxml (`1cd15271`)
- Remove manual XML string assembly (finalize_adapter_xml, generate_declaration, generate_doctype_declaration)
- All document-level concerns (declaration, doctype, line endings, indentation, encoding) handled by moxml document model
- Builder creates declaration/doctype nodes via moxml API
- Namespace declarations sorted alphabetically for deterministic output
- Supports declaration modes (`:none`, `:default`) and `standalone: :preserve`

### 2. Format-appropriate DSL terminology (`5beca2f2`, `68ba7f76`)

**XML mapping DSL:**
- `root` → `element` (element is what it IS in XML domain)
- `no_root` deprecated — omit `element` declaration for type-only models

**Key-value mapping DSL:**
- `root` → `key` (key is what it IS in key-value domain)
- `no_root` deprecated — omit `key` call for no wrapper key
- Add `no_key?` as canonical predicate

**Error classes:**
- `NoRootMappingError` → `TypeOnlyMappingError` (with deprecated alias)
- `NoRootNamespaceError` → `TypeOnlyNamespaceError` (with deprecated alias)

**Collection hooks:**
- `collection_no_root_to?` → `collection_unwrapped_to?`
- `wrap_no_root_input` → `wrap_unwrapped_input`
- `unwrap_no_root_data` → `unwrap_unwrapped_data`

### 3. Tests
- Pipeline specs for indent, line endings, and full integration
- All 5014 specs pass, rubocop clean

### Backward compatibility
All old names (`root`, `no_root`, `NoRootMappingError`, etc.) are kept as deprecated aliases. Existing code continues to work with deprecation warnings.
