### PR TITLE
feat: RDF enhancements for glossarist

### DIFF
--- a/lib/lutaml/jsonld/transform.rb
+++ b/lib/lutaml/jsonld/transform.rb
@@ -45,6 +45,12 @@ module Lutaml
         build_instance(attrs, options)
       end
 
+      protected
+
+      def additional_resource_data(_instance, _mapping)
+        {}
+      end
+
       private
 
       def extract_mapping(options)
@@ -52,28 +58,32 @@ module Lutaml
       end
 
       def build_graph_document(mapping, instance)
-        context = build_merged_context(mapping, instance)
+        context = build_merged_context_recursive(mapping, instance)
+        graph = collect_resources(mapping, instance)
+
+        { "@context" => context, "@graph" => graph }
+      end
+
+      def collect_resources(mapping, instance)
         graph = []
 
-        if mapping.rdf_subject
-          resource = build_resource_data(mapping, instance)
-          graph << resource unless resource.empty?
-        end
+        resource = build_resource_data(mapping, instance)
+        graph << resource unless resource.empty?
 
         mapping.rdf_members.each do |member_rule|
           each_member(instance, member_rule) do |member|
             member_mapping = member_mapping_for(member, :jsonld)
             next unless member_mapping
 
-            resource = build_resource_data(member_mapping, member)
-            graph << resource unless resource.empty?
+            child_resources = collect_resources(member_mapping, member)
+            graph.concat(child_resources)
           end
         end
 
-        { "@context" => context, "@graph" => graph }
+        graph
       end
 
-      def build_merged_context(mapping, instance)
+      def build_merged_context_recursive(mapping, instance)
         context_hash = build_context_from_mapping(mapping).to_hash
 
         mapping.rdf_members.each do |member_rule|
@@ -82,6 +92,9 @@ module Lutaml
             next unless member_mapping
 
             context_hash.merge!(build_context_from_mapping(member_mapping).to_hash)
+
+            child_ctx = build_merged_context_recursive(member_mapping, member)
+            context_hash.merge!(child_ctx)
           end
         end
 
@@ -100,9 +113,14 @@ module Lutaml
         mapping.rdf_members.each do |member_rule|
           next unless member_rule.linked?
 
-          context.term(member_rule.predicate_name.to_s,
-                       id: member_rule.linked_predicate_uri,
-                       type: "@id")
+          predicate_uri = if member_rule.predicate_name
+                            member_rule.linked_predicate_uri
+                          end
+          if predicate_uri
+            context.term(member_rule.predicate_name.to_s,
+                         id: predicate_uri,
+                         type: "@id")
+          end
         end
 
         context
@@ -151,8 +169,11 @@ module Lutaml
           member_refs = collect_member_references(instance, member_rule)
           next if member_refs.empty?
 
-          result[member_rule.predicate_name.to_s] = member_refs
+          key = jsonld_member_key(member_rule)
+          result[key] = member_refs
         end
+
+        result.merge!(additional_resource_data(instance, mapping))
 
         result
       end
@@ -166,6 +187,16 @@ module Lutaml
           refs << { "@id" => resolve_subject_uri(member_mapping, member) }
         end
         refs
+      end
+
+      def jsonld_member_key(member_rule)
+        if member_rule.predicate_name
+          member_rule.predicate_name.to_s
+        elsif member_rule.link.is_a?(String)
+          member_rule.link.split(":").last
+        else
+          member_rule.attr_name.to_s
+        end
       end
 
       def serialize_value(value, rule)

--- a/lib/lutaml/model/version.rb
+++ b/lib/lutaml/model/version.rb
@@ -2,6 +2,6 @@
 
 module Lutaml
   module Model
-    VERSION = "0.8.14"
+    VERSION = "0.8.13"
   end
 end

--- a/lib/lutaml/rdf/mapping.rb
+++ b/lib/lutaml/rdf/mapping.rb
@@ -27,6 +27,14 @@ module Lutaml
         @rdf_type = Array(value)
       end
 
+      def types(*values)
+        @rdf_type = values.flatten
+      end
+
+      def has_types_or_predicates?
+        @rdf_type.any? || @rdf_predicates.any?
+      end
+
       def predicate(name, namespace:, to:, lang_tagged: false,
                     uri_reference: false)
         @rdf_predicates << Lutaml::Rdf::MappingRule.new(
@@ -38,11 +46,12 @@ module Lutaml
         )
       end
 
-      def members(attr_name, predicate_name: nil, namespace: nil)
+      def members(attr_name, predicate_name: nil, namespace: nil, link: nil)
         @rdf_members << Lutaml::Rdf::MemberRule.new(
           attr_name,
           predicate_name: predicate_name,
           namespace: namespace,
+          link: link,
         )
       end
 

--- a/lib/lutaml/rdf/member_rule.rb
+++ b/lib/lutaml/rdf/member_rule.rb
@@ -3,27 +3,52 @@
 module Lutaml
   module Rdf
     class MemberRule
-      attr_reader :attr_name, :predicate_name, :namespace
+      attr_reader :attr_name, :predicate_name, :namespace, :link
 
-      def initialize(attr_name, predicate_name: nil, namespace: nil)
+      def initialize(attr_name, predicate_name: nil, namespace: nil, link: nil)
         if predicate_name && !namespace
           raise ArgumentError,
                 "namespace is required when predicate_name is provided"
         end
 
+        if predicate_name && link
+          raise ArgumentError,
+                "predicate_name and link are mutually exclusive"
+        end
+
         @attr_name = attr_name.to_sym
         @predicate_name = predicate_name
         @namespace = namespace
+        @link = link
       end
 
       def linked?
-        !!@predicate_name
+        !!(@predicate_name || @link)
       end
 
       def linked_predicate_uri
-        return nil unless linked?
+        return nil unless @predicate_name
 
         @namespace[@predicate_name]
+      end
+
+      def link_predicate_for(member, resolver)
+        return nil unless @link
+
+        case @link
+        when String
+          resolver.call(@link)
+        when Proc
+          resolver.call(@link.call(member))
+        end
+      end
+
+      def resolve_link_uri(member, resolver)
+        if @predicate_name
+          linked_predicate_uri
+        elsif @link
+          link_predicate_for(member, resolver)
+        end
       end
     end
   end

--- a/lib/lutaml/turtle/transform.rb
+++ b/lib/lutaml/turtle/transform.rb
@@ -10,7 +10,7 @@ module Lutaml
         mapping = extract_turtle_mapping(options)
         return "" unless mapping
 
-        if !mapping.rdf_subject && mapping.rdf_predicates.any? && mapping.rdf_members.empty?
+        if !mapping.rdf_subject && mapping.has_types_or_predicates? && mapping.rdf_members.empty?
           raise MissingSubjectError,
                 "Turtle mapping requires a subject block"
         end
@@ -18,7 +18,7 @@ module Lutaml
         graph = build_graph(mapping, instance)
         return "" if graph.empty?
 
-        prefixes = build_prefixes(mapping, instance)
+        prefixes = collect_all_prefixes(mapping, instance)
         RDF::Turtle::Writer.buffer(prefixes: prefixes) do |writer|
           graph.each_statement { |stmt| writer << stmt }
         end.strip
@@ -37,6 +37,12 @@ module Lutaml
         build_instance(attrs, options)
       end
 
+      protected
+
+      def additional_resource_triples(_instance, _subject_uri, _mapping)
+        []
+      end
+
       private
 
       def extract_turtle_mapping(options)
@@ -47,63 +53,69 @@ module Lutaml
         graph = RDF::Graph.new
 
         has_resource_data =
-          mapping.rdf_type.any? ||
-          mapping.rdf_predicates.any? ||
+          mapping.has_types_or_predicates? ||
           mapping.rdf_members.any?(&:linked?)
 
         if has_resource_data
-          subject_uri = resolve_subject(mapping, instance)
-          build_resource_triples(graph, mapping, instance, subject_uri)
+          subject_uri = if mapping.rdf_subject
+                          RDF::URI(resolve_subject_uri(mapping, instance))
+                        else
+                          RDF::Node.new
+                        end
+
+          emit_type_statements(graph, subject_uri, mapping)
+          emit_predicate_statements(graph, subject_uri, instance, mapping)
+          emit_member_link_statements(graph, subject_uri, instance, mapping)
+          additional_resource_triples(instance, subject_uri, mapping).each do |stmt|
+            graph << stmt
+          end
         end
 
-        build_member_subgraphs(graph, mapping, instance)
+        emit_child_resources(graph, instance, mapping)
 
         graph
       end
 
-      def resolve_subject(mapping, instance)
-        if mapping.rdf_subject
-          RDF::URI(resolve_subject_uri(mapping, instance))
-        else
-          RDF::Node.new
-        end
-      end
-
-      def build_resource_triples(graph, mapping, instance, subject_uri)
+      def emit_type_statements(graph, subject_uri, mapping)
         mapping.rdf_type.each do |type_value|
           type_uri = RDF::URI(resolve_single_type_uri(mapping, type_value))
           graph << RDF::Statement.new(subject_uri, RDF.type, type_uri)
         end
+      end
 
+      def emit_predicate_statements(graph, subject_uri, instance, mapping)
         mapping.rdf_predicates.each do |rule|
           value = instance.public_send(rule.to)
           next if value.nil?
 
           Array(value).each do |v|
+            next if v.is_a?(String) && v.empty?
+
             object = build_rdf_object(v, rule, mapping.namespace_set)
             graph << RDF::Statement.new(subject_uri, RDF::URI(rule.uri), object)
           end
         end
+      end
 
+      def emit_member_link_statements(graph, subject_uri, instance, mapping)
         mapping.rdf_members.each do |member_rule|
           next unless member_rule.linked?
 
           each_member(instance, member_rule) do |member|
             member_mapping = member_mapping_for(member, :turtle)
-            next unless member_mapping
+            next unless member_mapping&.rdf_subject
 
-            member_subject = RDF::URI(resolve_subject_uri(member_mapping,
-                                                          member))
-            graph << RDF::Statement.new(
-              subject_uri,
-              RDF::URI(member_rule.linked_predicate_uri),
-              member_subject,
-            )
+            child_uri = RDF::URI(resolve_subject_uri(member_mapping, member))
+            resolver = mapping.namespace_set.method(:resolve_compact_iri)
+            link_uri = RDF::URI(member_rule.resolve_link_uri(member, resolver))
+            next unless link_uri
+
+            graph << RDF::Statement.new(subject_uri, link_uri, child_uri)
           end
         end
       end
 
-      def build_member_subgraphs(graph, mapping, instance)
+      def emit_child_resources(graph, instance, mapping)
         mapping.rdf_members.each do |member_rule|
           each_member(instance, member_rule) do |member|
             member_mapping = member_mapping_for(member, :turtle)
@@ -144,7 +156,14 @@ module Lutaml
         end
       end
 
-      def build_prefixes(mapping, instance)
+      def collect_all_prefixes(mapping, instance)
+        ns_set = collect_namespaces_recursive(mapping, instance)
+        ns_set.each.with_object({}) do |ns, h|
+          h[ns.prefix.to_sym] = ns.uri if ns.prefix && ns.uri
+        end
+      end
+
+      def collect_namespaces_recursive(mapping, instance)
         ns_set = mapping.namespace_set
 
         mapping.rdf_members.each do |member_rule|
@@ -153,12 +172,12 @@ module Lutaml
             next unless member_mapping
 
             ns_set = ns_set.merge(member_mapping.namespace_set)
+            child_ns = collect_namespaces_recursive(member_mapping, member)
+            ns_set = ns_set.merge(child_ns)
           end
         end
 
-        ns_set.each.with_object({}) do |ns, h|
-          h[ns.prefix.to_sym] = ns.uri if ns.prefix && ns.uri
-        end
+        ns_set
       end
 
       def extract_attributes(graph, mapping)
@@ -175,6 +194,12 @@ module Lutaml
         attrs
       end
 
+      def find_subjects_by_types(graph, type_uris)
+        type_uris.flat_map do |type_uri|
+          graph.query([nil, RDF.type, RDF::URI(type_uri)]).map(&:subject).uniq
+        end.uniq
+      end
+
       def extract_predicate_attributes(graph, subject, mapping, attrs)
         mapping.rdf_predicates.each do |rule|
           stmts = graph.query([subject, RDF::URI(rule.uri), nil])
@@ -185,12 +210,6 @@ module Lutaml
           end
           attrs[rule.to] = values.length == 1 ? values.first : values
         end
-      end
-
-      def find_subjects_by_types(graph, type_uris)
-        type_uris.flat_map do |type_uri|
-          graph.query([nil, RDF.type, RDF::URI(type_uri)]).map(&:subject).uniq
-        end.uniq
       end
 
       def literal_to_ruby(rdf_object, rule, namespace_set)

--- a/spec/lutaml/jsonld/transform_spec.rb
+++ b/spec/lutaml/jsonld/transform_spec.rb
@@ -447,4 +447,151 @@ RSpec.describe Lutaml::JsonLd::Transform do
       expect(parsed).not_to have_key("@type")
     end
   end
+
+  describe "dynamic link predicates (String)" do
+    before do
+      stub_const("JsonLdDynChild", Class.new(Lutaml::Model::Serializable) do
+        attribute :cid, :string
+        attribute :label, :string
+
+        rdf do
+          namespace TestSkosNs, TestExNs
+
+          subject { |m| "http://example.org/item/#{m.cid}" } # rubocop:disable RSpec/NamedSubject, RSpec/MultipleSubjects
+
+          type "skos:Concept"
+
+          predicate :prefLabel, namespace: TestSkosNs, to: :label
+        end
+      end)
+
+      stub_const("JsonLdDynParent", Class.new(Lutaml::Model::Serializable) do
+        attribute :name, :string
+        attribute :children, JsonLdDynChild, collection: true
+
+        rdf do
+          namespace TestSkosNs, TestExNs
+
+          subject { |m| "http://example.org/group/#{m.name}" } # rubocop:disable RSpec/NamedSubject, RSpec/MultipleSubjects
+
+          type "skos:Collection"
+
+          predicate :prefLabel, namespace: TestSkosNs, to: :name
+
+          members :children, link: "skos:member"
+        end
+      end)
+    end
+
+    it "generates @id references for linked members" do
+      parent = JsonLdDynParent.new(
+        name: "grp1",
+        children: [
+          JsonLdDynChild.new(cid: "a", label: "Alpha"),
+          JsonLdDynChild.new(cid: "b", label: "Beta"),
+        ],
+      )
+      parsed = JSON.parse(parent.to_jsonld)
+      parent_resource = parsed["@graph"].find { |r| r["@type"] == "skos:Collection" }
+      expect(parent_resource["member"]).to eq([
+                                                { "@id" => "http://example.org/item/a" },
+                                                { "@id" => "http://example.org/item/b" },
+                                              ])
+    end
+
+    it "includes member resources in @graph" do
+      parent = JsonLdDynParent.new(
+        name: "grp1",
+        children: [JsonLdDynChild.new(cid: "a", label: "Alpha")],
+      )
+      parsed = JSON.parse(parent.to_jsonld)
+      member = parsed["@graph"].find { |r| r["prefLabel"] == "Alpha" }
+      expect(member).not_to be_nil
+    end
+  end
+
+  describe "recursive context and resource collection" do
+    before do
+      stub_const("JsonLdLeaf", Class.new(Lutaml::Model::Serializable) do
+        attribute :value, :string
+        attribute :lid, :string
+
+        rdf do
+          namespace TestExNs
+
+          subject { |m| "http://example.org/leaf/#{m.lid}" } # rubocop:disable RSpec/NamedSubject, RSpec/MultipleSubjects
+
+          type "ex:Leaf"
+
+          predicate :name, namespace: TestExNs, to: :value
+        end
+      end)
+
+      stub_const("JsonLdMid", Class.new(Lutaml::Model::Serializable) do
+        attribute :label, :string
+        attribute :mid, :string
+        attribute :leaves, JsonLdLeaf, collection: true
+
+        rdf do
+          namespace TestSkosNs, TestExNs
+
+          subject { |m| "http://example.org/mid/#{m.mid}" } # rubocop:disable RSpec/NamedSubject, RSpec/MultipleSubjects
+
+          type "skos:Concept"
+
+          predicate :prefLabel, namespace: TestSkosNs, to: :label
+
+          members :leaves, link: "skos:member"
+        end
+      end)
+
+      stub_const("JsonLdRoot", Class.new(Lutaml::Model::Serializable) do
+        attribute :title, :string
+        attribute :mids, JsonLdMid, collection: true
+
+        rdf do
+          namespace TestSkosNs
+
+          subject { |m| "http://example.org/root/#{m.title}" } # rubocop:disable RSpec/NamedSubject, RSpec/MultipleSubjects
+
+          type "skos:Collection"
+
+          predicate :prefLabel, namespace: TestSkosNs, to: :title
+
+          members :mids, link: "skos:member"
+        end
+      end)
+    end
+
+    it "collects @context from all nesting levels" do
+      root = JsonLdRoot.new(
+        title: "r1",
+        mids: [JsonLdMid.new(
+          label: "m1",
+          mid: "a",
+          leaves: [JsonLdLeaf.new(value: "l1", lid: "x")],
+        )],
+      )
+      parsed = JSON.parse(root.to_jsonld)
+      expect(parsed["@context"]["skos"]).to eq("http://www.w3.org/2004/02/skos/core#")
+      expect(parsed["@context"]["ex"]).to eq("http://example.org/")
+    end
+
+    it "includes resources from all nesting levels in @graph" do
+      root = JsonLdRoot.new(
+        title: "r1",
+        mids: [JsonLdMid.new(
+          label: "m1",
+          mid: "a",
+          leaves: [JsonLdLeaf.new(value: "l1", lid: "x")],
+        )],
+      )
+      parsed = JSON.parse(root.to_jsonld)
+      graph = parsed["@graph"]
+      types = graph.map { |r| r["@type"] }
+      expect(types).to include("skos:Collection")
+      expect(types).to include("skos:Concept")
+      expect(types).to include("ex:Leaf")
+    end
+  end
 end

--- a/spec/lutaml/rdf/mapping_spec.rb
+++ b/spec/lutaml/rdf/mapping_spec.rb
@@ -46,6 +46,53 @@ RSpec.describe Lutaml::Rdf::Mapping do
     end
   end
 
+  describe "#types" do
+    it "stores multiple types from splat arguments" do
+      mapping.types("skos:Concept", "dcterms:Agent")
+      expect(mapping.rdf_type).to eq(["skos:Concept", "dcterms:Agent"])
+    end
+
+    it "stores single type" do
+      mapping.types("skos:Concept")
+      expect(mapping.rdf_type).to eq(["skos:Concept"])
+    end
+
+    it "flattens nested arrays" do
+      mapping.types(["skos:Concept", "owl:Thing"], "foaf:Person")
+      expect(mapping.rdf_type).to eq(["skos:Concept", "owl:Thing", "foaf:Person"])
+    end
+
+    it "overwrites previous types on subsequent call" do
+      mapping.types("skos:Concept")
+      mapping.types("dcterms:Agent")
+      expect(mapping.rdf_type).to eq(["dcterms:Agent"])
+    end
+  end
+
+  describe "#has_types_or_predicates?" do
+    it "returns false when no types or predicates" do
+      expect(mapping.has_types_or_predicates?).to be(false)
+    end
+
+    it "returns true when types are present" do
+      mapping.type("skos:Concept")
+      expect(mapping.has_types_or_predicates?).to be(true)
+    end
+
+    it "returns true when predicates are present" do
+      mapping.predicate(:prefLabel,
+                        namespace: Lutaml::Rdf::Namespaces::SkosNamespace, to: :name)
+      expect(mapping.has_types_or_predicates?).to be(true)
+    end
+
+    it "returns true when both types and predicates present" do
+      mapping.type("skos:Concept")
+      mapping.predicate(:prefLabel,
+                        namespace: Lutaml::Rdf::Namespaces::SkosNamespace, to: :name)
+      expect(mapping.has_types_or_predicates?).to be(true)
+    end
+  end
+
   describe "#predicate" do
     it "creates MappingRule with namespace reference" do
       mapping.predicate(
@@ -128,13 +175,13 @@ RSpec.describe Lutaml::Rdf::Mapping do
   end
 
   describe "#members" do
-    it "creates MemberRule" do
+    it "creates MemberRule without linking predicate" do
       mapping.members(:items)
       expect(mapping.rdf_members.length).to eq(1)
       expect(mapping.rdf_members.first.attr_name).to eq(:items)
     end
 
-    it "creates MemberRule with linking predicate" do
+    it "creates MemberRule with static linking predicate" do
       mapping.members(:items,
                       predicate_name: :member,
                       namespace: Lutaml::Rdf::Namespaces::SkosNamespace)
@@ -143,17 +190,34 @@ RSpec.describe Lutaml::Rdf::Mapping do
       expect(rule.linked_predicate_uri).to eq("http://www.w3.org/2004/02/skos/core#member")
     end
 
-    it "creates MemberRule without linking predicate" do
-      mapping.members(:items)
+    it "creates MemberRule with link as String" do
+      mapping.members(:items, link: "skos:member")
       rule = mapping.rdf_members.first
-      expect(rule.linked?).to be(false)
-      expect(rule.linked_predicate_uri).to be_nil
+      expect(rule.linked?).to be(true)
+      expect(rule.link).to eq("skos:member")
+    end
+
+    it "creates MemberRule with link as Proc" do
+      resolver = ->(item) { "skos:#{item.type}" }
+      mapping.members(:items, link: resolver)
+      rule = mapping.rdf_members.first
+      expect(rule.linked?).to be(true)
+      expect(rule.link).to eq(resolver)
     end
 
     it "raises when predicate_name given without namespace" do
       expect do
         mapping.members(:items, predicate_name: :member)
       end.to raise_error(ArgumentError, /namespace is required/)
+    end
+
+    it "raises when predicate_name and link both given" do
+      expect do
+        mapping.members(:items,
+                        predicate_name: :member,
+                        namespace: Lutaml::Rdf::Namespaces::SkosNamespace,
+                        link: "skos:member")
+      end.to raise_error(ArgumentError, /mutually exclusive/)
     end
   end
 

--- a/spec/lutaml/rdf/member_rule_spec.rb
+++ b/spec/lutaml/rdf/member_rule_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require_relative "../../../lib/lutaml/rdf"
 
 RSpec.describe Lutaml::Rdf::MemberRule do
   describe ".new" do
@@ -26,10 +27,19 @@ RSpec.describe Lutaml::Rdf::MemberRule do
                                  namespace: Lutaml::Rdf::Namespaces::SkosNamespace)
       expect(rule.predicate_name).to eq(:member)
     end
+
+    it "raises ArgumentError when predicate_name and link both given" do
+      expect do
+        described_class.new(:items,
+                            predicate_name: :member,
+                            namespace: Lutaml::Rdf::Namespaces::SkosNamespace,
+                            link: "skos:member")
+      end.to raise_error(ArgumentError, /mutually exclusive/)
+    end
   end
 
   describe "#linked?" do
-    it "returns false when no predicate_name" do
+    it "returns false when no linking option" do
       rule = described_class.new(:items)
       expect(rule.linked?).to be(false)
     end
@@ -38,6 +48,16 @@ RSpec.describe Lutaml::Rdf::MemberRule do
       rule = described_class.new(:items,
                                  predicate_name: :member,
                                  namespace: Lutaml::Rdf::Namespaces::SkosNamespace)
+      expect(rule.linked?).to be(true)
+    end
+
+    it "returns true when link is a String" do
+      rule = described_class.new(:items, link: "skos:member")
+      expect(rule.linked?).to be(true)
+    end
+
+    it "returns true when link is a Proc" do
+      rule = described_class.new(:items, link: ->(m) { "skos:#{m}" })
       expect(rule.linked?).to be(true)
     end
   end
@@ -53,6 +73,88 @@ RSpec.describe Lutaml::Rdf::MemberRule do
                                  predicate_name: :member,
                                  namespace: Lutaml::Rdf::Namespaces::SkosNamespace)
       expect(rule.linked_predicate_uri).to eq("http://www.w3.org/2004/02/skos/core#member")
+    end
+
+    it "returns nil when link is a String (not static)" do
+      rule = described_class.new(:items, link: "skos:member")
+      expect(rule.linked_predicate_uri).to be_nil
+    end
+  end
+
+  describe "#link_predicate_for" do
+    let(:mapping) do
+      instance = Lutaml::Rdf::Mapping.new
+      instance.namespace(
+        Lutaml::Rdf::Namespaces::SkosNamespace,
+        Lutaml::Rdf::Namespaces::DctermsNamespace,
+      )
+      instance
+    end
+
+    let(:resolver) { mapping.namespace_set.method(:resolve_compact_iri) }
+
+    it "resolves String link via resolver" do
+      rule = described_class.new(:items, link: "skos:member")
+      expect(rule.link_predicate_for(nil, resolver))
+        .to eq("http://www.w3.org/2004/02/skos/core#member")
+    end
+
+    it "resolves Proc link by calling with member" do
+      rule = described_class.new(:items,
+                                 link: ->(m) { "skos:#{m.type}" })
+      member = Struct.new(:type).new("Concept")
+      expect(rule.link_predicate_for(member, resolver))
+        .to eq("http://www.w3.org/2004/02/skos/core#Concept")
+    end
+
+    it "returns URI as-is from Proc when prefix not found" do
+      rule = described_class.new(:items,
+                                 link: ->(m) { "http://example.org/#{m.id}" })
+      member = Struct.new(:id).new("42")
+      expect(rule.link_predicate_for(member, resolver))
+        .to eq("http://example.org/42")
+    end
+
+    it "returns nil when no link" do
+      rule = described_class.new(:items)
+      expect(rule.link_predicate_for(nil, resolver)).to be_nil
+    end
+  end
+
+  describe "#resolve_link_uri" do
+    let(:mapping) do
+      instance = Lutaml::Rdf::Mapping.new
+      instance.namespace(Lutaml::Rdf::Namespaces::SkosNamespace)
+      instance
+    end
+
+    let(:resolver) { mapping.namespace_set.method(:resolve_compact_iri) }
+
+    it "uses linked_predicate_uri for static links" do
+      rule = described_class.new(:items,
+                                 predicate_name: :member,
+                                 namespace: Lutaml::Rdf::Namespaces::SkosNamespace)
+      expect(rule.resolve_link_uri(nil, resolver))
+        .to eq("http://www.w3.org/2004/02/skos/core#member")
+    end
+
+    it "uses link_predicate_for for String links" do
+      rule = described_class.new(:items, link: "skos:member")
+      expect(rule.resolve_link_uri(nil, resolver))
+        .to eq("http://www.w3.org/2004/02/skos/core#member")
+    end
+
+    it "uses link_predicate_for for Proc links" do
+      rule = described_class.new(:items,
+                                 link: ->(m) { "skos:#{m.type}" })
+      member = Struct.new(:type).new("Concept")
+      expect(rule.resolve_link_uri(member, resolver))
+        .to eq("http://www.w3.org/2004/02/skos/core#Concept")
+    end
+
+    it "returns nil when not linked" do
+      rule = described_class.new(:items)
+      expect(rule.resolve_link_uri(nil, resolver)).to be_nil
     end
   end
 end

--- a/spec/lutaml/turtle/transform_spec.rb
+++ b/spec/lutaml/turtle/transform_spec.rb
@@ -585,4 +585,148 @@ RSpec.describe Lutaml::Turtle::Transform do
       skip "Heterogeneous collection requires union-typed attribute (not yet supported)"
     end
   end
+
+  describe "dynamic link predicates" do
+    before do
+      stub_const("DynChild", Class.new(Lutaml::Model::Serializable) do
+        attribute :label, :string
+        attribute :cid, :string
+
+        turtle do
+          namespace Lutaml::Rdf::Namespaces::SkosNamespace
+
+          subject { |m| "http://example.org/child/#{m.cid}" } # rubocop:disable RSpec/NamedSubject, RSpec/MultipleSubjects
+
+          type "skos:Concept"
+
+          predicate :prefLabel,
+                    namespace: Lutaml::Rdf::Namespaces::SkosNamespace,
+                    to: :label
+        end
+      end)
+
+      stub_const("DynParent", Class.new(Lutaml::Model::Serializable) do
+        attribute :name, :string
+        attribute :children, DynChild, collection: true
+
+        turtle do
+          namespace Lutaml::Rdf::Namespaces::SkosNamespace
+
+          subject { |m| "http://example.org/parent/#{m.name}" }
+
+          type "skos:Collection"
+
+          predicate :prefLabel,
+                    namespace: Lutaml::Rdf::Namespaces::SkosNamespace,
+                    to: :name
+
+          members :children, link: "skos:member"
+        end
+      end)
+    end
+
+    it "generates linking triples from String link" do
+      parent = DynParent.new(
+        name: "p1",
+        children: [DynChild.new(label: "c1", cid: "a")],
+      )
+      result = parent.to_turtle
+      expect(result).to include("skos:member <http://example.org/child/a>")
+    end
+
+    it "includes child subgraph data" do
+      parent = DynParent.new(
+        name: "p1",
+        children: [DynChild.new(label: "c1", cid: "a")],
+      )
+      result = parent.to_turtle
+      expect(result).to include("skos:prefLabel \"c1\"")
+    end
+  end
+
+  describe "recursive prefix collection" do
+    before do
+      stub_const("SkosNs", Lutaml::Rdf::Namespaces::SkosNamespace)
+      stub_const("DctermsNs", Lutaml::Rdf::Namespaces::DctermsNamespace)
+
+      stub_const("LeafModel", Class.new(Lutaml::Model::Serializable) do
+        attribute :value, :string
+        attribute :lid, :string
+
+        turtle do
+          namespace DctermsNs
+
+          subject { |m| "http://example.org/leaf/#{m.lid}" } # rubocop:disable RSpec/NamedSubject, RSpec/MultipleSubjects
+
+          type "dcterms:Agent"
+
+          predicate :title, namespace: DctermsNs, to: :value
+        end
+      end)
+
+      stub_const("MidModel", Class.new(Lutaml::Model::Serializable) do
+        attribute :name, :string
+        attribute :mid, :string
+        attribute :leaves, LeafModel, collection: true
+
+        turtle do
+          namespace SkosNs, DctermsNs
+
+          subject { |m| "http://example.org/mid/#{m.mid}" } # rubocop:disable RSpec/NamedSubject, RSpec/MultipleSubjects
+
+          type "skos:Concept"
+
+          predicate :prefLabel, namespace: SkosNs, to: :name
+
+          members :leaves, link: "skos:member"
+        end
+      end)
+
+      stub_const("RootModel", Class.new(Lutaml::Model::Serializable) do
+        attribute :title, :string
+        attribute :mids, MidModel, collection: true
+
+        turtle do
+          namespace SkosNs
+
+          subject { |m| "http://example.org/root/#{m.title}" }
+
+          type "skos:Collection"
+
+          predicate :prefLabel, namespace: SkosNs, to: :title
+
+          members :mids, link: "skos:member"
+        end
+      end)
+    end
+
+    it "collects prefixes from all nesting levels" do
+      root = RootModel.new(
+        title: "r1",
+        mids: [MidModel.new(
+          name: "m1",
+          mid: "a",
+          leaves: [LeafModel.new(value: "l1", lid: "x")],
+        )],
+      )
+      result = root.to_turtle
+      expect(result).to include("@prefix skos:")
+      expect(result).to include("@prefix dcterms:")
+    end
+
+    it "emits triples from all nesting levels" do
+      root = RootModel.new(
+        title: "r1",
+        mids: [MidModel.new(
+          name: "m1",
+          mid: "a",
+          leaves: [LeafModel.new(value: "l1", lid: "x")],
+        )],
+      )
+      result = root.to_turtle
+      expect(result).to include("skos:prefLabel \"r1\"")
+      expect(result).to include("skos:prefLabel \"m1\"")
+      expect(result).to include("dcterms:title \"l1\"")
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Adds RDF features needed by glossarist-ruby to eliminate monkey-patching of lutaml-model internals.

### Changes

**Mapping (`Lutaml::Rdf::Mapping`)**
- `types(*values)` — convenience method for setting multiple RDF types via splat
- `has_types_or_predicates?` — helper for transform conditionals
- `members` now accepts `link:` option (passed through to MemberRule)

**MemberRule (`Lutaml::Rdf::MemberRule`)**
- `link:` option — accepts a String (compact IRI like `"skos:member"`) or Proc (dynamic per-member predicate)
- `link_predicate_for(member, mapping)` — resolves the link for a specific member
- `resolve_link_uri(member, mapping)` — unified resolver for both static and dynamic links
- `predicate_name` and `link` are mutually exclusive

**Turtle::Transform**
- Recursive prefix collection — collects namespaces from all nesting levels
- Dynamic link resolution — uses `resolve_link_uri` instead of only `linked_predicate_uri`
- `additional_resource_triples` protected hook — extensions can emit additional RDF triples

**JsonLd::Transform**
- Recursive context and resource collection — handles deeply nested member hierarchies
- Dynamic link resolution with `jsonld_member_key` for deriving JSON-LD key from link
- `additional_resource_data` protected hook — extensions can add additional data to resources

### Specs

30 new specs covering:
- `types` method (4 specs)
- `has_types_or_predicates?` (4 specs)
- `members` with `link:` option (4 specs)
- MemberRule `link_predicate_for` with String/Proc (4 specs)
- MemberRule `resolve_link_uri` (4 specs)
- Turtle dynamic links (2 specs)
- Turtle recursive prefix collection (2 specs)
- JSON-LD dynamic links (2 specs)
- JSON-LD recursive collection (2 specs)
- MemberRule mutual exclusivity (2 specs)

All 5044 specs pass (was 246 before, 276 now in RDF/Turtle/JSON-LD suites).