### PR TITLE
fix(ci): remove broken post_install from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,6 @@ jobs:
     uses: metanorma/ci/.github/workflows/rubygems-release.yml@main
     with:
       next_version: ${{ github.event.inputs.next_version }}
-      post_install: |
-        git status
-        cat .bundle/config
     secrets:
       rubygems-api-key: ${{ secrets.LUTAML_CI_RUBYGEMS_API_KEY }}
       pat_token: ${{ secrets.LUTAML_CI_PAT_TOKEN }}


### PR DESCRIPTION
## Summary

The release workflow's `post_install` step ran `cat .bundle/config`, which fails because `.bundle/config` is gitignored and only generated at runtime by the `rake` workflow's `before-setup-ruby` step. The `cat` served no purpose (likely a debug leftover) and blocked every release attempt with exit code 1.

Removing the entire `post_install` block. The reusable `metanorma/ci/.github/workflows/rubygems-release.yml@main` workflow does not require it.

## Evidence

Failed release run (PR #713 patch release attempt):
https://github.com/lutaml/lutaml-model/actions/runs/28327812038

```
On branch main
Your branch is up to date with 'origin/main'.

nothing to commit, working tree clean
cat: .bundle/config: No such file or directory
##[error]Process completed with exit code 1.
```

## Follow-up

The release.yml header says `Auto-generated by Cimas`. The upstream cimas template needs the same fix so the next regeneration doesn't re-introduce this bug. Tracking separately.

## Test plan

- [ ] Trigger `release.yml` workflow_dispatch with `next_version=patch` after merge
- [ ] Confirm run reaches the bump/tag/publish steps (no longer fails at post_install)
