### PR TITLE
fix: valid XSD generation with model-driven namespaces

### DIFF
--- a/lib/lutaml/xml/schema/xsd_schema.rb
+++ b/lib/lutaml/xml/schema/xsd_schema.rb
@@ -53,6 +53,17 @@ module Lutaml
           "#{prefix}:#{type_name}"
         end
 
+        # The prefix a named-type reference should carry: the referenced model's
+        # own namespace prefix when it has one (the type lives in that
+        # namespace), otherwise the schema's target prefix.
+        def self.nested_ref_prefix(nested_mapping, target_prefix)
+          prefix = nested_mapping&.namespace_class&.prefix_default
+          return target_prefix if prefix.nil? || prefix.empty? ||
+            prefix == xsd_ns.prefix
+
+          prefix
+        end
+
         def self.generate(klass, options = {})
           register = extract_register_from(klass)
           xml_mapping = klass.mappings_for(:xml)
@@ -116,7 +127,11 @@ module Lutaml
         # @param klass [Class] The model class to validate
         # @param register [Register] The register for type resolution
         # @raise [UnresolvableTypeError] if any types cannot be resolved
-        def self.validate_xsd_types!(klass, register)
+        def self.validate_xsd_types!(klass, register, seen = Set.new)
+          # Cycle guard: recursive models (A -> B -> A) would otherwise recurse
+          # forever. A class already being validated needs no re-validation.
+          return unless seen.add?(klass)
+
           errors = []
 
           klass.attributes.each do |name, attr|
@@ -136,7 +151,7 @@ module Lutaml
             # Recursively validate nested models
             if attr_type <= Lutaml::Model::Serialize
               begin
-                validate_xsd_types!(attr_type, register)
+                validate_xsd_types!(attr_type, register, seen)
               rescue Lutaml::Model::UnresolvableTypeError => e
                 errors << "In nested model #{attr_type.name}: #{e.message}"
               end
@@ -182,31 +197,65 @@ module Lutaml
             end
           end
 
-          # Named-type references are qualified with the target-namespace
-          # prefix so they resolve to the namespace the type is defined in.
+          # Named-type references are qualified with the namespace prefix of the
+          # namespace the type is defined in.
           target_prefix = target_ns_prefix(xml_mapping)
+          target_uri = schema_attrs[:targetNamespace]
+
+          # A target namespace referenced by named-type QNames needs a usable
+          # prefix; synthesise one when the namespace class declares none.
+          if target_uri && (target_prefix.nil? || target_prefix.empty?)
+            target_prefix = "tns"
+            schema_attrs[:"xmlns:#{target_prefix}"] ||= target_uri
+          end
+
+          # Declare every namespace class used anywhere in the tree on the root
+          # <xs:schema>, deduped by class, so foreign type references resolve.
+          # A prefix bound to two different namespaces is unresolvable -> raise.
+          tree_ns_classes = collect_namespace_classes(klass, register)
+          tree_ns_classes.each do |ns_class|
+            prefix = ns_class.prefix_default
+            unusable = prefix.nil? || prefix.empty? || prefix == xsd_ns.prefix
+
+            # A foreign namespace is referenced by a prefixed QName, so it must
+            # have a usable prefix of its own — it cannot borrow the target's.
+            if unusable && ns_class.uri != target_uri
+              raise Lutaml::Model::Error,
+                    "XSD generation: foreign namespace '#{ns_class.uri}' needs " \
+                    "a usable prefix_default (not nil/empty/'xs') to be " \
+                    "referenced from the '#{target_uri}' schema."
+            end
+            next if unusable
+
+            key = :"xmlns:#{prefix}"
+            existing = schema_attrs[key]
+            if existing && existing != ns_class.uri
+              raise Lutaml::Model::Error,
+                    "XSD generation: namespace prefix '#{prefix}' is bound to " \
+                    "two different namespaces (#{existing} and #{ns_class.uri}). " \
+                    "Give them distinct prefixes."
+            end
+            schema_attrs[key] = ns_class.uri
+          end
 
           xml.public_send(qn("schema"), schema_attrs) do
-            # Generate imports from XmlNamespace
+            # Explicit imports declared on the root's XmlNamespace class.
+            imported_uris = Set.new
             if xml_mapping.namespace_class
-              generate_imports(xml, xml_mapping.namespace_class)
+              imported_uris = generate_imports(xml, xml_mapping.namespace_class)
               generate_includes(xml, xml_mapping.namespace_class)
             end
 
-            # Generate imports for Type namespaces
-            type_namespaces = collect_type_namespaces(klass, register)
-            type_namespaces.each do |ns_class|
-              # Only import if different from target namespace
-              next if ns_class.uri == schema_attrs[:targetNamespace]
-              # Skip bare, unresolvable imports: with no schemaLocation the
-              # imported components cannot be resolved, so the type is defined
-              # inline in this schema instead (single-document generation).
-              next unless ns_class.schema_location
+            # Import every foreign namespace referenced by the tree (any
+            # namespace other than this schema's own target), deduped by URI.
+            # Foreign types are defined in their own schema, not here.
+            tree_ns_classes.each do |ns_class|
+              next if ns_class.uri == target_uri
+              next unless imported_uris.add?(ns_class.uri)
 
               import_attrs = { namespace: ns_class.uri }
               if ns_class.schema_location
-                import_attrs[:schemaLocation] =
-                  ns_class.schema_location
+                import_attrs[:schemaLocation] = ns_class.schema_location
               end
               xml.public_send(qn("import"), import_attrs)
             end
@@ -251,14 +300,21 @@ module Lutaml
 
             # Generate type definitions for nested models with type_name
             generate_nested_type_definitions(xml, klass, register,
-                                             target_prefix: target_prefix)
+                                             target_prefix: target_prefix,
+                                             target_uri: target_uri)
           end
         end
 
+        # Emit <xs:import> for each namespace the root's XmlNamespace class
+        # explicitly declares. Returns the Set of imported URIs so the tree
+        # import loop can dedupe against them.
         def self.generate_imports(xml, namespace_class)
-          return unless namespace_class.imports&.any?
+          imported = Set.new
+          return imported unless namespace_class.imports&.any?
 
           namespace_class.imports.each do |imported_ns|
+            next unless imported.add?(imported_ns.uri)
+
             import_attrs = { namespace: imported_ns.uri }
             if imported_ns.schema_location
               import_attrs[:schemaLocation] =
@@ -266,6 +322,8 @@ module Lutaml
             end
             xml.public_send(qn("import"), import_attrs)
           end
+
+          imported
         end
 
         def self.generate_includes(xml, namespace_class)
@@ -286,23 +344,42 @@ module Lutaml
         end
 
         def self.generate_nested_type_definitions(xml, klass, register,
-target_prefix: nil)
+target_prefix: nil, target_uri: nil, seen: nil)
+          # Cycle guard, seeded with the root class (already defined by
+          # generate_schema) so it is never redefined via a back-reference.
+          seen ||= Set[klass]
+
           klass.attributes.each_value do |attr|
             attr_type = attr.type(register)
             next unless attr_type <= Lutaml::Model::Serialize
+            next unless seen.add?(attr_type)
 
             nested_mapping = attr_type.mappings_for(:xml)
             nested_type_name = nested_mapping&.type_name_value
 
-            # Generate type definition if nested model has type_name
-            if nested_type_name
+            # Define a named type only when it belongs to this schema's target
+            # namespace; a foreign type is imported, not defined here. Recurse
+            # regardless — a same-target type can be nested under a foreign model.
+            if nested_type_name &&
+                !foreign_namespace?(nested_mapping, target_uri)
               generate_complex_type(xml, attr_type, nested_type_name, register,
                                     nested_mapping, target_prefix: target_prefix)
-              # Recursively generate nested types
-              generate_nested_type_definitions(xml, attr_type, register,
-                                               target_prefix: target_prefix)
             end
+
+            generate_nested_type_definitions(xml, attr_type, register,
+                                             target_prefix: target_prefix,
+                                             target_uri: target_uri, seen: seen)
           end
+        end
+
+        # Whether a nested model's mapping belongs to a namespace other than the
+        # schema's target namespace. A model with no namespace belongs to the
+        # target schema (not foreign).
+        def self.foreign_namespace?(mapping, target_uri)
+          ns_class = mapping&.namespace_class
+          return false unless ns_class
+
+          ns_class.uri != target_uri
         end
 
         def self.generate_complex_type_content(xml, klass, register,
@@ -356,9 +433,11 @@ target_prefix: nil)
                 element_attrs[:maxOccurs] = "unbounded"
 
                 if nested_type_name
-                  # Reference named type
-                  element_attrs[:type] =
-                    qualify_type_ref(nested_type_name, target_prefix)
+                  # Reference named type by its owning namespace's prefix
+                  element_attrs[:type] = qualify_type_ref(
+                    nested_type_name,
+                    nested_ref_prefix(nested_mapping, target_prefix),
+                  )
                   xml.public_send(qn("element"), element_attrs)
                 else
                   # Inline anonymous complexType
@@ -372,10 +451,15 @@ target_prefix: nil)
                   end
                 end
               elsif nested_type_name
-                # Single nested model - Reference named type
-                xml.public_send(qn("element"),
-                                { name: name.to_s,
-                                  type: qualify_type_ref(nested_type_name, target_prefix) })
+                # Single nested model - reference by its owning namespace prefix
+                xml.public_send(
+                  qn("element"),
+                  { name: name.to_s,
+                    type: qualify_type_ref(
+                      nested_type_name,
+                      nested_ref_prefix(nested_mapping, target_prefix),
+                    ) },
+                )
               else
                 # Inline anonymous complexType
                 xml.public_send(qn("element"), { name: name.to_s }) do
@@ -496,19 +580,35 @@ _mapping_rule = nil)
           get_xsd_type(attr_type)
         end
 
-        def self.collect_type_namespaces(klass, register)
-          namespaces = Set.new
+        # Collect every distinct XmlNamespace class used anywhere in the model
+        # tree: the model's own namespace and nested Serializable models'
+        # namespaces (recursively). Type::Value type namespaces are intentionally
+        # NOT collected (see the note inside). Deduped by class (the atomic unit).
+        # A class-level structural walk — needs no instance.
+        def self.collect_namespace_classes(klass, register, seen = Set.new)
+          return [] unless klass.is_a?(::Class) && seen.add?(klass)
+
+          classes = []
+          own = get_namespace_info(klass)[:class]
+          classes << own if own
 
           klass.attributes.each_value do |attr|
             type_class = attr.type(register)
             next unless type_class
 
-            # Use unified get_namespace_info method
-            ns_info = get_namespace_info(type_class)
-            namespaces << ns_info[:class] if ns_info[:class]
+            # Only nested Serializable models contribute namespaces here: their
+            # named-type references are prefixed by owning namespace. Type::Value
+            # type namespaces are NOT collected — their xsd_type refs are emitted
+            # verbatim (unprefixed), so importing their namespace would leave an
+            # import the refs never use. (Type::Value namespace support: TODO.)
+            if type_class <= Lutaml::Model::Serialize
+              classes.concat(
+                collect_namespace_classes(type_class, register, seen),
+              )
+            end
           end
 
-          namespaces.to_a
+          classes.uniq
         end
 
         # Get unified namespace information from Model or Type class

--- a/lib/lutaml/xml/schema/xsd_schema.rb
+++ b/lib/lutaml/xml/schema/xsd_schema.rb
@@ -300,33 +300,33 @@ module Lutaml
         end
 
         # Declare xmlns:<prefix> for every namespace this schema references.
-        # Foreign model namespaces are strict: their types are referenced by
-        # prefixed QNames and resolved through an import, so an unusable
-        # prefix, a prefix collision, or a missing schema_location makes the
-        # output unresolvable — raise, or warn and skip under skip_validation.
+        # Foreign model namespaces are strict: an unusable prefix or a prefix
+        # collision always raises (the emitted QNames would resolve to the
+        # wrong namespace), while a missing schema_location raises unless
+        # skip_validation downgrades it to a warning (the output stays
+        # structurally correct, only the import is unresolvable).
         # Type::Value namespaces are declared best-effort (their xsd_type
         # references are emitted verbatim).
         def self.declare_referenced_namespaces!(schema_attrs, referenced,
 target_uri, skip_validation)
           referenced[:foreign_models].each do |ns_class|
-            error = foreign_namespace_error(ns_class, schema_attrs, target_uri)
-            if error
+            # An unusable or colliding prefix makes emitted QNames resolve to
+            # the wrong namespace — never recoverable, even under
+            # skip_validation.
+            error = foreign_prefix_error(ns_class, schema_attrs, target_uri)
+            raise Lutaml::Model::Error, error if error
+
+            # A missing schema_location leaves the import unresolvable but the
+            # output structurally correct — recoverable under skip_validation.
+            unless ns_class.schema_location
+              error = missing_schema_location_error(ns_class)
               raise Lutaml::Model::Error, error unless skip_validation
 
               warn "[Lutaml::Model] WARN: #{error} " \
                    "(skip_validation: emitting best-effort output)"
             end
 
-            # Best-effort even after a warning: a usable, non-colliding prefix
-            # is still declared so the emitted QNames resolve; only the
-            # unusable/colliding cases have nothing declarable.
-            prefix = ns_class.prefix_default
-            next unless usable_prefix?(prefix)
-
-            key = :"xmlns:#{prefix}"
-            next if schema_attrs[key] && schema_attrs[key] != ns_class.uri
-
-            schema_attrs[key] = ns_class.uri
+            schema_attrs[:"xmlns:#{ns_class.prefix_default}"] = ns_class.uri
           end
 
           referenced[:type_values].each do |ns_class|
@@ -337,9 +337,9 @@ target_uri, skip_validation)
           end
         end
 
-        # Why a foreign namespace cannot be referenced from this schema, or
-        # nil when it can.
-        def self.foreign_namespace_error(ns_class, schema_attrs, target_uri)
+        # Why a foreign namespace's prefix cannot be used in this schema's
+        # QNames, or nil when it can.
+        def self.foreign_prefix_error(ns_class, schema_attrs, target_uri)
           prefix = ns_class.prefix_default
           unless usable_prefix?(prefix)
             return "XSD generation: foreign namespace '#{ns_class.uri}' " \
@@ -348,14 +348,14 @@ target_uri, skip_validation)
           end
 
           existing = schema_attrs[:"xmlns:#{prefix}"]
-          if existing && existing != ns_class.uri
-            return "XSD generation: namespace prefix '#{prefix}' is bound " \
-                   "to two different namespaces (#{existing} and " \
-                   "#{ns_class.uri}). Give them distinct prefixes."
-          end
+          return unless existing && existing != ns_class.uri
 
-          return if ns_class.schema_location
+          "XSD generation: namespace prefix '#{prefix}' is bound " \
+            "to two different namespaces (#{existing} and " \
+            "#{ns_class.uri}). Give them distinct prefixes."
+        end
 
+        def self.missing_schema_location_error(ns_class)
           "XSD generation: foreign namespace '#{ns_class.uri}' needs a " \
             "schema_location so its imported types can be resolved."
         end

--- a/lib/lutaml/xml/schema/xsd_schema.rb
+++ b/lib/lutaml/xml/schema/xsd_schema.rb
@@ -12,6 +12,47 @@ module Lutaml
         include Lutaml::Model::Schema::SharedMethods
         extend Lutaml::Model::Schema::SharedMethods
 
+        # The XSD vocabulary namespace, routed through the project's namespace
+        # object so the declared prefix and every emitted prefix stay in sync.
+        # W3c::XsNamespace binds "xs" (matching the built-in xs:-prefixed type
+        # references) and opts out of the W3C-reserved-prefix warning.
+        def self.xsd_ns
+          @xsd_ns ||= Lutaml::Xml::W3c::XsNamespace.new
+        end
+
+        # Qualify an XSD structure element name with the bound prefix, so the
+        # prefix used on emitted elements always matches the declared xmlns.
+        def self.qn(local)
+          "#{xsd_ns.prefix}:#{local}"
+        end
+
+        # The prefix of the schema's target namespace, or nil when the schema
+        # has no target namespace (named types then live in no-namespace and
+        # their references stay unprefixed). Never returns the reserved "xs".
+        def self.target_ns_prefix(xml_mapping)
+          prefix =
+            if xml_mapping&.namespace_class
+              xml_mapping.namespace_prefix ||
+                xml_mapping.namespace_class.prefix_default
+            elsif xml_mapping&.namespace_uri
+              xml_mapping.namespace_prefix
+            end
+          return if prefix.nil? || prefix.empty? || prefix == xsd_ns.prefix
+
+          prefix
+        end
+
+        # Qualify a named-type reference with the target-namespace prefix so it
+        # resolves to the namespace the type is defined in. Built-in refs (which
+        # already carry a prefix, e.g. "xs:string") and no-namespace schemas
+        # (prefix nil) are returned unchanged.
+        def self.qualify_type_ref(type_name, prefix)
+          return type_name if prefix.nil? || type_name.nil?
+          return type_name if type_name.include?(":")
+
+          "#{prefix}:#{type_name}"
+        end
+
         def self.generate(klass, options = {})
           register = extract_register_from(klass)
           xml_mapping = klass.mappings_for(:xml)
@@ -109,7 +150,10 @@ module Lutaml
         end
 
         def self.generate_schema(xml, klass, xml_mapping, register, _options)
-          schema_attrs = { xmlns: "http://www.w3.org/2001/XMLSchema" }
+          # Bind the XSD vocabulary namespace to the "xs" prefix (via the
+          # namespace object, not a hardcoded string) so the xs:-prefixed type
+          # references and the prefixed structure elements are both declared.
+          schema_attrs = { xsd_ns.attr_name.to_sym => xsd_ns.uri }
 
           # Add namespace metadata from XmlNamespace class if present
           if xml_mapping.namespace_class
@@ -119,9 +163,10 @@ module Lutaml
             schema_attrs[:attributeFormDefault] = ns.attribute_form_default.to_s
             schema_attrs[:version] = ns.version if ns.version
 
-            # Add xmlns declarations for the target namespace
+            # Add xmlns declarations for the target namespace, but never rebind
+            # the reserved "xs" prefix already bound to the XSD namespace.
             prefix = xml_mapping.namespace_prefix || ns.prefix_default
-            if prefix && !prefix.empty?
+            if prefix && !prefix.empty? && prefix != xsd_ns.prefix
               schema_attrs[:"xmlns:#{prefix}"] = ns.uri
             end
           elsif xml_mapping.namespace_uri
@@ -130,13 +175,18 @@ module Lutaml
             schema_attrs[:elementFormDefault] = "unqualified"
             schema_attrs[:attributeFormDefault] = "unqualified"
 
-            if xml_mapping.namespace_prefix
+            if xml_mapping.namespace_prefix &&
+                xml_mapping.namespace_prefix != xsd_ns.prefix
               schema_attrs[:"xmlns:#{xml_mapping.namespace_prefix}"] =
                 xml_mapping.namespace_uri
             end
           end
 
-          xml.schema(schema_attrs) do
+          # Named-type references are qualified with the target-namespace
+          # prefix so they resolve to the namespace the type is defined in.
+          target_prefix = target_ns_prefix(xml_mapping)
+
+          xml.public_send(qn("schema"), schema_attrs) do
             # Generate imports from XmlNamespace
             if xml_mapping.namespace_class
               generate_imports(xml, xml_mapping.namespace_class)
@@ -148,13 +198,17 @@ module Lutaml
             type_namespaces.each do |ns_class|
               # Only import if different from target namespace
               next if ns_class.uri == schema_attrs[:targetNamespace]
+              # Skip bare, unresolvable imports: with no schemaLocation the
+              # imported components cannot be resolved, so the type is defined
+              # inline in this schema instead (single-document generation).
+              next unless ns_class.schema_location
 
               import_attrs = { namespace: ns_class.uri }
               if ns_class.schema_location
                 import_attrs[:schemaLocation] =
                   ns_class.schema_location
               end
-              xml.import(import_attrs)
+              xml.public_send(qn("import"), import_attrs)
             end
 
             # Generate annotation if present
@@ -176,24 +230,28 @@ module Lutaml
 
             if element_name && type_name
               # Pattern 3: Both element and named type
-              xml.element(name: element_name, type: type_name)
+              xml.public_send(qn("element"),
+                              { name: element_name,
+                                type: qualify_type_ref(type_name, target_prefix) })
               generate_complex_type(xml, klass, type_name, register,
-                                    xml_mapping)
+                                    xml_mapping, target_prefix: target_prefix)
             elsif type_name && !element_name
               # Pattern 2: Type-only (no element)
               generate_complex_type(xml, klass, type_name, register,
-                                    xml_mapping)
+                                    xml_mapping, target_prefix: target_prefix)
             else
               # Pattern 1: Anonymous inline (element with no type_name)
               # Use class name as fallback element name if not specified
               elem_name = element_name || klass.name
-              xml.element(name: elem_name) do
-                generate_complex_type_content(xml, klass, register, xml_mapping)
+              xml.public_send(qn("element"), { name: elem_name }) do
+                generate_complex_type_content(xml, klass, register, xml_mapping,
+                                              target_prefix: target_prefix)
               end
             end
 
             # Generate type definitions for nested models with type_name
-            generate_nested_type_definitions(xml, klass, register)
+            generate_nested_type_definitions(xml, klass, register,
+                                             target_prefix: target_prefix)
           end
         end
 
@@ -206,7 +264,7 @@ module Lutaml
               import_attrs[:schemaLocation] =
                 imported_ns.schema_location
             end
-            xml.import(import_attrs)
+            xml.public_send(qn("import"), import_attrs)
           end
         end
 
@@ -214,20 +272,21 @@ module Lutaml
           return unless namespace_class.includes&.any?
 
           namespace_class.includes.each do |schema_location|
-            xml.include(schemaLocation: schema_location)
+            xml.public_send(qn("include"), { schemaLocation: schema_location })
           end
         end
 
         def self.generate_annotation(xml, xml_mapping)
-          xml.annotation do
+          xml.public_send(qn("annotation")) do
             doc_text = xml_mapping.documentation_text
             doc_text ||= xml_mapping.namespace_class&.documentation if xml_mapping.namespace_class
 
-            xml.documentation(doc_text) if doc_text
+            xml.public_send(qn("documentation"), doc_text) if doc_text
           end
         end
 
-        def self.generate_nested_type_definitions(xml, klass, register)
+        def self.generate_nested_type_definitions(xml, klass, register,
+target_prefix: nil)
           klass.attributes.each_value do |attr|
             attr_type = attr.type(register)
             next unless attr_type <= Lutaml::Model::Serialize
@@ -238,19 +297,21 @@ module Lutaml
             # Generate type definition if nested model has type_name
             if nested_type_name
               generate_complex_type(xml, attr_type, nested_type_name, register,
-                                    nested_mapping)
+                                    nested_mapping, target_prefix: target_prefix)
               # Recursively generate nested types
-              generate_nested_type_definitions(xml, attr_type, register)
+              generate_nested_type_definitions(xml, attr_type, register,
+                                               target_prefix: target_prefix)
             end
           end
         end
 
         def self.generate_complex_type_content(xml, klass, register,
-xml_mapping)
-          xml.complexType do
+xml_mapping, target_prefix: nil)
+          xml.public_send(qn("complexType")) do
             if klass.attributes.any?
-              xml.sequence do
-                generate_elements(xml, klass, register, xml_mapping)
+              xml.public_send(qn("sequence")) do
+                generate_elements(xml, klass, register, xml_mapping,
+                                  target_prefix: target_prefix)
               end
             end
             if xml_mapping
@@ -261,18 +322,20 @@ xml_mapping)
         end
 
         def self.generate_complex_type(xml, klass, type_name, register,
-xml_mapping = nil)
-          xml.complexType(name: type_name) do
+xml_mapping = nil, target_prefix: nil)
+          xml.public_send(qn("complexType"), { name: type_name }) do
             if klass.attributes.any?
-              xml.sequence do
-                generate_elements(xml, klass, register, xml_mapping)
+              xml.public_send(qn("sequence")) do
+                generate_elements(xml, klass, register, xml_mapping,
+                                  target_prefix: target_prefix)
               end
             end
             generate_attributes(xml, klass, register, xml_mapping)
           end
         end
 
-        def self.generate_elements(xml, klass, register, xml_mapping)
+        def self.generate_elements(xml, klass, register, xml_mapping,
+target_prefix: nil)
           klass.attributes.each do |name, attr|
             next if xml_mapping && attr_is_xml_attribute?(xml_mapping, name)
 
@@ -294,25 +357,30 @@ xml_mapping = nil)
 
                 if nested_type_name
                   # Reference named type
-                  element_attrs[:type] = nested_type_name
-                  xml.element(element_attrs)
+                  element_attrs[:type] =
+                    qualify_type_ref(nested_type_name, target_prefix)
+                  xml.public_send(qn("element"), element_attrs)
                 else
                   # Inline anonymous complexType
-                  xml.element(element_attrs) do
-                    xml.complexType do
-                      xml.sequence do
-                        xml.element(name: "item", type: get_xsd_type(attr_type))
+                  xml.public_send(qn("element"), element_attrs) do
+                    xml.public_send(qn("complexType")) do
+                      xml.public_send(qn("sequence")) do
+                        xml.public_send(qn("element"),
+                                        { name: "item", type: get_xsd_type(attr_type) })
                       end
                     end
                   end
                 end
               elsif nested_type_name
                 # Single nested model - Reference named type
-                xml.element(name: name.to_s, type: nested_type_name)
+                xml.public_send(qn("element"),
+                                { name: name.to_s,
+                                  type: qualify_type_ref(nested_type_name, target_prefix) })
               else
                 # Inline anonymous complexType
-                xml.element(name: name.to_s) do
-                  generate_complex_type_content(xml, attr_type, register, nil)
+                xml.public_send(qn("element"), { name: name.to_s }) do
+                  generate_complex_type_content(xml, attr_type, register, nil,
+                                                target_prefix: target_prefix)
                 end
               end
             else
@@ -326,10 +394,11 @@ xml_mapping = nil)
                 element_attrs[:minOccurs] = "0"
                 element_attrs[:maxOccurs] = "unbounded"
 
-                xml.element(element_attrs) do
-                  xml.complexType do
-                    xml.sequence do
-                      xml.element(name: "item", type: xsd_type)
+                xml.public_send(qn("element"), element_attrs) do
+                  xml.public_send(qn("complexType")) do
+                    xml.public_send(qn("sequence")) do
+                      xml.public_send(qn("element"),
+                                      { name: "item", type: xsd_type })
                     end
                   end
                 end
@@ -337,7 +406,7 @@ xml_mapping = nil)
                 # Simple element
                 element_attrs = build_element_attributes(name, xsd_type, attr,
                                                          xml_mapping, name)
-                xml.element(element_attrs)
+                xml.public_send(qn("element"), element_attrs)
               end
             end
           end
@@ -358,13 +427,13 @@ xml_mapping = nil)
             attr_attrs[:form] = rule.form.to_s if rule.form
 
             if rule.documentation
-              xml.attribute(attr_attrs) do
-                xml.annotation do
-                  xml.documentation(rule.documentation)
+              xml.public_send(qn("attribute"), attr_attrs) do
+                xml.public_send(qn("annotation")) do
+                  xml.public_send(qn("documentation"), rule.documentation)
                 end
               end
             else
-              xml.attribute(attr_attrs)
+              xml.public_send(qn("attribute"), attr_attrs)
             end
           end
         end

--- a/lib/lutaml/xml/schema/xsd_schema.rb
+++ b/lib/lutaml/xml/schema/xsd_schema.rb
@@ -307,8 +307,7 @@ module Lutaml
         # structurally correct, only the import is unresolvable).
         # Type::Value namespaces are declared best-effort (their xsd_type
         # references are emitted verbatim).
-        def self.declare_referenced_namespaces!(schema_attrs, referenced,
-target_uri, skip_validation)
+        def self.declare_referenced_namespaces!(schema_attrs, referenced, target_uri, skip_validation)
           referenced[:foreign_models].each do |ns_class|
             # An unusable or colliding prefix makes emitted QNames resolve to
             # the wrong namespace — never recoverable, even under
@@ -349,9 +348,10 @@ target_uri, skip_validation)
         def self.foreign_prefix_error(ns_class, schema_attrs, target_uri)
           prefix = ns_class.prefix_default
           unless usable_prefix?(prefix)
+            schema_desc = target_uri ? "the '#{target_uri}'" : "this no-namespace"
             return "XSD generation: foreign namespace '#{ns_class.uri}' " \
                    "needs a usable prefix_default (not nil/empty/'xs') to " \
-                   "be referenced from the '#{target_uri}' schema."
+                   "be referenced from #{schema_desc} schema."
           end
 
           prefix_collision_error(prefix, ns_class.uri, schema_attrs)
@@ -376,8 +376,7 @@ target_uri, skip_validation)
 
         # <xs:import> for every referenced foreign namespace, deduped by URI
         # against the explicit imports already emitted.
-        def self.generate_referenced_imports(xml, referenced, target_uri,
-imported_uris)
+        def self.generate_referenced_imports(xml, referenced, target_uri, imported_uris)
           (referenced[:foreign_models] + referenced[:type_values]).each do |ns_class|
             next if ns_class.uri == target_uri
             next unless imported_uris.add?(ns_class.uri)
@@ -429,8 +428,7 @@ imported_uris)
           end
         end
 
-        def self.generate_nested_type_definitions(xml, klass, register, ctx:,
-seen: nil)
+        def self.generate_nested_type_definitions(xml, klass, register, ctx:, seen: nil)
           # Cycle guard, seeded with the root class (already defined by
           # generate_schema) so it is never redefined via a back-reference.
           seen ||= Set[klass]
@@ -493,8 +491,7 @@ seen: nil)
           attr.collection? && mapping&.type_name_value.nil?
         end
 
-        def self.generate_complex_type_content(xml, klass, register,
-xml_mapping, ctx:)
+        def self.generate_complex_type_content(xml, klass, register, xml_mapping, ctx:)
           xs(xml, "complexType") do
             if klass.attributes.any?
               xs(xml, "sequence") do
@@ -508,8 +505,7 @@ xml_mapping, ctx:)
           end
         end
 
-        def self.generate_complex_type(xml, klass, type_name, register,
-xml_mapping = nil, ctx:)
+        def self.generate_complex_type(xml, klass, type_name, register, xml_mapping = nil, ctx:)
           xs(xml, "complexType", { name: type_name }) do
             if klass.attributes.any?
               xs(xml, "sequence") do
@@ -696,8 +692,7 @@ _mapping_rule = nil)
         #   resolved through an import); :type_values — namespace classes
         #   declared by Type::Value attribute types (imported so their
         #   verbatim xsd_type references can resolve). Both deduped by class.
-        def self.referenced_namespaces(klass, register, target_uri,
-seen = Set.new)
+        def self.referenced_namespaces(klass, register, target_uri, seen = Set.new)
           result = { foreign_models: [], type_values: [] }
           return result unless klass.is_a?(::Class) && seen.add?(klass)
 

--- a/lib/lutaml/xml/schema/xsd_schema.rb
+++ b/lib/lutaml/xml/schema/xsd_schema.rb
@@ -26,6 +26,26 @@ module Lutaml
           "#{xsd_ns.prefix}:#{local}"
         end
 
+        # Emit an XSD structure element (<xs:local ...>) through the builder.
+        def self.xs(xml, local, attrs = nil, &)
+          if attrs
+            xml.public_send(qn(local), attrs, &)
+          else
+            xml.public_send(qn(local), &)
+          end
+        end
+
+        # Whether a prefix can appear in emitted QNames: present and not the
+        # reserved XSD vocabulary prefix.
+        def self.usable_prefix?(prefix)
+          !prefix.nil? && !prefix.empty? && prefix != xsd_ns.prefix
+        end
+
+        # Per-generation namespace context threaded through the generate_*
+        # methods: the schema's target namespace URI and the prefix that
+        # qualifies named-type references into it.
+        Context = Struct.new(:target_prefix, :target_uri)
+
         # The prefix of the schema's target namespace, or nil when the schema
         # has no target namespace (named types then live in no-namespace and
         # their references stay unprefixed). Never returns the reserved "xs".
@@ -37,15 +57,14 @@ module Lutaml
             elsif xml_mapping&.namespace_uri
               xml_mapping.namespace_prefix
             end
-          return if prefix.nil? || prefix.empty? || prefix == xsd_ns.prefix
 
-          prefix
+          prefix if usable_prefix?(prefix)
         end
 
-        # Qualify a named-type reference with the target-namespace prefix so it
-        # resolves to the namespace the type is defined in. Built-in refs (which
-        # already carry a prefix, e.g. "xs:string") and no-namespace schemas
-        # (prefix nil) are returned unchanged.
+        # Qualify a named-type reference with the given prefix so it resolves
+        # to the namespace the type is defined in. Built-in refs (which already
+        # carry a prefix, e.g. "xs:string") and no-namespace schemas (prefix
+        # nil) are returned unchanged.
         def self.qualify_type_ref(type_name, prefix)
           return type_name if prefix.nil? || type_name.nil?
           return type_name if type_name.include?(":")
@@ -53,15 +72,17 @@ module Lutaml
           "#{prefix}:#{type_name}"
         end
 
-        # The prefix a named-type reference should carry: the referenced model's
-        # own namespace prefix when it has one (the type lives in that
-        # namespace), otherwise the schema's target prefix.
-        def self.nested_ref_prefix(nested_mapping, target_prefix)
-          prefix = nested_mapping&.namespace_class&.prefix_default
-          return target_prefix if prefix.nil? || prefix.empty? ||
-            prefix == xsd_ns.prefix
+        # The prefix a named-type reference should carry. A foreign model's
+        # type lives in its own namespace, so the ref uses that namespace's
+        # prefix; a model in the target namespace (same URI or none) is defined
+        # in this schema, so the ref uses the target prefix.
+        def self.nested_ref_prefix(nested_mapping, ctx)
+          ns_class = nested_mapping&.namespace_class
+          return ctx.target_prefix unless ns_class
+          return ctx.target_prefix if ns_class.uri == ctx.target_uri
 
-          prefix
+          prefix = ns_class.prefix_default
+          usable_prefix?(prefix) ? prefix : ctx.target_prefix
         end
 
         def self.generate(klass, options = {})
@@ -164,81 +185,33 @@ module Lutaml
           end
         end
 
-        def self.generate_schema(xml, klass, xml_mapping, register, _options)
+        def self.generate_schema(xml, klass, xml_mapping, register, options)
+          skip_validation = options[:skip_validation]
+
           # Bind the XSD vocabulary namespace to the "xs" prefix (via the
           # namespace object, not a hardcoded string) so the xs:-prefixed type
           # references and the prefixed structure elements are both declared.
           schema_attrs = { xsd_ns.attr_name.to_sym => xsd_ns.uri }
-
-          # Add namespace metadata from XmlNamespace class if present
-          if xml_mapping.namespace_class
-            ns = xml_mapping.namespace_class
-            schema_attrs[:targetNamespace] = ns.uri
-            schema_attrs[:elementFormDefault] = ns.element_form_default.to_s
-            schema_attrs[:attributeFormDefault] = ns.attribute_form_default.to_s
-            schema_attrs[:version] = ns.version if ns.version
-
-            # Add xmlns declarations for the target namespace, but never rebind
-            # the reserved "xs" prefix already bound to the XSD namespace.
-            prefix = xml_mapping.namespace_prefix || ns.prefix_default
-            if prefix && !prefix.empty? && prefix != xsd_ns.prefix
-              schema_attrs[:"xmlns:#{prefix}"] = ns.uri
-            end
-          elsif xml_mapping.namespace_uri
-            # Legacy: namespace URI without XmlNamespace class
-            schema_attrs[:targetNamespace] = xml_mapping.namespace_uri
-            schema_attrs[:elementFormDefault] = "unqualified"
-            schema_attrs[:attributeFormDefault] = "unqualified"
-
-            if xml_mapping.namespace_prefix &&
-                xml_mapping.namespace_prefix != xsd_ns.prefix
-              schema_attrs[:"xmlns:#{xml_mapping.namespace_prefix}"] =
-                xml_mapping.namespace_uri
-            end
-          end
-
-          # Named-type references are qualified with the namespace prefix of the
-          # namespace the type is defined in.
-          target_prefix = target_ns_prefix(xml_mapping)
+          schema_attrs.merge!(target_namespace_attrs(xml_mapping))
           target_uri = schema_attrs[:targetNamespace]
 
-          # A target namespace referenced by named-type QNames needs a usable
-          # prefix; synthesise one when the namespace class declares none.
-          if target_uri && (target_prefix.nil? || target_prefix.empty?)
-            target_prefix = "tns"
-            schema_attrs[:"xmlns:#{target_prefix}"] ||= target_uri
+          referenced = referenced_namespaces(klass, register, target_uri)
+
+          # Named-type references into the target namespace need a usable
+          # prefix; synthesise a non-colliding one when the namespace class
+          # declares none.
+          target_prefix = target_ns_prefix(xml_mapping)
+          if target_uri && target_prefix.nil?
+            target_prefix = synthesize_target_prefix(referenced)
+            schema_attrs[:"xmlns:#{target_prefix}"] = target_uri
           end
 
-          # Declare every namespace class used anywhere in the tree on the root
-          # <xs:schema>, deduped by class, so foreign type references resolve.
-          # A prefix bound to two different namespaces is unresolvable -> raise.
-          tree_ns_classes = collect_namespace_classes(klass, register)
-          tree_ns_classes.each do |ns_class|
-            prefix = ns_class.prefix_default
-            unusable = prefix.nil? || prefix.empty? || prefix == xsd_ns.prefix
+          declare_referenced_namespaces!(schema_attrs, referenced, target_uri,
+                                         skip_validation)
 
-            # A foreign namespace is referenced by a prefixed QName, so it must
-            # have a usable prefix of its own — it cannot borrow the target's.
-            if unusable && ns_class.uri != target_uri
-              raise Lutaml::Model::Error,
-                    "XSD generation: foreign namespace '#{ns_class.uri}' needs " \
-                    "a usable prefix_default (not nil/empty/'xs') to be " \
-                    "referenced from the '#{target_uri}' schema."
-            end
-            next if unusable
+          ctx = Context.new(target_prefix, target_uri)
 
-            key = :"xmlns:#{prefix}"
-            existing = schema_attrs[key]
-            if existing && existing != ns_class.uri
-              raise Lutaml::Model::Error,
-                    "XSD generation: namespace prefix '#{prefix}' is bound to " \
-                    "two different namespaces (#{existing} and #{ns_class.uri}). " \
-                    "Give them distinct prefixes."
-            end
-            schema_attrs[key] = ns_class.uri
-          end
-
-          xml.public_send(qn("schema"), schema_attrs) do
+          xs(xml, "schema", schema_attrs) do
             # Explicit imports declared on the root's XmlNamespace class.
             imported_uris = Set.new
             if xml_mapping.namespace_class
@@ -246,26 +219,13 @@ module Lutaml
               generate_includes(xml, xml_mapping.namespace_class)
             end
 
-            # Import every foreign namespace referenced by the tree (any
-            # namespace other than this schema's own target), deduped by URI.
-            # Foreign types are defined in their own schema, not here.
-            tree_ns_classes.each do |ns_class|
-              next if ns_class.uri == target_uri
-              next unless imported_uris.add?(ns_class.uri)
+            generate_referenced_imports(xml, referenced, target_uri,
+                                        imported_uris)
 
-              import_attrs = { namespace: ns_class.uri }
-              if ns_class.schema_location
-                import_attrs[:schemaLocation] = ns_class.schema_location
-              end
-              xml.public_send(qn("import"), import_attrs)
-            end
-
-            # Generate annotation if present
             if xml_mapping.documentation_text || xml_mapping.namespace_class&.documentation
               generate_annotation(xml, xml_mapping)
             end
 
-            # Determine element name and type name for XSD pattern selection
             element_name = if has_explicit_xml_mapping?(klass, xml_mapping)
                              xml_mapping.element_name || xml_mapping.root_element
                            end
@@ -278,30 +238,141 @@ module Lutaml
             # Pattern 3: both element and type_name -> element + named complexType
 
             if element_name && type_name
-              # Pattern 3: Both element and named type
-              xml.public_send(qn("element"),
-                              { name: element_name,
-                                type: qualify_type_ref(type_name, target_prefix) })
+              xs(xml, "element",
+                 { name: element_name,
+                   type: qualify_type_ref(type_name, target_prefix) })
               generate_complex_type(xml, klass, type_name, register,
-                                    xml_mapping, target_prefix: target_prefix)
+                                    xml_mapping, ctx: ctx)
             elsif type_name && !element_name
-              # Pattern 2: Type-only (no element)
               generate_complex_type(xml, klass, type_name, register,
-                                    xml_mapping, target_prefix: target_prefix)
+                                    xml_mapping, ctx: ctx)
             else
-              # Pattern 1: Anonymous inline (element with no type_name)
               # Use class name as fallback element name if not specified
               elem_name = element_name || klass.name
-              xml.public_send(qn("element"), { name: elem_name }) do
+              xs(xml, "element", { name: elem_name }) do
                 generate_complex_type_content(xml, klass, register, xml_mapping,
-                                              target_prefix: target_prefix)
+                                              ctx: ctx)
               end
             end
 
-            # Generate type definitions for nested models with type_name
-            generate_nested_type_definitions(xml, klass, register,
-                                             target_prefix: target_prefix,
-                                             target_uri: target_uri)
+            generate_nested_type_definitions(xml, klass, register, ctx: ctx)
+          end
+        end
+
+        # targetNamespace, form defaults, and the target xmlns declaration,
+        # derived from the root mapping's namespace configuration.
+        def self.target_namespace_attrs(xml_mapping)
+          attrs = {}
+
+          if xml_mapping.namespace_class
+            ns = xml_mapping.namespace_class
+            attrs[:targetNamespace] = ns.uri
+            attrs[:elementFormDefault] = ns.element_form_default.to_s
+            attrs[:attributeFormDefault] = ns.attribute_form_default.to_s
+            attrs[:version] = ns.version if ns.version
+
+            prefix = xml_mapping.namespace_prefix || ns.prefix_default
+            attrs[:"xmlns:#{prefix}"] = ns.uri if usable_prefix?(prefix)
+          elsif xml_mapping.namespace_uri
+            # Legacy: namespace URI without XmlNamespace class
+            attrs[:targetNamespace] = xml_mapping.namespace_uri
+            attrs[:elementFormDefault] = "unqualified"
+            attrs[:attributeFormDefault] = "unqualified"
+
+            if usable_prefix?(xml_mapping.namespace_prefix)
+              attrs[:"xmlns:#{xml_mapping.namespace_prefix}"] =
+                xml_mapping.namespace_uri
+            end
+          end
+
+          attrs
+        end
+
+        # A synthetic prefix for a target namespace that declares none,
+        # avoiding every prefix claimed by a referenced namespace.
+        def self.synthesize_target_prefix(referenced)
+          taken = (referenced[:foreign_models] + referenced[:type_values])
+            .filter_map(&:prefix_default)
+          candidate = "tns"
+          suffix = 0
+          candidate = "tns#{suffix += 1}" while taken.include?(candidate)
+          candidate
+        end
+
+        # Declare xmlns:<prefix> for every namespace this schema references.
+        # Foreign model namespaces are strict: their types are referenced by
+        # prefixed QNames and resolved through an import, so an unusable
+        # prefix, a prefix collision, or a missing schema_location makes the
+        # output unresolvable — raise, or warn and skip under skip_validation.
+        # Type::Value namespaces are declared best-effort (their xsd_type
+        # references are emitted verbatim).
+        def self.declare_referenced_namespaces!(schema_attrs, referenced,
+target_uri, skip_validation)
+          referenced[:foreign_models].each do |ns_class|
+            error = foreign_namespace_error(ns_class, schema_attrs, target_uri)
+            if error
+              raise Lutaml::Model::Error, error unless skip_validation
+
+              warn "[Lutaml::Model] WARN: #{error} " \
+                   "(skip_validation: emitting best-effort output)"
+            end
+
+            # Best-effort even after a warning: a usable, non-colliding prefix
+            # is still declared so the emitted QNames resolve; only the
+            # unusable/colliding cases have nothing declarable.
+            prefix = ns_class.prefix_default
+            next unless usable_prefix?(prefix)
+
+            key = :"xmlns:#{prefix}"
+            next if schema_attrs[key] && schema_attrs[key] != ns_class.uri
+
+            schema_attrs[key] = ns_class.uri
+          end
+
+          referenced[:type_values].each do |ns_class|
+            prefix = ns_class.prefix_default
+            next unless usable_prefix?(prefix)
+
+            schema_attrs[:"xmlns:#{prefix}"] ||= ns_class.uri
+          end
+        end
+
+        # Why a foreign namespace cannot be referenced from this schema, or
+        # nil when it can.
+        def self.foreign_namespace_error(ns_class, schema_attrs, target_uri)
+          prefix = ns_class.prefix_default
+          unless usable_prefix?(prefix)
+            return "XSD generation: foreign namespace '#{ns_class.uri}' " \
+                   "needs a usable prefix_default (not nil/empty/'xs') to " \
+                   "be referenced from the '#{target_uri}' schema."
+          end
+
+          existing = schema_attrs[:"xmlns:#{prefix}"]
+          if existing && existing != ns_class.uri
+            return "XSD generation: namespace prefix '#{prefix}' is bound " \
+                   "to two different namespaces (#{existing} and " \
+                   "#{ns_class.uri}). Give them distinct prefixes."
+          end
+
+          return if ns_class.schema_location
+
+          "XSD generation: foreign namespace '#{ns_class.uri}' needs a " \
+            "schema_location so its imported types can be resolved."
+        end
+
+        # <xs:import> for every referenced foreign namespace, deduped by URI
+        # against the explicit imports already emitted.
+        def self.generate_referenced_imports(xml, referenced, target_uri,
+imported_uris)
+          (referenced[:foreign_models] + referenced[:type_values]).each do |ns_class|
+            next if ns_class.uri == target_uri
+            next unless imported_uris.add?(ns_class.uri)
+
+            import_attrs = { namespace: ns_class.uri }
+            if ns_class.schema_location
+              import_attrs[:schemaLocation] = ns_class.schema_location
+            end
+            xs(xml, "import", import_attrs)
           end
         end
 
@@ -320,7 +391,7 @@ module Lutaml
               import_attrs[:schemaLocation] =
                 imported_ns.schema_location
             end
-            xml.public_send(qn("import"), import_attrs)
+            xs(xml, "import", import_attrs)
           end
 
           imported
@@ -330,21 +401,21 @@ module Lutaml
           return unless namespace_class.includes&.any?
 
           namespace_class.includes.each do |schema_location|
-            xml.public_send(qn("include"), { schemaLocation: schema_location })
+            xs(xml, "include", { schemaLocation: schema_location })
           end
         end
 
         def self.generate_annotation(xml, xml_mapping)
-          xml.public_send(qn("annotation")) do
+          xs(xml, "annotation") do
             doc_text = xml_mapping.documentation_text
             doc_text ||= xml_mapping.namespace_class&.documentation if xml_mapping.namespace_class
 
-            xml.public_send(qn("documentation"), doc_text) if doc_text
+            xs(xml, "documentation", doc_text) if doc_text
           end
         end
 
-        def self.generate_nested_type_definitions(xml, klass, register,
-target_prefix: nil, target_uri: nil, seen: nil)
+        def self.generate_nested_type_definitions(xml, klass, register, ctx:,
+seen: nil)
           # Cycle guard, seeded with the root class (already defined by
           # generate_schema) so it is never redefined via a back-reference.
           seen ||= Set[klass]
@@ -355,20 +426,19 @@ target_prefix: nil, target_uri: nil, seen: nil)
             next unless seen.add?(attr_type)
 
             nested_mapping = attr_type.mappings_for(:xml)
-            nested_type_name = nested_mapping&.type_name_value
 
-            # Define a named type only when it belongs to this schema's target
-            # namespace; a foreign type is imported, not defined here. Recurse
-            # regardless — a same-target type can be nested under a foreign model.
-            if nested_type_name &&
-                !foreign_namespace?(nested_mapping, target_uri)
+            # A foreign model's type is imported from its own schema document;
+            # neither it nor anything inside it is defined here.
+            next if foreign_namespace?(nested_mapping, ctx.target_uri)
+
+            nested_type_name = nested_mapping&.type_name_value
+            if nested_type_name
               generate_complex_type(xml, attr_type, nested_type_name, register,
-                                    nested_mapping, target_prefix: target_prefix)
+                                    nested_mapping, ctx: ctx)
             end
 
             generate_nested_type_definitions(xml, attr_type, register,
-                                             target_prefix: target_prefix,
-                                             target_uri: target_uri, seen: seen)
+                                             ctx: ctx, seen: seen)
           end
         end
 
@@ -383,12 +453,11 @@ target_prefix: nil, target_uri: nil, seen: nil)
         end
 
         def self.generate_complex_type_content(xml, klass, register,
-xml_mapping, target_prefix: nil)
-          xml.public_send(qn("complexType")) do
+xml_mapping, ctx:)
+          xs(xml, "complexType") do
             if klass.attributes.any?
-              xml.public_send(qn("sequence")) do
-                generate_elements(xml, klass, register, xml_mapping,
-                                  target_prefix: target_prefix)
+              xs(xml, "sequence") do
+                generate_elements(xml, klass, register, xml_mapping, ctx: ctx)
               end
             end
             if xml_mapping
@@ -399,20 +468,18 @@ xml_mapping, target_prefix: nil)
         end
 
         def self.generate_complex_type(xml, klass, type_name, register,
-xml_mapping = nil, target_prefix: nil)
-          xml.public_send(qn("complexType"), { name: type_name }) do
+xml_mapping = nil, ctx:)
+          xs(xml, "complexType", { name: type_name }) do
             if klass.attributes.any?
-              xml.public_send(qn("sequence")) do
-                generate_elements(xml, klass, register, xml_mapping,
-                                  target_prefix: target_prefix)
+              xs(xml, "sequence") do
+                generate_elements(xml, klass, register, xml_mapping, ctx: ctx)
               end
             end
             generate_attributes(xml, klass, register, xml_mapping)
           end
         end
 
-        def self.generate_elements(xml, klass, register, xml_mapping,
-target_prefix: nil)
+        def self.generate_elements(xml, klass, register, xml_mapping, ctx:)
           klass.attributes.each do |name, attr|
             next if xml_mapping && attr_is_xml_attribute?(xml_mapping, name)
 
@@ -436,35 +503,33 @@ target_prefix: nil)
                   # Reference named type by its owning namespace's prefix
                   element_attrs[:type] = qualify_type_ref(
                     nested_type_name,
-                    nested_ref_prefix(nested_mapping, target_prefix),
+                    nested_ref_prefix(nested_mapping, ctx),
                   )
-                  xml.public_send(qn("element"), element_attrs)
+                  xs(xml, "element", element_attrs)
                 else
                   # Inline anonymous complexType
-                  xml.public_send(qn("element"), element_attrs) do
-                    xml.public_send(qn("complexType")) do
-                      xml.public_send(qn("sequence")) do
-                        xml.public_send(qn("element"),
-                                        { name: "item", type: get_xsd_type(attr_type) })
+                  xs(xml, "element", element_attrs) do
+                    xs(xml, "complexType") do
+                      xs(xml, "sequence") do
+                        xs(xml, "element",
+                           { name: "item", type: get_xsd_type(attr_type) })
                       end
                     end
                   end
                 end
               elsif nested_type_name
                 # Single nested model - reference by its owning namespace prefix
-                xml.public_send(
-                  qn("element"),
-                  { name: name.to_s,
-                    type: qualify_type_ref(
-                      nested_type_name,
-                      nested_ref_prefix(nested_mapping, target_prefix),
-                    ) },
-                )
+                xs(xml, "element",
+                   { name: name.to_s,
+                     type: qualify_type_ref(
+                       nested_type_name,
+                       nested_ref_prefix(nested_mapping, ctx),
+                     ) })
               else
                 # Inline anonymous complexType
-                xml.public_send(qn("element"), { name: name.to_s }) do
+                xs(xml, "element", { name: name.to_s }) do
                   generate_complex_type_content(xml, attr_type, register, nil,
-                                                target_prefix: target_prefix)
+                                                ctx: ctx)
                 end
               end
             else
@@ -478,11 +543,10 @@ target_prefix: nil)
                 element_attrs[:minOccurs] = "0"
                 element_attrs[:maxOccurs] = "unbounded"
 
-                xml.public_send(qn("element"), element_attrs) do
-                  xml.public_send(qn("complexType")) do
-                    xml.public_send(qn("sequence")) do
-                      xml.public_send(qn("element"),
-                                      { name: "item", type: xsd_type })
+                xs(xml, "element", element_attrs) do
+                  xs(xml, "complexType") do
+                    xs(xml, "sequence") do
+                      xs(xml, "element", { name: "item", type: xsd_type })
                     end
                   end
                 end
@@ -490,7 +554,7 @@ target_prefix: nil)
                 # Simple element
                 element_attrs = build_element_attributes(name, xsd_type, attr,
                                                          xml_mapping, name)
-                xml.public_send(qn("element"), element_attrs)
+                xs(xml, "element", element_attrs)
               end
             end
           end
@@ -511,13 +575,13 @@ target_prefix: nil)
             attr_attrs[:form] = rule.form.to_s if rule.form
 
             if rule.documentation
-              xml.public_send(qn("attribute"), attr_attrs) do
-                xml.public_send(qn("annotation")) do
-                  xml.public_send(qn("documentation"), rule.documentation)
+              xs(xml, "attribute", attr_attrs) do
+                xs(xml, "annotation") do
+                  xs(xml, "documentation", rule.documentation)
                 end
               end
             else
-              xml.public_send(qn("attribute"), attr_attrs)
+              xs(xml, "attribute", attr_attrs)
             end
           end
         end
@@ -580,35 +644,47 @@ _mapping_rule = nil)
           get_xsd_type(attr_type)
         end
 
-        # Collect every distinct XmlNamespace class used anywhere in the model
-        # tree: the model's own namespace and nested Serializable models'
-        # namespaces (recursively). Type::Value type namespaces are intentionally
-        # NOT collected (see the note inside). Deduped by class (the atomic unit).
-        # A class-level structural walk — needs no instance.
-        def self.collect_namespace_classes(klass, register, seen = Set.new)
-          return [] unless klass.is_a?(::Class) && seen.add?(klass)
-
-          classes = []
-          own = get_namespace_info(klass)[:class]
-          classes << own if own
+        # Namespaces referenced by THIS schema document, collected by walking
+        # the model tree from the root class (structural, no instance needed).
+        # The walk stops at foreign-model boundaries: a foreign model's type is
+        # imported — defined in its own schema document — so namespaces used
+        # only inside it are that document's concern, not this one's.
+        #
+        # @return [Hash] :foreign_models — namespace classes of directly
+        #   referenced foreign models (their type refs are prefixed QNames
+        #   resolved through an import); :type_values — namespace classes
+        #   declared by Type::Value attribute types (imported so their
+        #   verbatim xsd_type references can resolve). Both deduped by class.
+        def self.referenced_namespaces(klass, register, target_uri,
+seen = Set.new)
+          result = { foreign_models: [], type_values: [] }
+          return result unless klass.is_a?(::Class) && seen.add?(klass)
 
           klass.attributes.each_value do |attr|
             type_class = attr.type(register)
             next unless type_class
 
-            # Only nested Serializable models contribute namespaces here: their
-            # named-type references are prefixed by owning namespace. Type::Value
-            # type namespaces are NOT collected — their xsd_type refs are emitted
-            # verbatim (unprefixed), so importing their namespace would leave an
-            # import the refs never use. (Type::Value namespace support: TODO.)
             if type_class <= Lutaml::Model::Serialize
-              classes.concat(
-                collect_namespace_classes(type_class, register, seen),
-              )
+              mapping = type_class.mappings_for(:xml)
+              if foreign_namespace?(mapping, target_uri)
+                result[:foreign_models] << mapping.namespace_class
+              else
+                nested = referenced_namespaces(type_class, register,
+                                               target_uri, seen)
+                result[:foreign_models].concat(nested[:foreign_models])
+                result[:type_values].concat(nested[:type_values])
+              end
+            else
+              ns = get_namespace_info(type_class)[:class]
+              if ns.is_a?(::Class) && ns < Lutaml::Xml::Namespace
+                result[:type_values] << ns
+              end
             end
           end
 
-          classes.uniq
+          result[:foreign_models].uniq!
+          result[:type_values].uniq!
+          result
         end
 
         # Get unified namespace information from Model or Type class

--- a/lib/lutaml/xml/schema/xsd_schema.rb
+++ b/lib/lutaml/xml/schema/xsd_schema.rb
@@ -333,7 +333,14 @@ target_uri, skip_validation)
             prefix = ns_class.prefix_default
             next unless usable_prefix?(prefix)
 
-            schema_attrs[:"xmlns:#{prefix}"] ||= ns_class.uri
+            # A prefix bound to two different namespaces emits QNames that
+            # resolve to the wrong one — the same unrecoverable collision the
+            # foreign path raises on, so raise here too rather than silently
+            # keeping the first binding.
+            error = prefix_collision_error(prefix, ns_class.uri, schema_attrs)
+            raise Lutaml::Model::Error, error if error
+
+            schema_attrs[:"xmlns:#{prefix}"] = ns_class.uri
           end
         end
 
@@ -347,12 +354,19 @@ target_uri, skip_validation)
                    "be referenced from the '#{target_uri}' schema."
           end
 
+          prefix_collision_error(prefix, ns_class.uri, schema_attrs)
+        end
+
+        # The collision message when +prefix+ is already bound to a different
+        # namespace than +uri+ in +schema_attrs+, or nil when there is no
+        # conflict.
+        def self.prefix_collision_error(prefix, uri, schema_attrs)
           existing = schema_attrs[:"xmlns:#{prefix}"]
-          return unless existing && existing != ns_class.uri
+          return unless existing && existing != uri
 
           "XSD generation: namespace prefix '#{prefix}' is bound " \
-            "to two different namespaces (#{existing} and " \
-            "#{ns_class.uri}). Give them distinct prefixes."
+            "to two different namespaces (#{existing} and #{uri}). " \
+            "Give them distinct prefixes."
         end
 
         def self.missing_schema_location_error(ns_class)
@@ -368,11 +382,7 @@ imported_uris)
             next if ns_class.uri == target_uri
             next unless imported_uris.add?(ns_class.uri)
 
-            import_attrs = { namespace: ns_class.uri }
-            if ns_class.schema_location
-              import_attrs[:schemaLocation] = ns_class.schema_location
-            end
-            xs(xml, "import", import_attrs)
+            emit_import(xml, ns_class)
           end
         end
 
@@ -386,15 +396,20 @@ imported_uris)
           namespace_class.imports.each do |imported_ns|
             next unless imported.add?(imported_ns.uri)
 
-            import_attrs = { namespace: imported_ns.uri }
-            if imported_ns.schema_location
-              import_attrs[:schemaLocation] =
-                imported_ns.schema_location
-            end
-            xs(xml, "import", import_attrs)
+            emit_import(xml, imported_ns)
           end
 
           imported
+        end
+
+        # Emit a single <xs:import> for a namespace class, with schemaLocation
+        # when the class declares one.
+        def self.emit_import(xml, ns_class)
+          import_attrs = { namespace: ns_class.uri }
+          if ns_class.schema_location
+            import_attrs[:schemaLocation] = ns_class.schema_location
+          end
+          xs(xml, "import", import_attrs)
         end
 
         def self.generate_includes(xml, namespace_class)
@@ -423,13 +438,18 @@ seen: nil)
           klass.attributes.each_value do |attr|
             attr_type = attr.type(register)
             next unless attr_type <= Lutaml::Model::Serialize
-            next unless seen.add?(attr_type)
 
             nested_mapping = attr_type.mappings_for(:xml)
 
-            # A foreign model's type is imported from its own schema document;
-            # neither it nor anything inside it is defined here.
-            next if foreign_namespace?(nested_mapping, ctx.target_uri)
+            # Skip models this document does not emit — checked before the cycle
+            # guard so an unemitted reference never consumes the model's slot and
+            # masks an emitted reference elsewhere. A collection of a type_name-
+            # less model is a placeholder; an imported foreign type is defined in
+            # its own schema document. A foreign model without a type_name is
+            # inlined here, so we still descend to define the types it references.
+            next if collection_placeholder?(attr, nested_mapping)
+            next if imported_foreign_type?(nested_mapping, ctx.target_uri)
+            next unless seen.add?(attr_type)
 
             nested_type_name = nested_mapping&.type_name_value
             if nested_type_name
@@ -450,6 +470,27 @@ seen: nil)
           return false unless ns_class
 
           ns_class.uri != target_uri
+        end
+
+        # Whether a nested model is referenced across a schema-document boundary:
+        # it lives in a foreign namespace AND exposes a named type, so it is
+        # referenced by a prefixed QName and resolved through an <xs:import>.
+        # A foreign model WITHOUT a type_name has no named type to reference, so
+        # generate_elements inlines it into this document — it is not a boundary,
+        # and both the namespace walk and the type-definition walk must descend
+        # into it rather than treat it as imported.
+        def self.imported_foreign_type?(mapping, target_uri)
+          foreign_namespace?(mapping, target_uri) &&
+            !mapping.type_name_value.nil?
+        end
+
+        # Whether a nested model is emitted only as a placeholder: a collection
+        # of a type_name-less model renders as `<element name="item"
+        # type="xs:string"/>`, so the model's own content is never inlined or
+        # referenced. This document therefore neither declares its namespaces
+        # nor defines its nested types — the walkers must not descend into it.
+        def self.collection_placeholder?(attr, mapping)
+          attr.collection? && mapping&.type_name_value.nil?
         end
 
         def self.generate_complex_type_content(xml, klass, register,
@@ -666,8 +707,12 @@ seen = Set.new)
 
             if type_class <= Lutaml::Model::Serialize
               mapping = type_class.mappings_for(:xml)
-              if foreign_namespace?(mapping, target_uri)
+              if imported_foreign_type?(mapping, target_uri)
                 result[:foreign_models] << mapping.namespace_class
+              elsif collection_placeholder?(attr, mapping)
+                # Placeholder collection: its content is never emitted, so it
+                # contributes no namespaces to this document.
+                next
               else
                 nested = referenced_namespaces(type_class, register,
                                                target_uri, seen)
@@ -687,17 +732,12 @@ seen = Set.new)
           result
         end
 
-        # Get unified namespace information from Model or Type class
+        # Namespace information for a Type::Value class (the only kind the
+        # namespace walk queries — nested models are handled structurally by
+        # referenced_namespaces). Returns {} for anything else.
         def self.get_namespace_info(klass)
           return {} unless klass.is_a?(::Class)
 
-          # Check for Model class (Serializable)
-          if defined?(Lutaml::Model::Serialize) &&
-              klass <= Lutaml::Model::Serialize
-            return get_model_namespace_info(klass)
-          end
-
-          # Check for Type class (Type::Value)
           if defined?(Lutaml::Model::Type::Value) &&
               klass <= Lutaml::Model::Type::Value
             return get_type_namespace_info(klass)
@@ -708,18 +748,6 @@ seen = Set.new)
 
         class << self
           private
-
-          # Get namespace info from Model class (Serializable)
-          def get_model_namespace_info(klass)
-            mapping = klass.is_a?(Class) && klass.include?(Lutaml::Model::Serialize) ? klass.mappings_for(:xml) : nil
-            return {} unless mapping
-
-            {
-              uri: mapping.namespace_uri,
-              prefix: mapping.namespace_prefix,
-              class: mapping.namespace_class,
-            }
-          end
 
           # Get namespace info from Type class (Type::Value)
           def get_type_namespace_info(klass)

--- a/spec/lutaml/model/schema/xsd_schema_spec.rb
+++ b/spec/lutaml/model/schema/xsd_schema_spec.rb
@@ -469,6 +469,39 @@ RSpec.describe Lutaml::Xml::Schema::XsdSchema do
       expect(xsd).to include('<xs:import namespace="http://w-warn.example/w"/>')
     end
 
+    # Prefix errors emit QNames that resolve to the WRONG namespace, so they
+    # stay hard errors even under skip_validation.
+    it "does not downgrade prefix errors under skip_validation" do
+      no_pfx = Class.new(Lutaml::Xml::W3c::XmlNamespace) do
+        uri "http://p-hard.example" # no prefix_default
+      end
+      ex_ns = Class.new(Lutaml::Xml::W3c::XmlNamespace) do
+        uri "http://ex.example/ex"
+        prefix_default "ex"
+      end
+      child = Class.new(Lutaml::Model::Serializable) do
+        attribute :v, :string
+        xml do
+          root "child"
+          namespace no_pfx
+          type_name "PType"
+          map_element "v", to: :v
+        end
+      end
+      parent = Class.new(Lutaml::Model::Serializable) do
+        attribute :child, child
+        xml do
+          root "parent"
+          namespace ex_ns
+          map_element "child", to: :child
+        end
+      end
+
+      expect do
+        Lutaml::Model::Schema.to_xsd(parent, skip_validation: true)
+      end.to raise_error(Lutaml::Model::Error, /usable prefix/)
+    end
+
     # A Type::Value attribute type that declares its own namespace resolves
     # through that namespace's imported schema.
     it "declares and imports a Type::Value attribute type's namespace" do

--- a/spec/lutaml/model/schema/xsd_schema_spec.rb
+++ b/spec/lutaml/model/schema/xsd_schema_spec.rb
@@ -783,5 +783,33 @@ RSpec.describe Lutaml::Xml::Schema::XsdSchema do
         expect { Nokogiri::XML::Schema(xsd) }.not_to raise_error
       end
     end
+
+    # When the root schema has no targetNamespace, the foreign-prefix error must
+    # not interpolate a nil target into a confusing "'' schema" string.
+    it "reports the no-namespace schema clearly in the foreign-prefix error" do
+      foreign_ns = Class.new(Lutaml::Xml::W3c::XmlNamespace) do
+        uri "http://foreign.example/f"
+        prefix_default "xs" # reserved -> unusable prefix, triggers the error
+      end
+      child = Class.new(Lutaml::Model::Serializable) do
+        attribute :v, :string
+        xml do
+          root "child"
+          namespace foreign_ns
+          type_name "ChildType"
+          map_element "v", to: :v
+        end
+      end
+      root = Class.new(Lutaml::Model::Serializable) do
+        attribute :child, child
+        xml do
+          root "root" # no namespace -> target_uri is nil
+          map_element "child", to: :child
+        end
+      end
+
+      expect { Lutaml::Model::Schema.to_xsd(root) }
+        .to raise_error(Lutaml::Model::Error, /this no-namespace schema/)
+    end
   end
 end

--- a/spec/lutaml/model/schema/xsd_schema_spec.rb
+++ b/spec/lutaml/model/schema/xsd_schema_spec.rb
@@ -1,5 +1,6 @@
 require "spec_helper"
 require "lutaml/model/schema"
+require "nokogiri"
 
 module SchemaGeneration
   class Glaze < Lutaml::Model::Serializable
@@ -22,34 +23,168 @@ RSpec.describe Lutaml::Xml::Schema::XsdSchema do
 
       expected_schema = <<~XSD
         <?xml version="1.0" encoding="UTF-8"?>
-        <schema xmlns="http://www.w3.org/2001/XMLSchema">
-          <element name="SchemaGeneration::Vase">
-            <complexType>
-              <sequence>
-                <element name="height" type="xs:float"/>
-                <element name="diameter" type="xs:float"/>
-                <element name="glaze">
-                  <complexType>
-                    <sequence>
-                      <element name="color" type="xs:string"/>
-                      <element name="finish" type="xs:string"/>
-                    </sequence>
-                  </complexType>
-                </element>
-                <element name="materials" minOccurs="0" maxOccurs="unbounded">
-                  <complexType>
-                    <sequence>
-                      <element name="item" type="xs:string"/>
-                    </sequence>
-                  </complexType>
-                </element>
-              </sequence>
-            </complexType>
-          </element>
-        </schema>
+        <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+          <xs:element name="SchemaGeneration::Vase">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="height" type="xs:float"/>
+                <xs:element name="diameter" type="xs:float"/>
+                <xs:element name="glaze">
+                  <xs:complexType>
+                    <xs:sequence>
+                      <xs:element name="color" type="xs:string"/>
+                      <xs:element name="finish" type="xs:string"/>
+                    </xs:sequence>
+                  </xs:complexType>
+                </xs:element>
+                <xs:element name="materials" minOccurs="0" maxOccurs="unbounded">
+                  <xs:complexType>
+                    <xs:sequence>
+                      <xs:element name="item" type="xs:string"/>
+                    </xs:sequence>
+                  </xs:complexType>
+                </xs:element>
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+        </xs:schema>
       XSD
 
       expect(schema).to eq(expected_schema)
+    end
+  end
+
+  # Regression guard for issue #717: the generated XSD bound the XSD namespace
+  # only as the default xmlns while referencing built-in types with an
+  # undeclared "xs:" prefix, so no XSD processor could load the output.
+  describe "generated XSD validity (issue #717)" do
+    it "produces a schema Nokogiri can load (no target namespace)" do
+      klass = Class.new(Lutaml::Model::Serializable) do
+        attribute :id, :string
+        xml do
+          root "address"
+          map_element "id", to: :id
+        end
+      end
+
+      xsd = Lutaml::Model::Schema.to_xsd(klass)
+
+      expect(xsd).to include('<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"')
+      expect(xsd).to include('type="xs:string"')
+      expect { Nokogiri::XML::Schema(xsd) }.not_to raise_error
+    end
+
+    it "produces a schema Nokogiri can load (with target namespace)" do
+      ns = Class.new(Lutaml::Xml::W3c::XmlNamespace) do
+        uri "http://example.com/addr"
+        prefix_default "ex"
+        element_form_default :qualified
+      end
+      klass = Class.new(Lutaml::Model::Serializable) do
+        attribute :street, :string
+        xml do
+          root "address"
+          namespace ns
+          map_element "street", to: :street
+        end
+      end
+
+      xsd = Lutaml::Model::Schema.to_xsd(klass)
+
+      expect(xsd).to include('xmlns:xs="http://www.w3.org/2001/XMLSchema"')
+      expect(xsd).to include('targetNamespace="http://example.com/addr"')
+      expect { Nokogiri::XML::Schema(xsd) }.not_to raise_error
+    end
+
+    # The hole #717 fell through: a nested named-type reference under a target
+    # namespace must be prefixed, or it resolves to no-namespace and fails.
+    it "qualifies named-type references under a target namespace" do
+      ns = Class.new(Lutaml::Xml::W3c::XmlNamespace) do
+        uri "http://example.com/addr"
+        prefix_default "ex"
+        element_form_default :qualified
+      end
+      widget = Class.new(Lutaml::Model::Serializable) do
+        attribute :label, :string
+        xml do
+          root "widget"
+          type_name "WidgetType"
+          map_element "label", to: :label
+        end
+      end
+      doc = Class.new(Lutaml::Model::Serializable) do
+        attribute :widget, widget
+        attribute :title, :string
+        xml do
+          root "doc"
+          namespace ns
+          map_element "widget", to: :widget
+          map_element "title", to: :title
+        end
+      end
+
+      xsd = Lutaml::Model::Schema.to_xsd(doc)
+
+      expect(xsd).to include('xmlns:ex="http://example.com/addr"')
+      expect(xsd).to include('type="ex:WidgetType"')
+      expect(xsd).to include('<xs:complexType name="WidgetType">')
+      expect(xsd).not_to include("<xs:import")
+      expect { Nokogiri::XML::Schema(xsd) }.not_to raise_error
+    end
+
+    # Guard against over-eager prefixing: with no namespace, named-type refs
+    # must stay unqualified (they resolve to no-namespace, which is valid).
+    it "leaves named-type references unqualified when there is no namespace" do
+      inner = Class.new(Lutaml::Model::Serializable) do
+        attribute :city, :string
+        xml do
+          root "address"
+          type_name "AddressType"
+          map_element "city", to: :city
+        end
+      end
+      outer = Class.new(Lutaml::Model::Serializable) do
+        attribute :address, inner
+        xml do
+          root "person"
+          map_element "address", to: :address
+        end
+      end
+
+      xsd = Lutaml::Model::Schema.to_xsd(outer)
+
+      expect(xsd).to include('type="AddressType"')
+      expect(xsd).not_to include('type=":AddressType"')
+      expect { Nokogiri::XML::Schema(xsd) }.not_to raise_error
+    end
+
+    it "qualifies named-type references for collections under a target namespace" do
+      ns = Class.new(Lutaml::Xml::W3c::XmlNamespace) do
+        uri "http://example.com/addr"
+        prefix_default "ex"
+        element_form_default :qualified
+      end
+      item = Class.new(Lutaml::Model::Serializable) do
+        attribute :label, :string
+        xml do
+          root "item"
+          type_name "ItemType"
+          map_element "label", to: :label
+        end
+      end
+      doc = Class.new(Lutaml::Model::Serializable) do
+        attribute :items, item, collection: true
+        xml do
+          root "doc"
+          namespace ns
+          map_element "item", to: :items
+        end
+      end
+
+      xsd = Lutaml::Model::Schema.to_xsd(doc)
+
+      expect(xsd).to include('type="ex:ItemType"')
+      expect { Nokogiri::XML::Schema(xsd) }.not_to raise_error
     end
   end
 end

--- a/spec/lutaml/model/schema/xsd_schema_spec.rb
+++ b/spec/lutaml/model/schema/xsd_schema_spec.rb
@@ -186,5 +186,169 @@ RSpec.describe Lutaml::Xml::Schema::XsdSchema do
       expect(xsd).to include('type="ex:ItemType"')
       expect { Nokogiri::XML::Schema(xsd) }.not_to raise_error
     end
+
+    # A nested model in its OWN (different) namespace is imported and referenced
+    # by its own prefix, NOT folded into the root namespace. (A schema document
+    # has a single targetNamespace, so its type lives in its own schema.)
+    it "imports and prefixes a nested model that declares a different namespace" do
+      w_ns = Class.new(Lutaml::Xml::W3c::XmlNamespace) do
+        uri "http://w.example/w"
+        prefix_default "w"
+        element_form_default :qualified
+        schema_location "widget.xsd"
+      end
+      ex_ns = Class.new(Lutaml::Xml::W3c::XmlNamespace) do
+        uri "http://ex.example/ex"
+        prefix_default "ex"
+        element_form_default :qualified
+      end
+      widget = Class.new(Lutaml::Model::Serializable) do
+        attribute :label, :string
+        xml do
+          root "widget"
+          namespace w_ns
+          type_name "WidgetType"
+          map_element "label", to: :label
+        end
+      end
+      doc = Class.new(Lutaml::Model::Serializable) do
+        attribute :widget, widget
+        xml do
+          root "doc"
+          namespace ex_ns
+          map_element "widget", to: :widget
+        end
+      end
+
+      xsd = Lutaml::Model::Schema.to_xsd(doc)
+
+      # both namespaces declared, foreign one imported, ref uses its own prefix
+      expect(xsd).to include('xmlns:w="http://w.example/w"')
+      expect(xsd).to include('targetNamespace="http://ex.example/ex"')
+      expect(xsd).to include('<xs:import namespace="http://w.example/w" schemaLocation="widget.xsd"/>')
+      expect(xsd).to include('type="w:WidgetType"')
+      # the foreign type is NOT defined in this document
+      expect(xsd).not_to include('<xs:complexType name="WidgetType">')
+    end
+
+    # A target namespace whose class declares no prefix_default still needs a
+    # usable prefix for named-type QNames; one is synthesised (tns).
+    it "synthesises a prefix for a target namespace with no prefix_default" do
+      ns = Class.new(Lutaml::Xml::W3c::XmlNamespace) do
+        uri "http://example.com/np"
+        element_form_default :qualified
+      end
+      klass = Class.new(Lutaml::Model::Serializable) do
+        attribute :id, :string
+        xml do
+          root "root"
+          namespace ns
+          type_name "RootType"
+          map_element "id", to: :id
+        end
+      end
+
+      xsd = Lutaml::Model::Schema.to_xsd(klass)
+
+      expect(xsd).to include('xmlns:tns="http://example.com/np"')
+      expect(xsd).to include('type="tns:RootType"')
+      expect { Nokogiri::XML::Schema(xsd) }.not_to raise_error
+    end
+
+    # Two different namespaces bound to the same prefix are unresolvable; the
+    # generator raises rather than emit a silently-wrong QName.
+    it "raises when two namespaces share a prefix" do
+      a_ns = Class.new(Lutaml::Xml::W3c::XmlNamespace) do
+        uri "http://a.example"
+        prefix_default "p"
+      end
+      b_ns = Class.new(Lutaml::Xml::W3c::XmlNamespace) do
+        uri "http://b.example"
+        prefix_default "p"
+      end
+      child = Class.new(Lutaml::Model::Serializable) do
+        attribute :v, :string
+        xml do
+          root "child"
+          namespace b_ns
+          type_name "BType"
+          map_element "v", to: :v
+        end
+      end
+      parent = Class.new(Lutaml::Model::Serializable) do
+        attribute :child, child
+        xml do
+          root "parent"
+          namespace a_ns
+          map_element "child", to: :child
+        end
+      end
+
+      expect { Lutaml::Model::Schema.to_xsd(parent) }
+        .to raise_error(Lutaml::Model::Error, /prefix 'p' is bound to two/)
+    end
+
+    # A recursive model (A -> B -> A) must terminate and define both types.
+    it "handles recursive model references without overflowing" do
+      rec_a = Class.new(Lutaml::Model::Serializable)
+      rec_b = Class.new(Lutaml::Model::Serializable) do
+        attribute :a, rec_a
+        xml do
+          root "b"
+          type_name "BType"
+          map_element "a", to: :a
+        end
+      end
+      rec_a.class_eval do
+        attribute :b, rec_b
+        xml do
+          root "a"
+          type_name "AType"
+          map_element "b", to: :b
+        end
+      end
+
+      xsd = nil
+      expect { xsd = Lutaml::Model::Schema.to_xsd(rec_a) }.not_to raise_error
+      expect(xsd).to include('<xs:complexType name="AType">')
+      expect(xsd).to include('<xs:complexType name="BType">')
+    end
+
+    # A foreign namespace with no usable prefix (nil, empty, or the reserved
+    # "xs") cannot be referenced by a prefixed QName and must not borrow the
+    # target prefix — raise instead.
+    [nil, "", "xs"].each do |bad_prefix|
+      it "raises for a foreign namespace with unusable prefix #{bad_prefix.inspect}" do
+        foreign = Class.new(Lutaml::Xml::W3c::XmlNamespace) do
+          uri "http://foreign.example"
+          prefix_default bad_prefix unless bad_prefix.nil?
+          element_form_default :qualified
+        end
+        ex_ns = Class.new(Lutaml::Xml::W3c::XmlNamespace) do
+          uri "http://ex.example/ex"
+          prefix_default "ex"
+        end
+        child = Class.new(Lutaml::Model::Serializable) do
+          attribute :v, :string
+          xml do
+            root "child"
+            namespace foreign
+            type_name "ForeignType"
+            map_element "v", to: :v
+          end
+        end
+        parent = Class.new(Lutaml::Model::Serializable) do
+          attribute :child, child
+          xml do
+            root "parent"
+            namespace ex_ns
+            map_element "child", to: :child
+          end
+        end
+
+        expect { Lutaml::Model::Schema.to_xsd(parent) }
+          .to raise_error(Lutaml::Model::Error, /foreign namespace .* usable prefix/)
+      end
+    end
   end
 end

--- a/spec/lutaml/model/schema/xsd_schema_spec.rb
+++ b/spec/lutaml/model/schema/xsd_schema_spec.rb
@@ -568,5 +568,220 @@ RSpec.describe Lutaml::Xml::Schema::XsdSchema do
       expect(xsd).to include('type="tns1:DocType"')
       expect(xsd).to include('type="tns:TType"')
     end
+
+    # A foreign-namespaced nested model with NO type_name is inlined into this
+    # document (like a same-namespace model), not imported — so its namespace
+    # must not trigger the foreign-import schema_location requirement. The
+    # namespace walk and the element walk must agree that it is not a boundary.
+    it "does not require schema_location for an inlined (type_name-less) foreign model" do
+      inner_ns = Class.new(Lutaml::Xml::W3c::XmlNamespace) do
+        uri "http://inner.example/in"
+        prefix_default "in" # no schema_location, no type_name below
+      end
+      outer_ns = Class.new(Lutaml::Xml::W3c::XmlNamespace) do
+        uri "http://outer.example/out"
+        prefix_default "out"
+      end
+      inner = Class.new(Lutaml::Model::Serializable) do
+        attribute :label, :string
+        xml do
+          root "inner"
+          namespace inner_ns
+          map_element "label", to: :label
+        end
+      end
+      outer = Class.new(Lutaml::Model::Serializable) do
+        attribute :inner, inner
+        xml do
+          root "outer"
+          namespace outer_ns
+          map_element "inner", to: :inner
+        end
+      end
+
+      xsd = Lutaml::Model::Schema.to_xsd(outer)
+
+      # Inlined, not imported: its content appears here, no <xs:import> for it.
+      expect(xsd).to include('name="label"')
+      expect(xsd).not_to include("http://inner.example/in")
+    end
+
+    it "does not emit a spurious import for an inlined foreign model with a schema_location" do
+      inner_ns = Class.new(Lutaml::Xml::W3c::XmlNamespace) do
+        uri "http://inner2.example/in"
+        prefix_default "in"
+        schema_location "inner.xsd" # present, but model has no type_name
+      end
+      outer_ns = Class.new(Lutaml::Xml::W3c::XmlNamespace) do
+        uri "http://outer2.example/out"
+        prefix_default "out"
+      end
+      inner = Class.new(Lutaml::Model::Serializable) do
+        attribute :label, :string
+        xml do
+          root "inner"
+          namespace inner_ns
+          map_element "label", to: :label
+        end
+      end
+      outer = Class.new(Lutaml::Model::Serializable) do
+        attribute :inner, inner
+        xml do
+          root "outer"
+          namespace outer_ns
+          map_element "inner", to: :inner
+        end
+      end
+
+      xsd = Lutaml::Model::Schema.to_xsd(outer)
+
+      expect(xsd).to include('name="label"')
+      expect(xsd).not_to include("<xs:import")
+    end
+
+    # A prefix bound to two different namespaces — a foreign model vs a
+    # Type::Value type sharing a prefix_default — is unresolvable and must
+    # raise, not silently keep the first binding.
+    it "raises when a foreign model and a Type::Value share a prefix for different namespaces" do
+      model_ns = Class.new(Lutaml::Xml::W3c::XmlNamespace) do
+        uri "http://model.example/gml"
+        prefix_default "gml"
+        schema_location "model.xsd"
+      end
+      type_ns = Class.new(Lutaml::Xml::W3c::XmlNamespace) do
+        uri "http://type.example/gml"
+        prefix_default "gml"
+        schema_location "type.xsd"
+      end
+      measure = Class.new(Lutaml::Model::Type::String) do
+        xml { namespace type_ns }
+        xsd_type "gml:MeasureType"
+      end
+      widget = Class.new(Lutaml::Model::Serializable) do
+        attribute :label, :string
+        xml do
+          root "widget"
+          namespace model_ns
+          type_name "WidgetType"
+          map_element "label", to: :label
+        end
+      end
+      target_ns = Class.new(Lutaml::Xml::W3c::XmlNamespace) do
+        uri "http://doc.example/doc"
+        prefix_default "doc"
+      end
+      doc = Class.new(Lutaml::Model::Serializable) do
+        attribute :size, measure
+        attribute :widget, widget
+        xml do
+          root "doc"
+          namespace target_ns
+          map_element "size", to: :size
+          map_element "widget", to: :widget
+        end
+      end
+
+      # Raises even under skip_validation — a wrong-namespace QName is never
+      # recoverable, matching the foreign prefix-collision behavior.
+      expect do
+        Lutaml::Model::Schema.to_xsd(doc, skip_validation: true)
+      end.to raise_error(Lutaml::Model::Error, /two different namespaces/)
+    end
+
+    # A collection of a type_name-less model renders as a placeholder `item`
+    # element, so nothing inside it is emitted — the namespace walk must not
+    # descend into it and import a foreign type the schema never references.
+    it "does not import namespaces reachable only through a placeholder collection" do
+      child_ns = Class.new(Lutaml::Xml::W3c::XmlNamespace) do
+        uri "http://child.example/ch"
+        prefix_default "ch" # foreign + type_name + NO schema_location
+      end
+      inner_ns = Class.new(Lutaml::Xml::W3c::XmlNamespace) do
+        uri "http://binner.example/b"
+        prefix_default "bin"
+      end
+      child = Class.new(Lutaml::Model::Serializable) do
+        attribute :v, :string
+        xml do
+          root "child"
+          namespace child_ns
+          type_name "ChildType"
+          map_element "v", to: :v
+        end
+      end
+      inner = Class.new(Lutaml::Model::Serializable) do
+        attribute :child, child
+        xml do
+          root "inner"
+          namespace inner_ns
+          map_element "child", to: :child
+        end
+      end
+      root_ns = Class.new(Lutaml::Xml::W3c::XmlNamespace) do
+        uri "http://root.example/r"
+        prefix_default "r"
+      end
+      root = Class.new(Lutaml::Model::Serializable) do
+        attribute :inners, inner, collection: true
+        xml do
+          root "root"
+          namespace root_ns
+          map_element "inner", to: :inners
+        end
+      end
+
+      xsd = Lutaml::Model::Schema.to_xsd(root)
+
+      # No spurious import/raise for the foreign child reachable only through
+      # the placeholder collection.
+      expect(xsd).not_to include("http://child.example/ch")
+      expect(xsd).not_to include("http://binner.example/b")
+    end
+
+    # Locks the deliberate skip-before-cycle-guard ordering: a model referenced
+    # BOTH as a placeholder collection and as a single inlined attribute must
+    # still be inlined via the single path — the placeholder reference must not
+    # consume the model's cycle-guard slot and mask the emitted one. Regardless
+    # of attribute order, the inlined model's nested named type stays defined.
+    %i[collection_first single_first].each do |order|
+      it "defines a nested type of a model also referenced as a placeholder collection (#{order})" do
+        child = Class.new(Lutaml::Model::Serializable) do
+          attribute :v, :string
+          xml do
+            root "child"
+            type_name "CType"
+            map_element "v", to: :v
+          end
+        end
+        mid = Class.new(Lutaml::Model::Serializable) do
+          attribute :child, child
+          xml do
+            root "mid"
+            map_element "child", to: :child
+          end
+        end
+        root = Class.new(Lutaml::Model::Serializable) do
+          if order == :collection_first
+            attribute :many, mid, collection: true
+            attribute :one, mid
+          else
+            attribute :one, mid
+            attribute :many, mid, collection: true
+          end
+          xml do
+            root "root"
+            map_element "many", to: :many
+            map_element "one", to: :one
+          end
+        end
+
+        xsd = Lutaml::Model::Schema.to_xsd(root)
+
+        # The single-inline path references CType, so CType must be defined —
+        # even when the placeholder collection references `mid` first.
+        expect(xsd).to include('<xs:complexType name="CType">')
+        expect { Nokogiri::XML::Schema(xsd) }.not_to raise_error
+      end
+    end
   end
 end

--- a/spec/lutaml/model/schema/xsd_schema_spec.rb
+++ b/spec/lutaml/model/schema/xsd_schema_spec.rb
@@ -350,5 +350,190 @@ RSpec.describe Lutaml::Xml::Schema::XsdSchema do
           .to raise_error(Lutaml::Model::Error, /foreign namespace .* usable prefix/)
       end
     end
+
+    # Namespaces used only INSIDE an imported foreign type belong to that
+    # type's own schema document — they must not be declared, imported, or
+    # validated here.
+    it "ignores namespaces nested inside an imported foreign subtree" do
+      inner_ns = Class.new(Lutaml::Xml::W3c::XmlNamespace) do
+        uri "http://c.example" # deliberately no prefix_default
+      end
+      w_ns = Class.new(Lutaml::Xml::W3c::XmlNamespace) do
+        uri "http://w.example/w"
+        prefix_default "w"
+        schema_location "widget.xsd"
+      end
+      ex_ns = Class.new(Lutaml::Xml::W3c::XmlNamespace) do
+        uri "http://ex.example/ex"
+        prefix_default "ex"
+      end
+      inner = Class.new(Lutaml::Model::Serializable) do
+        attribute :v, :string
+        xml do
+          root "inner"
+          namespace inner_ns
+          type_name "InnerType"
+          map_element "v", to: :v
+        end
+      end
+      widget = Class.new(Lutaml::Model::Serializable) do
+        attribute :inner, inner
+        xml do
+          root "widget"
+          namespace w_ns
+          type_name "WidgetType"
+          map_element "inner", to: :inner
+        end
+      end
+      doc = Class.new(Lutaml::Model::Serializable) do
+        attribute :widget, widget
+        xml do
+          root "doc"
+          namespace ex_ns
+          map_element "widget", to: :widget
+        end
+      end
+
+      xsd = Lutaml::Model::Schema.to_xsd(doc)
+
+      expect(xsd).to include('type="w:WidgetType"')
+      expect(xsd).not_to include("http://c.example")
+    end
+
+    it "raises when a foreign namespace has no schema_location" do
+      w_ns = Class.new(Lutaml::Xml::W3c::XmlNamespace) do
+        uri "http://w-noloc.example/w"
+        prefix_default "w" # no schema_location
+      end
+      ex_ns = Class.new(Lutaml::Xml::W3c::XmlNamespace) do
+        uri "http://ex.example/ex"
+        prefix_default "ex"
+      end
+      widget = Class.new(Lutaml::Model::Serializable) do
+        attribute :label, :string
+        xml do
+          root "widget"
+          namespace w_ns
+          type_name "WidgetType"
+          map_element "label", to: :label
+        end
+      end
+      doc = Class.new(Lutaml::Model::Serializable) do
+        attribute :widget, widget
+        xml do
+          root "doc"
+          namespace ex_ns
+          map_element "widget", to: :widget
+        end
+      end
+
+      expect { Lutaml::Model::Schema.to_xsd(doc) }
+        .to raise_error(Lutaml::Model::Error, /schema_location/)
+    end
+
+    it "downgrades foreign-namespace errors to warnings under skip_validation" do
+      w_ns = Class.new(Lutaml::Xml::W3c::XmlNamespace) do
+        uri "http://w-warn.example/w"
+        prefix_default "w" # no schema_location -> error without skip_validation
+      end
+      ex_ns = Class.new(Lutaml::Xml::W3c::XmlNamespace) do
+        uri "http://ex.example/ex"
+        prefix_default "ex"
+      end
+      widget = Class.new(Lutaml::Model::Serializable) do
+        attribute :label, :string
+        xml do
+          root "widget"
+          namespace w_ns
+          type_name "WidgetType"
+          map_element "label", to: :label
+        end
+      end
+      doc = Class.new(Lutaml::Model::Serializable) do
+        attribute :widget, widget
+        xml do
+          root "doc"
+          namespace ex_ns
+          map_element "widget", to: :widget
+        end
+      end
+
+      xsd = nil
+      expect { xsd = Lutaml::Model::Schema.to_xsd(doc, skip_validation: true) }
+        .to output(/schema_location/).to_stderr
+
+      # Best-effort output still declares the usable prefix its QNames use,
+      # and imports the namespace (location-less).
+      expect(xsd).to include('xmlns:w="http://w-warn.example/w"')
+      expect(xsd).to include('type="w:WidgetType"')
+      expect(xsd).to include('<xs:import namespace="http://w-warn.example/w"/>')
+    end
+
+    # A Type::Value attribute type that declares its own namespace resolves
+    # through that namespace's imported schema.
+    it "declares and imports a Type::Value attribute type's namespace" do
+      gml_ns = Class.new(Lutaml::Xml::W3c::XmlNamespace) do
+        uri "http://www.opengis.net/gml"
+        prefix_default "gml"
+        schema_location "gml.xsd"
+      end
+      measure = Class.new(Lutaml::Model::Type::String) do
+        xml { namespace gml_ns }
+        xsd_type "gml:MeasureType"
+      end
+      doc = Class.new(Lutaml::Model::Serializable) do
+        attribute :measure, measure
+        xml do
+          root "doc"
+          map_element "measure", to: :measure
+        end
+      end
+
+      # skip_validation matches main's behavior for namespaced custom types;
+      # accepting them in validation is a deferred follow-up.
+      xsd = Lutaml::Model::Schema.to_xsd(doc, skip_validation: true)
+
+      expect(xsd).to include('xmlns:gml="http://www.opengis.net/gml"')
+      expect(xsd).to include('<xs:import namespace="http://www.opengis.net/gml" schemaLocation="gml.xsd"/>')
+      expect(xsd).to include('type="gml:MeasureType"')
+    end
+
+    it "synthesizes a non-colliding prefix when a foreign namespace claims tns" do
+      no_pfx_target = Class.new(Lutaml::Xml::W3c::XmlNamespace) do
+        uri "http://example.com/np" # no prefix_default -> synthesized
+      end
+      tns_ns = Class.new(Lutaml::Xml::W3c::XmlNamespace) do
+        uri "http://t.example"
+        prefix_default "tns"
+        schema_location "t.xsd"
+      end
+      child = Class.new(Lutaml::Model::Serializable) do
+        attribute :v, :string
+        xml do
+          root "child"
+          namespace tns_ns
+          type_name "TType"
+          map_element "v", to: :v
+        end
+      end
+      doc = Class.new(Lutaml::Model::Serializable) do
+        attribute :child, child
+        attribute :id, :string
+        xml do
+          root "doc"
+          namespace no_pfx_target
+          type_name "DocType"
+          map_element "child", to: :child
+          map_element "id", to: :id
+        end
+      end
+
+      xsd = Lutaml::Model::Schema.to_xsd(doc)
+
+      expect(xsd).to include('xmlns:tns="http://t.example"')
+      expect(xsd).to include('xmlns:tns1="http://example.com/np"')
+      expect(xsd).to include('type="tns1:DocType"')
+      expect(xsd).to include('type="tns:TType"')
+    end
   end
 end

--- a/spec/lutaml/model/xsd_form_default_patterns_spec.rb
+++ b/spec/lutaml/model/xsd_form_default_patterns_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "XSD Form Default Patterns" do
   #
   # Valid instance:
   # <ex:elementFormUnqualified>
-  #     <xs:element>string</xs:element>
+  #     <element>string</element>
   # </ex:elementFormUnqualified>
   describe "ElementFormUnqualified pattern" do
     context "when elementFormDefault is unqualified (default)" do

--- a/spec/lutaml/model/xsd_form_default_patterns_spec.rb
+++ b/spec/lutaml/model/xsd_form_default_patterns_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "XSD Form Default Patterns" do
   #
   # Valid instance:
   # <ex:elementFormUnqualified>
-  #     <element>string</element>
+  #     <xs:element>string</xs:element>
   # </ex:elementFormUnqualified>
   describe "ElementFormUnqualified pattern" do
     context "when elementFormDefault is unqualified (default)" do
@@ -66,7 +66,7 @@ RSpec.describe "XSD Form Default Patterns" do
         xsd = Lutaml::Model::Schema.to_xsd(model_class)
 
         # Per XSD spec, form attribute should NOT be emitted when it matches the default
-        expect(xsd).to include('<element name="premium" type="xs:string"/>')
+        expect(xsd).to include('<xs:element name="premium" type="xs:string"/>')
         expect(xsd).not_to include('form="unqualified"')
       end
 
@@ -125,7 +125,7 @@ RSpec.describe "XSD Form Default Patterns" do
 
         # Per XSD spec, form="unqualified" MUST be emitted when it differs from elementFormDefault
         expect(xsd).to include('form="unqualified"')
-        expect(xsd).to include('<element name="element" type="xs:string" form="unqualified"/>')
+        expect(xsd).to include('<xs:element name="element" type="xs:string" form="unqualified"/>')
       end
 
       it "serializes element without namespace prefix (as declared)" do
@@ -174,8 +174,8 @@ RSpec.describe "XSD Form Default Patterns" do
         xsd = Lutaml::Model::Schema.to_xsd(model_class)
 
         # Per XSD spec, form attribute should NOT be emitted when it matches elementFormDefault
-        expect(xsd).to include('<element name="name" type="xs:string"/>')
-        expect(xsd).to include('<element name="value" type="xs:string"/>')
+        expect(xsd).to include('<xs:element name="name" type="xs:string"/>')
+        expect(xsd).to include('<xs:element name="value" type="xs:string"/>')
         expect(xsd).not_to include('form="qualified"')
       end
 
@@ -364,7 +364,7 @@ RSpec.describe "XSD Form Default Patterns" do
         xsd = Lutaml::Model::Schema.to_xsd(model_class)
 
         # Per XSD spec, form attribute should NOT be emitted when it matches the default
-        expect(xsd).to include('<attribute name="id" type="xs:string"/>')
+        expect(xsd).to include('<xs:attribute name="id" type="xs:string"/>')
         expect(xsd).not_to include('form="unqualified"')
       end
 
@@ -414,7 +414,7 @@ RSpec.describe "XSD Form Default Patterns" do
 
         # Per XSD spec, form="unqualified" MUST be emitted when it differs from attributeFormDefault
         expect(xsd).to include('form="unqualified"')
-        expect(xsd).to include('<attribute name="id" type="xs:string" form="unqualified"/>')
+        expect(xsd).to include('<xs:attribute name="id" type="xs:string" form="unqualified"/>')
       end
 
       # NOTE: The following test documents a known issue where form: :unqualified
@@ -479,8 +479,8 @@ RSpec.describe "XSD Form Default Patterns" do
         xsd = Lutaml::Model::Schema.to_xsd(model_class)
 
         # Per XSD spec, form attribute should NOT be emitted when it matches attributeFormDefault
-        expect(xsd).to include('<attribute name="id" type="xs:string"/>')
-        expect(xsd).to include('<attribute name="type" type="xs:string"/>')
+        expect(xsd).to include('<xs:attribute name="id" type="xs:string"/>')
+        expect(xsd).to include('<xs:attribute name="type" type="xs:string"/>')
         expect(xsd).not_to include('form="qualified"')
       end
 
@@ -535,13 +535,13 @@ RSpec.describe "XSD Form Default Patterns" do
     it "emits form='unqualified' on element that differs from default" do
       xsd = Lutaml::Model::Schema.to_xsd(model_class)
 
-      expect(xsd).to include('<element name="element_content" type="xs:string" form="unqualified"/>')
+      expect(xsd).to include('<xs:element name="element_content" type="xs:string" form="unqualified"/>')
     end
 
     it "emits form='unqualified' on attribute that differs from default" do
       xsd = Lutaml::Model::Schema.to_xsd(model_class)
 
-      expect(xsd).to include('<attribute name="id" type="xs:string" form="unqualified"/>')
+      expect(xsd).to include('<xs:attribute name="id" type="xs:string" form="unqualified"/>')
     end
 
     it "serializes element without namespace prefix" do
@@ -596,7 +596,7 @@ RSpec.describe "XSD Form Default Patterns" do
         expect(xsd).to include('elementFormDefault="qualified"')
 
         # Elements should be declared WITHOUT form attribute (matches default)
-        expect(xsd).to include('<element name="premium" type="xs:string"/>')
+        expect(xsd).to include('<xs:element name="premium" type="xs:string"/>')
 
         # Instance should use prefixed elements when prefix: true is specified
         instance = model_class.new(premium: "100")
@@ -644,7 +644,7 @@ RSpec.describe "XSD Form Default Patterns" do
         expect(xsd).to include('attributeFormDefault="qualified"')
 
         # Attributes should be declared WITHOUT form attribute (matches default)
-        expect(xsd).to include('<attribute name="id" type="xs:string"/>')
+        expect(xsd).to include('<xs:attribute name="id" type="xs:string"/>')
 
         # Instance should use prefixed attributes
         instance = model_class.new(id: "abc")

--- a/spec/lutaml/model/xsd_patterns_spec.rb
+++ b/spec/lutaml/model/xsd_patterns_spec.rb
@@ -20,11 +20,11 @@ RSpec.describe "XSD Three Pattern Architecture" do
       xsd = Lutaml::Model::Schema.to_xsd(klass)
 
       # Should generate inline complexType
-      expect(xsd).to include('<element name="product">')
-      expect(xsd).to include("<complexType>")
-      expect(xsd).not_to include("<complexType name=")
-      expect(xsd).to include('<element name="name" type="xs:string"/>')
-      expect(xsd).to include('<element name="value" type="xs:integer"/>')
+      expect(xsd).to include('<xs:element name="product">')
+      expect(xsd).to include("<xs:complexType>")
+      expect(xsd).not_to include("<xs:complexType name=")
+      expect(xsd).to include('<xs:element name="name" type="xs:string"/>')
+      expect(xsd).to include('<xs:element name="value" type="xs:integer"/>')
     end
 
     it "generates inline complexType for nested model without type_name" do
@@ -41,10 +41,10 @@ RSpec.describe "XSD Three Pattern Architecture" do
 
       xsd = Lutaml::Model::Schema.to_xsd(klass)
 
-      expect(xsd).to include('<element name="item">')
-      expect(xsd).to include("<complexType>")
-      expect(xsd).not_to include("<complexType name=")
-      expect(xsd).to include('<attribute name="id" type="xs:string"/>')
+      expect(xsd).to include('<xs:element name="item">')
+      expect(xsd).to include("<xs:complexType>")
+      expect(xsd).not_to include("<xs:complexType name=")
+      expect(xsd).to include('<xs:attribute name="id" type="xs:string"/>')
     end
   end
 
@@ -64,11 +64,11 @@ RSpec.describe "XSD Three Pattern Architecture" do
       xsd = Lutaml::Model::Schema.to_xsd(klass)
 
       # Should generate named complexType only (no element)
-      expect(xsd).to include('<complexType name="ProductType">')
-      expect(xsd).to include('<element name="name" type="xs:string"/>')
-      expect(xsd).to include('<element name="value" type="xs:integer"/>')
+      expect(xsd).to include('<xs:complexType name="ProductType">')
+      expect(xsd).to include('<xs:element name="name" type="xs:string"/>')
+      expect(xsd).to include('<xs:element name="value" type="xs:integer"/>')
       # Should NOT generate standalone element declaration
-      expect(xsd).not_to include('<element name="product"')
+      expect(xsd).not_to include('<xs:element name="product"')
     end
 
     it "type-only model can be referenced by other elements" do
@@ -99,8 +99,8 @@ RSpec.describe "XSD Three Pattern Architecture" do
       xsd = Lutaml::Model::Schema.to_xsd(person_klass)
 
       # Should reference AddressType
-      expect(xsd).to include('<element name="address" type="AddressType"/>')
-      expect(xsd).to include('<complexType name="AddressType">')
+      expect(xsd).to include('<xs:element name="address" type="AddressType"/>')
+      expect(xsd).to include('<xs:complexType name="AddressType">')
     end
   end
 
@@ -121,10 +121,10 @@ RSpec.describe "XSD Three Pattern Architecture" do
       xsd = Lutaml::Model::Schema.to_xsd(klass)
 
       # Should generate both element and named type
-      expect(xsd).to include('<element name="product" type="ProductType"/>')
-      expect(xsd).to include('<complexType name="ProductType">')
-      expect(xsd).to include('<element name="name" type="xs:string"/>')
-      expect(xsd).to include('<element name="value" type="xs:integer"/>')
+      expect(xsd).to include('<xs:element name="product" type="ProductType"/>')
+      expect(xsd).to include('<xs:complexType name="ProductType">')
+      expect(xsd).to include('<xs:element name="name" type="xs:string"/>')
+      expect(xsd).to include('<xs:element name="value" type="xs:integer"/>')
     end
 
     it "allows reuse of named type by other elements" do
@@ -143,9 +143,9 @@ RSpec.describe "XSD Three Pattern Architecture" do
       xsd = Lutaml::Model::Schema.to_xsd(klass)
 
       # Element references the named type
-      expect(xsd).to include('<element name="catalog" type="CatalogType"/>')
+      expect(xsd).to include('<xs:element name="catalog" type="CatalogType"/>')
       # Type definition exists separately
-      expect(xsd).to include('<complexType name="CatalogType">')
+      expect(xsd).to include('<xs:complexType name="CatalogType">')
     end
   end
 
@@ -192,8 +192,8 @@ RSpec.describe "XSD Three Pattern Architecture" do
 
       # Both should generate identical XSD
       expect(xsd1).to eq(xsd2)
-      expect(xsd1).to include('<element name="test" type="TestType"/>')
-      expect(xsd1).to include('<complexType name="TestType">')
+      expect(xsd1).to include('<xs:element name="test" type="TestType"/>')
+      expect(xsd1).to include('<xs:complexType name="TestType">')
     end
 
     it "xsd_type does NOT auto-set type-only (NO MAGIC)" do
@@ -232,8 +232,8 @@ RSpec.describe "XSD Three Pattern Architecture" do
       expect(mapping).not_to be_no_root
 
       xsd = Lutaml::Model::Schema.to_xsd(klass)
-      expect(xsd).to include('<element name="simple">')
-      expect(xsd).not_to include('<element name="simple" type=')
+      expect(xsd).to include('<xs:element name="simple">')
+      expect(xsd).not_to include('<xs:element name="simple" type=')
     end
 
     it "Pattern 2: type_name only -> named reusable" do
@@ -250,9 +250,9 @@ RSpec.describe "XSD Three Pattern Architecture" do
       expect(mapping.type_name_value).to eq("SimpleType")
 
       xsd = Lutaml::Model::Schema.to_xsd(klass)
-      expect(xsd).to include('<complexType name="SimpleType">')
+      expect(xsd).to include('<xs:complexType name="SimpleType">')
       # Should not have standalone element declaration (only child elements in sequence are OK)
-      expect(xsd).not_to include('<element name="SimpleType"')
+      expect(xsd).not_to include('<xs:element name="SimpleType"')
     end
 
     it "Pattern 3: both -> element with named type" do
@@ -270,8 +270,8 @@ RSpec.describe "XSD Three Pattern Architecture" do
       expect(mapping.type_name_value).to eq("SimpleType")
 
       xsd = Lutaml::Model::Schema.to_xsd(klass)
-      expect(xsd).to include('<element name="simple" type="SimpleType"/>')
-      expect(xsd).to include('<complexType name="SimpleType">')
+      expect(xsd).to include('<xs:element name="simple" type="SimpleType"/>')
+      expect(xsd).to include('<xs:complexType name="SimpleType">')
     end
   end
 end

--- a/spec/lutaml/model/xsd_type_validation_spec.rb
+++ b/spec/lutaml/model/xsd_type_validation_spec.rb
@@ -433,7 +433,7 @@ RSpec.describe "XSD Type Validation" do
         end
 
         xsd = described_class.generate(model)
-        expect(xsd).to match('<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">')
+        expect(xsd).to include('<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"')
         expect(xsd).to include('type="xs:string"')
         expect(xsd).to include('type="xs:integer"')
       end

--- a/spec/lutaml/model/xsd_type_validation_spec.rb
+++ b/spec/lutaml/model/xsd_type_validation_spec.rb
@@ -433,7 +433,7 @@ RSpec.describe "XSD Type Validation" do
         end
 
         xsd = described_class.generate(model)
-        expect(xsd).to match('<schema xmlns="http://www.w3.org/2001/XMLSchema">')
+        expect(xsd).to match('<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">')
         expect(xsd).to include('type="xs:string"')
         expect(xsd).to include('type="xs:integer"')
       end


### PR DESCRIPTION
This PR fixes the invalid XSD produced by `Model.to_xsd`, which referenced the
`xs:` prefix without ever binding it, so no XSD processor could load the
output. It binds the XML Schema vocabulary to `xmlns:xs` and derives all
namespace handling from the models' `XmlNamespace` classes, so schemas spanning
multiple namespaces are generated correctly.

### What this changes

- binds the XSD vocabulary to `xmlns:xs` and emits `xs:`-prefixed structure elements
- collects every namespace in the model tree from the `XmlNamespace` classes and declares `xmlns:<prefix>` for each
- sets `targetNamespace` from the root model and qualifies named-type references by their owning namespace
- emits deduplicated `xs:import` for foreign namespaces instead of folding their types into the root schema
- synthesizes a `tns` prefix when the target namespace declares none
- raises clear errors on prefix collisions and foreign namespaces without a usable prefix
- guards recursive models (`A -> B -> A`) against infinite recursion in validation and type generation
- adds specs covering the above, including schema-load checks

`Type::Value` type-namespace prefixing is left as a follow-up (documented in-code).

closes #717
