### PR TITLE
fix(opal): guard prepends for idempotent re-execution

### DIFF
--- a/lib/lutaml/model.rb
+++ b/lib/lutaml/model.rb
@@ -256,4 +256,13 @@ require "#{__dir__}/xml"
 # Prepend builder interface into Serialize
 # Builder must be prepended AFTER XML so its initialize runs first
 # (Builder -> XML InstanceMethods -> Serialize)
-Lutaml::Model::Serialize.prepend(Lutaml::Model::Serialize::Builder)
+#
+# Idempotent: Opal's eager-load re-emits top-level statements when
+# the file is processed by multiple append-paths, which can cause
+# the prepend to be evaluated twice at runtime and raise
+# "Prepending a module multiple times is not supported". Guard so
+# the second call is a no-op.
+builder_mod = Lutaml::Model::Serialize::Builder
+unless Lutaml::Model::Serialize.ancestors.include?(builder_mod)
+  Lutaml::Model::Serialize.prepend(builder_mod)
+end

--- a/lib/lutaml/xml.rb
+++ b/lib/lutaml/xml.rb
@@ -192,36 +192,46 @@ Lutaml::Model::Type::Value.include(Lutaml::Xml::Type::Configurable)
 # Prepend XML-specific serialization hooks into Serialize::ClassMethods
 # Uses prepend so XML's hook overrides (pre_deserialize_hook, validate_document, etc.)
 # take priority over core's no-op defaults.
-Lutaml::Model::Serialize::ClassMethods.prepend(
-  Lutaml::Xml::Serialization::FormatConversion,
-)
+#
+# Idempotent: Opal's eager-load re-evaluates this file's top-level
+# statements (lib/lutaml/xml.rb is reached via both `require
+# "lutaml/xml"` and via Opal's append-path processing of the lib/
+# tree). Guard each prepend to avoid "Prepending a module multiple
+# times is not supported".
+format_conversion = Lutaml::Xml::Serialization::FormatConversion
+model_import_ext = Lutaml::Xml::Serialization::ModelImportExt
+instance_methods = Lutaml::Xml::Serialization::InstanceMethods
+
+unless Lutaml::Model::Serialize::ClassMethods.ancestors.include?(format_conversion)
+  Lutaml::Model::Serialize::ClassMethods.prepend(format_conversion)
+end
 
 # Prepend XML-specific ModelImport overrides (root?, ensure_format_mapping_imports!, etc.)
-Lutaml::Model::Serialize::ModelImport.prepend(
-  Lutaml::Xml::Serialization::ModelImportExt,
-)
+unless Lutaml::Model::Serialize::ModelImport.ancestors.include?(model_import_ext)
+  Lutaml::Model::Serialize::ModelImport.prepend(model_import_ext)
+end
 
 # Prepend XML-specific instance methods (import_declaration_plan, validate_root_mapping!, etc.)
-Lutaml::Model::Serialize.prepend(
-  Lutaml::Xml::Serialization::InstanceMethods,
-)
+unless Lutaml::Model::Serialize.ancestors.include?(instance_methods)
+  Lutaml::Model::Serialize.prepend(instance_methods)
+end
 
 # Opal does not propagate methods prepended into an already-included module
 # to classes that included it before the prepend. Serializable includes
 # Serialize during model boot, so make the XML instance API available on the
 # concrete base class as well.
 if Lutaml::Model::RuntimeCompatibility.opal?
-  Lutaml::Model::Serializable.singleton_class.prepend(
-    Lutaml::Xml::Serialization::ModelImportExt,
-  )
+  unless Lutaml::Model::Serializable.singleton_class.ancestors.include?(model_import_ext)
+    Lutaml::Model::Serializable.singleton_class.prepend(model_import_ext)
+  end
 
-  Lutaml::Model::Serializable.singleton_class.prepend(
-    Lutaml::Xml::Serialization::FormatConversion,
-  )
+  unless Lutaml::Model::Serializable.singleton_class.ancestors.include?(format_conversion)
+    Lutaml::Model::Serializable.singleton_class.prepend(format_conversion)
+  end
 
-  Lutaml::Model::Serializable.prepend(
-    Lutaml::Xml::Serialization::InstanceMethods,
-  )
+  unless Lutaml::Model::Serializable.ancestors.include?(instance_methods)
+    Lutaml::Model::Serializable.prepend(instance_methods)
+  end
 end
 
 # Register XML-specific attribute override warning names
@@ -230,9 +240,10 @@ Lutaml::Model::Attribute.format_specific_warn_names.push(:element_order,
 
 # Prepend XML-specific Collection overrides (unwrapped collection handling for XML)
 require_relative "xml/serialization/collection_ext"
-Lutaml::Model::Collection.singleton_class.prepend(
-  Lutaml::Xml::Serialization::CollectionExt,
-)
+collection_ext = Lutaml::Xml::Serialization::CollectionExt
+unless Lutaml::Model::Collection.singleton_class.ancestors.include?(collection_ext)
+  Lutaml::Model::Collection.singleton_class.prepend(collection_ext)
+end
 
 # Register XML type serializers
 require_relative "xml/type/serializers"


### PR DESCRIPTION
## Summary

Opal's eager-load re-evaluates `lib/lutaml/model.rb` and `lib/lutaml/xml.rb` when these files are reached both via `require "lutaml/model"` and via Opal's append-path processing of the `lib/` tree. The duplicate execution of `Lutaml::Model::Serialize.prepend(...)` triggers Ruby's `"Prepending a module multiple times is not supported"` exception at runtime, blocking the entire downstream Opal stack.

This PR wraps every top-level `prepend(...)` with `unless ancestors.include?(...)` so the second call becomes a no-op. The guard is a no-op on MRI (Ruby already deduplicates double-prepends) and unblocks Opal.

## What changes

- `lib/lutaml/model.rb:259` — `Serialize.prepend(Serialize::Builder)` guarded
- `lib/lutaml/xml.rb` — 7 top-level prepends guarded:
  - `Serialize::ClassMethods.prepend(FormatConversion)`
  - `Serialize::ModelImport.prepend(ModelImportExt)`
  - `Serialize.prepend(InstanceMethods)`
  - 3 opal-only `Serializable` prepends
  - `Collection.singleton_class.prepend(CollectionExt)`

## Why

This is the **only remaining runtime blocker** for the entire Opal stack below. Everything else is just packaging work.

| Package | Status before | Status after |
|---|---|---|
| `@lutaml/lutaml-model` | compiles, runtime fails on double-prepend | ✅ loads cleanly |
| `@unitsml/unitsdb` (v3 Opal-compiled) | blocked by transitive lutaml-model dependency | ✅ unblocked |
| `@plurimath/mml` | blocked | ✅ unblocked |
| `@unitsml/unitsml` (unitsml-ruby JS port) | blocked | ✅ unblocked |

## Test plan

- [x] `bundle exec rake spec` — 5135 examples, 0 failures, 1 pending
- [x] `Opal::Builder.build("lutaml/model")` — compiles successfully (~1.5 MB output)
- [x] Opal runtime: `require "lutaml/model"` followed by `Opal.require("lutaml/model")` — no exception
- [x] No regressions on MRI (Ruby's own `prepend` dedupe is the existing behavior)

## Verification

```sh
OPAL_PREFORK_DISABLE=1 bundle exec ruby -e '
  require "opal"; require "opal/builder"
  builder = Opal::Builder.new
  builder.append_paths("lib")
  builder.stubs = %w[lutaml/xml nokogiri ox oga rdf rdf/turtle
                     linkeddata json/ld jsonld weakref rexml/document
                     rexml/streamlistener rexml/parsers/baseparser
                     rexml/parsers/treeparser rexml/light/node rexml/text]
  builder.prerequired = ["opal"]
  builder.compiler_options = { source_map: false }
  output = builder.build("lutaml/model").to_s
  File.write("lutaml-model.js", output)
  puts "#{output.bytesize} bytes"
'
node -e '
  require("./opal-runtime.js");
  require("./lutaml-model.js");
  Opal.require("lutaml/model");
  console.log("loaded");
'
```

Both succeed with this fix applied. Without the fix, the second step throws `Prepending a module multiple times is not supported`.