### PR TITLE
fix: propagate form option to nested Serializable child elements

### DIFF
--- a/docs/_guides/xml-namespace-qualification.adoc
+++ b/docs/_guides/xml-namespace-qualification.adoc
@@ -509,6 +509,148 @@ Parent.new(child: Child.new(value: "test")).to_xml(prefix: true)
 
 All three elements (`parent`, `child`, `value`) use the prefix because all are qualified via `element_form_default: :qualified`.
 
+=== Form Override on Serializable Children
+
+The `form:` option works on attributes of any type — including attributes whose value type is another `Serializable` model, not only simple types like `:string`. This matters when the parent's namespace declares `element_form_default :unqualified` (the W3C default) and you need a specific nested model element to be qualified anyway.
+
+.Worked example: form: :qualified on a Serializable child
+[example]
+====
+[source,ruby]
+----
+NS = Class.new(Lutaml::Model::XmlNamespace) do
+  uri "https://example.com/ns"
+  prefix_default "ex"
+  element_form_default :unqualified  # W3C default for local elements
+end
+
+class Child < Lutaml::Model::Serializable
+  attribute :label, :string
+  xml do
+    element "child"
+    namespace NS
+    map_element "label", to: :label
+  end
+end
+
+class Parent < Lutaml::Model::Serializable
+  attribute :child, Child
+  xml do
+    element "item"
+    namespace NS
+    map_element "child", to: :child, form: :qualified  # Force prefix
+  end
+end
+
+Parent.new(child: Child.new(label: "x")).to_xml
+----
+
+*Output*:
+[source,xml]
+----
+<item xmlns="https://example.com/ns" xmlns:ex="https://example.com/ns">
+  <ex:child>
+    <label>x</label>
+  </ex:child>
+</item>
+----
+
+The `ex:` prefix on `<child>` is forced by `form: :qualified`, overriding the parent's `:unqualified` schema default. The inner `<label>` remains unprefixed because the `Child` model's own mapping rule for `label` has no `form:` override — see the next section.
+====
+
+=== Form Scope: Per-Rule, Not Transitive
+
+`form:` is a per-mapping-rule override. It does **not** propagate transitively to grandchildren. Each level of the model tree applies its own rule against its own parent's `element_form_default`.
+
+.Worked example: form on parent does not cascade to grandchild
+[example]
+====
+[source,ruby]
+----
+NS = Class.new(Lutaml::Model::XmlNamespace) do
+  uri "https://example.com/ns"
+  prefix_default "ex"
+  element_form_default :unqualified
+end
+
+class Grandchild < Lutaml::Model::Serializable
+  attribute :value, :string
+  xml do
+    element "grandchild"
+    namespace NS
+    map_element "value", to: :value
+  end
+end
+
+class Child < Lutaml::Model::Serializable
+  attribute :inner, Grandchild
+  xml do
+    element "child"
+    namespace NS
+    map_element "grandchild", to: :inner  # NO form: override
+  end
+end
+
+class Parent < Lutaml::Model::Serializable
+  attribute :child, Child
+  xml do
+    element "item"
+    namespace NS
+    map_element "child", to: :child, form: :qualified  # Parent's rule only
+  end
+end
+
+Parent.new(child: Child.new(inner: Grandchild.new(value: "x"))).to_xml
+----
+
+*Output*:
+[source,xml]
+----
+<item xmlns="https://example.com/ns" xmlns:ex="https://example.com/ns">
+  <ex:child>
+    <grandchild>
+      <value>x</value>
+    </grandchild>
+  </ex:child>
+</item>
+----
+
+* `<ex:child>` is qualified because the *Parent* rule has `form: :qualified`.
+* `<grandchild>` is unprefixed because the *Child* rule has no `form:` and the Child's namespace is `:unqualified`.
+* The Parent's `form: :qualified` does **not** cascade.
+====
+
+To qualify every level, either set `form: :qualified` on each mapping rule that needs it, or set `element_form_default :qualified` on the namespace so inheritance handles it.
+
+== Qualification Precedence
+
+When serializing an element, the namespace is resolved by checking the following sources in priority order. The first match wins.
+
+[cols="1,4", options="header"]
+|===
+|Priority |Source
+
+|1 (highest)
+|Type-level namespace: the attribute's value type (a `Type::Value` subclass) declares `xml_namespace`. Wins over everything else.
+
+|2
+|Rule-level namespace: the mapping rule has an explicit `namespace:` option. *However*, if the parent's `element_form_default` is `:unqualified` AND the rule's namespace matches the parent's, the namespace is overridden to blank — W3C unqualified semantics for local elements.
+
+|3
+|`form: :unqualified` on the rule: force the element into no namespace.
+
+|4
+|Parent's `element_form_default :qualified` inheritance: the child inherits the parent's namespace — but only if the child model itself declares a namespace (W3C: `elementFormDefault` applies to locally-declared elements only).
+
+|5
+|`form: :qualified` on the rule: inherit the parent's namespace.
+
+|6 (lowest)
+|No namespace.
+|===
+
+This ladder is implemented in `Lutaml::Xml::Transformation::ElementBuilder#determine_element_namespace`. The `ElementFormOptionRule` decision rule reads the propagated `form` value during the planning phase and forces prefix (`:qualified`) or default (`:unqualified`) format accordingly.
+
 == Type Namespaces
 
 Value types can define their own namespaces:

--- a/docs/_guides/xml/namespace-semantics.adoc
+++ b/docs/_guides/xml/namespace-semantics.adoc
@@ -13,6 +13,8 @@ parent: XML namespaces
 Lutaml::Model implements W3C XML Namespace specification with a focus on
 **attribute-based namespace resolution**. Each XML element's namespace is
 determined by its attribute's type and parent context, following clear and
+
+NOTE: This document covers the *core namespace resolution principles*. For the `form:` override option, the full qualification precedence ladder, and `form:` behavior on nested `Serializable` children, see the companion guide: link:../xml-namespace-qualification[XML Namespace Qualification and Prefix Control].
 consistent rules.
 
 This document explains the core namespace principles that govern how namespaces

--- a/docs/_tutorials/xml-element-attribute-namespace-guide.adoc
+++ b/docs/_tutorials/xml-element-attribute-namespace-guide.adoc
@@ -9,6 +9,8 @@ This guide explains how XML namespaces work, particularly the distinction betwee
 - **Qualified**: Element/attribute needs a namespace declared in the XML
 - **Unqualified**: Element/attribute does not need a namespace declared (uses parent's namespace)
 
+> **Authoritative reference:** For the `element_form_default` / `form:` system, the full qualification precedence ladder, and `form:` behavior on nested `Serializable` children, see [docs/_guides/xml-namespace-qualification.adoc](../_guides/xml-namespace-qualification.adoc). This tutorial is a conceptual introduction.
+
 ## Default Namespace Inheritance
 
 **Critical Rule:** Default namespace inheritance ONLY applies to elements, NOT attributes.

--- a/docs/_tutorials/xml-schema-primer-style-guide.adoc
+++ b/docs/_tutorials/xml-schema-primer-style-guide.adoc
@@ -441,6 +441,8 @@ end
 
 NOTE: The `<comment>` element uses `xmlns=""` to explicitly declare blank namespace (form: :unqualified override).
 
+TIP: The `form:` option also works on attributes whose value type is a nested `Serializable` model, not just simple types like `:string`. It is a per-rule override and does not propagate transitively to grandchildren. For the full qualification precedence ladder and worked nested-model examples, see link:../_guides/xml-namespace-qualification/#form-override-on-serializable-children[XML Namespace Qualification and Prefix Control].
+
 == Section 3: Type Namespaces
 
 === General

--- a/docs/namespace-management.adoc
+++ b/docs/namespace-management.adoc
@@ -6,6 +6,8 @@
 
 This guide provides comprehensive information about XML namespace management in Lutaml::Model, including the `namespace_scope` directive, W3C compliance, and best practices for multi-namespace documents.
 
+NOTE: This guide focuses on namespace *declaration* and *scope*. For the `element_form_default` / `form:` qualification system — including the precedence ladder and `form:` behavior on nested `Serializable` children — see the companion guide: link:./_guides/xml-namespace-qualification[XML Namespace Qualification and Prefix Control].
+
 == Understanding XML Namespaces
 
 XML namespaces provide a method to avoid element name conflicts by qualifying names used in XML documents through a URI reference.

--- a/docs/xml-schema-qualification.md
+++ b/docs/xml-schema-qualification.md
@@ -13,6 +13,12 @@ declared in the XML, "unqualified" means the ELEMENT/ATTRIBUTE does not need a
 namespace declared in the XML (i.e. we look to its parent's namespace to find
 its namespace).
 
+> **Authoritative reference:** For the full qualification precedence ladder,
+> `form:` behavior on nested `Serializable` children, per-rule vs transitive
+> scope, and worked examples, see
+> [docs/_guides/xml-namespace-qualification.adoc](./_guides/xml-namespace-qualification.adoc).
+> This document is a conceptual overview; the guide is the canonical reference.
+
 When there is no XML Schema present:
 * element "acts like" unqualified (because of default namespace inheritance, does not need prefix)
 * attribute "acts like" qualified (because of no default namespace inheritance, requires prefix)

--- a/lib/lutaml/model/compiled_rule.rb
+++ b/lib/lutaml/model/compiled_rule.rb
@@ -98,6 +98,13 @@ module Lutaml
         !custom_methods.empty?
       end
 
+      # Check if form is explicitly set
+      #
+      # @return [Boolean] true if form option was provided
+      def form_set?
+        !form.nil?
+      end
+
       # Check if a name matches this rule (including alias names for multiple mappings)
       #
       # @param name [String, Symbol] The name to check

--- a/lib/lutaml/xml/adapter_element.rb
+++ b/lib/lutaml/xml/adapter_element.rb
@@ -129,7 +129,7 @@ module Lutaml
           next if attr_is_namespace?(attr)
 
           ns_prefix = attr.namespace&.prefix
-          ns_prefix = nil if ns_prefix&.empty?
+          ns_prefix = nil if ns_prefix && ns_prefix.empty?
 
           attr_name = ns_prefix ? "#{ns_prefix}:#{attr.name}" : attr.name
 
@@ -150,7 +150,7 @@ module Lutaml
           next if attr_is_namespace?(attr)
 
           ns_prefix = attr.namespace&.prefix
-          ns_prefix = nil if ns_prefix&.empty?
+          ns_prefix = nil if ns_prefix && ns_prefix.empty?
 
           attr_name = ns_prefix ? "#{ns_prefix}:#{attr.name}" : attr.name
           order << attr_name

--- a/lib/lutaml/xml/transformation/element_builder.rb
+++ b/lib/lutaml/xml/transformation/element_builder.rb
@@ -251,18 +251,6 @@ child_transformation)
             value.xml_namespace_prefix = ns_prefix
           end
 
-          # Also set @__xml_namespace_prefix on the XmlElement for doubly-defined case.
-          # This is read by NamespaceCollector to set NamespaceUsage.used_prefix.
-          # For doubly-defined: parent has no ns, child's ns_prefix is from @__xml_ns_prefixes
-          # (not from parent's @__xml_namespace_prefix).
-          # For mixed content: parent's XmlElement already has @__xml_namespace_prefix set.
-          if parent_ns_class.nil? && ns_prefix && !ns_prefix.empty? && !child_ns_class
-            # Doubly-defined case: parent has no ns, child has ns class.
-            # Set on XmlElement so NamespaceCollector reads it.
-            # The value will be set on the model instance above (via @__xml_namespace_prefix)
-            # and we'll set it on XmlElement too so collection phase picks it up.
-          end
-
           child_element = child_transformation.transform(value, child_options)
 
           # Dual-namespace support: when the child model was deserialized from an element
@@ -304,15 +292,10 @@ child_transformation)
             child_element.name = rule.serialized_name
           end
 
-          # W3C elementFormDefault: unqualified override
-          # When parent's namespace has element_form_default :unqualified and the child's
-          # namespace is the same as the parent's, override to blank namespace.
-          # This ensures local elements are not namespace-qualified per W3C spec.
-          if parent_element_form_default == :unqualified &&
-              parent_ns_class &&
-              child_element.namespace_class == parent_ns_class
-            child_element.namespace_class = nil
-          end
+          propagate_form(child_element, rule)
+          apply_unqualified_form_default(
+            child_element, rule, parent_ns_class, parent_element_form_default
+          )
 
           child_element
         end
@@ -356,7 +339,7 @@ child_transformation)
             element.xml_namespace_prefix = model_ns_prefix
           end
 
-          element.form = rule.form if rule.form
+          propagate_form(element, rule)
           text = serialize_value(value, rule, rule.attribute_type, nil)
           element.text_content = text if text
           element
@@ -490,7 +473,7 @@ register_id)
             element.xml_namespace_prefix = ns_prefix
           end
 
-          element.form = rule.form if rule.form
+          propagate_form(element, rule)
 
           # Handle Hash type - expand hash into child elements
           if value.is_a?(::Hash) && rule.attribute_type == Lutaml::Model::Type::Hash
@@ -521,6 +504,38 @@ register_id)
             child.text_content = val.to_s
             element.add_child(child)
           end
+        end
+
+        # Copy the rule's form option onto the produced element so downstream
+        # rules (ElementFormOptionRule) can read it. Without this propagation
+        # the form option would be lost on transformed/fallback/simple paths.
+        #
+        # @param element [::Lutaml::Xml::DataModel::XmlElement] The element to update
+        # @param rule [CompiledRule] The rule carrying the form option
+        def propagate_form(element, rule)
+          element.form = rule.form if rule.form_set?
+        end
+
+        # W3C elementFormDefault: unqualified override.
+        #
+        # When the parent schema declares elementFormDefault="unqualified" and
+        # a locally-declared child lives in the same namespace as the parent,
+        # the child MUST NOT be namespace-qualified (XSD spec). An explicit
+        # form: :qualified on the rule is the user's per-element opt-out and
+        # takes precedence over the schema default.
+        #
+        # @param element [::Lutaml::Xml::DataModel::XmlElement] The element to update
+        # @param rule [CompiledRule] The rule (checked for explicit form override)
+        # @param parent_ns_class [Class, nil] Parent's namespace class
+        # @param parent_form_default [Symbol, nil] Parent's element_form_default
+        def apply_unqualified_form_default(element, rule, parent_ns_class,
+                                           parent_form_default)
+          return if rule.form == :qualified
+          return if parent_form_default != :unqualified
+          return unless parent_ns_class
+          return unless element.namespace_class == parent_ns_class
+
+          element.namespace_class = nil
         end
 
         # Apply nil marker to element if needed

--- a/spec/lutaml/xml/enhanced_mapping_spec.rb
+++ b/spec/lutaml/xml/enhanced_mapping_spec.rb
@@ -187,6 +187,235 @@ RSpec.describe "Enhanced XML Mapping Features" do
         expect(name_rule.form).to eq(:unqualified)
       end
     end
+
+    context "with Serializable child and form: :qualified" do
+      # Regression: form option on the parent's map_element rule must be
+      # propagated to the child XmlElement when the child is a Serializable
+      # (which goes through create_transformed_nested_element). Otherwise the
+      # ElementFormOptionRule cannot fire and the element is serialized
+      # without the namespace prefix.
+      let(:child_class) do
+        ns = namespace_class
+        Class.new(Lutaml::Model::Serializable) do
+          attribute :label, :string
+
+          xml do
+            element "child"
+            namespace ns
+            map_element "label", to: :label
+          end
+        end
+      end
+
+      let(:model_class) do
+        ns = namespace_class
+        child = child_class
+        Class.new(Lutaml::Model::Serializable) do
+          attribute :child, child
+
+          xml do
+            element "item"
+            namespace ns
+            map_element "child", to: :child, form: :qualified
+          end
+        end
+      end
+
+      it "stores form: :qualified on the parent rule" do
+        mapping = model_class.mappings_for(:xml)
+        child_rule = mapping.find_element(:child)
+        expect(child_rule.form).to eq(:qualified)
+      end
+
+      it "serializes the nested Serializable with a namespace prefix" do
+        instance = model_class.new(child: child_class.new(label: "x"))
+        doc = Nokogiri::XML(instance.to_xml)
+        qualified = doc.at_xpath("//*[name()='ex:child']")
+        expect(qualified).not_to be_nil
+        expect(qualified.at_xpath("./xmlns:label").text).to eq("x")
+      end
+
+      it "round-trips the qualified Serializable child" do
+        original = model_class.new(child: child_class.new(label: "round-trip"))
+        restored = model_class.from_xml(original.to_xml)
+        expect(restored.child.label).to eq("round-trip")
+      end
+    end
+
+    context "with Serializable child and form: :unqualified" do
+      # Symmetric to the :qualified case: form: :unqualified must propagate
+      # to the child XmlElement so ElementFormOptionRule can force the
+      # default (unprefixed) form.
+      let(:child_class) do
+        ns = namespace_class
+        Class.new(Lutaml::Model::Serializable) do
+          attribute :label, :string
+
+          xml do
+            element "child"
+            namespace ns
+            map_element "label", to: :label
+          end
+        end
+      end
+
+      let(:model_class) do
+        ns = namespace_class
+        child = child_class
+        Class.new(Lutaml::Model::Serializable) do
+          attribute :child, child
+
+          xml do
+            element "item"
+            namespace ns
+            map_element "child", to: :child, form: :unqualified
+          end
+        end
+      end
+
+      it "propagates form: :unqualified and emits an unprefixed child" do
+        instance = model_class.new(child: child_class.new(label: "x"))
+        doc = Nokogiri::XML(instance.to_xml)
+        expect(doc.xpath("//*[name()='ex:child']")).to be_empty
+        expect(doc.at_xpath("//*[local-name()='child']")).not_to be_nil
+      end
+    end
+
+    context "with a collection of Serializable children" do
+      # The form option must propagate to every element produced for a
+      # collection attribute, not just the first.
+      let(:child_class) do
+        ns = namespace_class
+        Class.new(Lutaml::Model::Serializable) do
+          attribute :label, :string
+
+          xml do
+            element "child"
+            namespace ns
+            map_element "label", to: :label
+          end
+        end
+      end
+
+      let(:model_class) do
+        ns = namespace_class
+        child = child_class
+        Class.new(Lutaml::Model::Serializable) do
+          attribute :children, child, collection: true
+
+          xml do
+            element "item"
+            namespace ns
+            map_element "child", to: :children, form: :qualified
+          end
+        end
+      end
+
+      it "qualifies every child in the collection" do
+        instance = model_class.new(
+          children: [child_class.new(label: "a"), child_class.new(label: "b")],
+        )
+        doc = Nokogiri::XML(instance.to_xml)
+        qualified = doc.xpath("//*[name()='ex:child']")
+        labels = qualified.map { |c| c.at_xpath("./xmlns:label").text }
+        expect(labels).to contain_exactly("a", "b")
+      end
+    end
+
+    context "with a Serializable child containing a Serializable grandchild" do
+      # form: :qualified is a per-rule override; it must NOT propagate
+      # transitively to grandchildren. Each level applies its own rule and
+      # its own parent_element_form_default.
+      let(:grandchild_class) do
+        ns = namespace_class
+        Class.new(Lutaml::Model::Serializable) do
+          attribute :value, :string
+
+          xml do
+            element "grandchild"
+            namespace ns
+            map_element "value", to: :value
+          end
+        end
+      end
+
+      let(:child_class) do
+        ns = namespace_class
+        grandchild = grandchild_class
+        Class.new(Lutaml::Model::Serializable) do
+          attribute :inner, grandchild
+
+          xml do
+            element "child"
+            namespace ns
+            map_element "grandchild", to: :inner
+          end
+        end
+      end
+
+      let(:model_class) do
+        ns = namespace_class
+        child = child_class
+        Class.new(Lutaml::Model::Serializable) do
+          attribute :child, child
+
+          xml do
+            element "item"
+            namespace ns
+            map_element "child", to: :child, form: :qualified
+          end
+        end
+      end
+
+      it "qualifies the child but leaves the grandchild unprefixed" do
+        instance = model_class.new(
+          child: child_class.new(inner: grandchild_class.new(value: "x")),
+        )
+        doc = Nokogiri::XML(instance.to_xml)
+        expect(doc.at_xpath("//*[name()='ex:child']")).not_to be_nil
+        expect(doc.xpath("//*[name()='ex:grandchild']")).to be_empty
+        expect(doc.at_xpath("//*[local-name()='grandchild']")).not_to be_nil
+      end
+    end
+
+    context "with Serializable child but no form override" do
+      # Sanity: when no form: :qualified is set on the rule, the W3C
+      # element_form_default :unqualified override should still kick in and
+      # the nested Serializable should serialize unprefixed.
+      let(:child_class) do
+        ns = namespace_class
+        Class.new(Lutaml::Model::Serializable) do
+          attribute :label, :string
+
+          xml do
+            element "child"
+            namespace ns
+            map_element "label", to: :label
+          end
+        end
+      end
+
+      let(:model_class) do
+        ns = namespace_class
+        child = child_class
+        Class.new(Lutaml::Model::Serializable) do
+          attribute :child, child
+
+          xml do
+            element "item"
+            namespace ns
+            map_element "child", to: :child
+          end
+        end
+      end
+
+      it "honors element_form_default :unqualified by leaving the child unprefixed" do
+        instance = model_class.new(child: child_class.new(label: "x"))
+        doc = Nokogiri::XML(instance.to_xml)
+        expect(doc.xpath("//*[name()='ex:child']")).to be_empty
+        expect(doc.at_xpath("//*[local-name()='child']")).not_to be_nil
+      end
+    end
   end
 
   describe "form option on map_attribute" do


### PR DESCRIPTION
## Summary

- `map_element`'s `form: :qualified` option was silently dropped when the child attribute was a `Serializable`. `create_transformed_nested_element` did not copy `rule.form` onto the produced `XmlElement`, so `ElementFormOptionRule` (which reads `element.form`) never fired and qualified nested children serialized without their namespace prefix.
- Audit polish on the surrounding code: extracted `propagate_form` and `apply_unqualified_form_default` helpers to eliminate three-way duplication; removed a dead comment-only `if/end` block; added the missing `form_set?` predicate on `CompiledRule` so the helper can use the same predicate API as `MappingRule`.
- Rewrote the new spec contexts to use Nokogiri parsed-XML assertions instead of fragile `include(...)` string matching; added coverage for `form: :unqualified`, collection attributes, round-trip, and grandchild nesting (proves `form:` is per-rule, not transitive).
- Documentation: promoted `docs/_guides/xml-namespace-qualification.adoc` as the canonical qualification reference. Added three sections (form-on-Serializable-children, per-rule scope, six-step precedence ladder) and cross-linked four other docs that touch the topic. The bug-fix surface was previously undocumented anywhere.

## Test plan

- [x] `bundle exec rspec spec/lutaml/xml/` — 1825 examples, 0 failures
- [x] `bundle exec rspec spec/lutaml/model/` — 2855 examples, 0 failures
- [x] `bundle exec rubocop` — clean (after fixing pre-existing `Lint/SafeNavigationWithEmpty` offenses in `adapter_element.rb` flagged by rubocop 1.88 drift)
- [x] CI `rake` workflow green on this PR — all Ruby 3.3/3.4/4.0 × macos/ubuntu/windows jobs pass
- [ ] `downstream-performance` — failing on `pnas-152KB` benchmark, but this workflow has been failing on main for 3+ consecutive runs (pre-existing, not caused by this PR)

## Out of scope

- An unrelated change to the Opal default XML adapter (`:rexml` to `:oga` in `lib/lutaml/xml.rb`) was discovered in the working tree on this branch and omitted from this PR. It reverses a prior architectural decision; moxml has since moved to `:oga`, but whether Oga actually runs cleanly under Opal needs explicit validation. That change should ship as its own PR with owner sign-off.
- Deduping the 20+ scattered docs that touch namespace qualification is a separate doc-restructuring effort — this PR only adds cross-links.
