### PR TITLE
Added strict cardinality validation

### DIFF
--- a/bench/bench_common.rb
+++ b/bench/bench_common.rb
@@ -17,7 +17,8 @@ require "fileutils"
 
 module BenchCommon
   ITERATIONS = (ENV["ITERATIONS"] || "3").to_i
-  WARMUP_ITERATIONS = 1
+  # Two warmups, so first-parse memoisation stays out of the sample.
+  WARMUP_ITERATIONS = 2
 
   module_function
 
@@ -31,31 +32,38 @@ module BenchCommon
     iterations.times do
       GC.start
       GC.disable
-      mem_before = ObjectSpace.count_objects[:TOTAL]
+      # total_allocated_objects counts every object allocated. The older
+      # ObjectSpace.count_objects[:TOTAL] counts heap slots, which only move
+      # when Ruby adds a page — that made the reading page-quantised and
+      # bimodal enough for a fixture to fail its own ratio gate against an
+      # identical build.
+      alloc_before = GC.stat[:total_allocated_objects]
       t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       yield
       t1 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      alloc_after = GC.stat[:total_allocated_objects]
       GC.enable
-      mem_after = ObjectSpace.count_objects[:TOTAL]
       times << (t1 - t0)
-      allocations << (mem_after - mem_before)
+      allocations << (alloc_after - alloc_before)
     end
 
     avg_time = times.sum / times.size
     min_time = times.min
     max_time = times.max
-    avg_alloc = (allocations.sum / allocations.size).round
+    # Minimum, for the same reason the time gate uses min_time: it is the run
+    # least polluted by whatever else the machine was doing.
+    min_alloc = allocations.min
     ips = 1.0 / avg_time
 
-    printf "  %-55s %6.3fs (min: %.3f, max: %.3f)  %9d allocs  %6.1f IPS\n",
-           name, avg_time, min_time, max_time, avg_alloc, ips
+    printf "  %-55s %6.3fs (min: %.3f, max: %.3f)  %9d allocs (min)  %6.1f IPS\n",
+           name, avg_time, min_time, max_time, min_alloc, ips
 
     {
       name: name,
       avg_time: avg_time,
       min_time: min_time,
       max_time: max_time,
-      allocations: avg_alloc,
+      allocations: min_alloc,
       ips: ips,
     }
   end

--- a/docs/_pages/breaking-changes.adoc
+++ b/docs/_pages/breaking-changes.adoc
@@ -143,6 +143,64 @@ end
 Simply remove the `no_root` call - models without `element()` are type-only by default.
 
 
+=== v0.9.0: Strict cardinality validation
+
+Attributes now enforce their declared cardinality. An attribute without
+`collection:` holds a single value, and giving it several is a violation that
+`#validate` reports. See link:validation[Validation] for the full rules.
+
+Four behavior changes come with it.
+
+==== Nested models now run their own validations
+
+`#validate` recurses into nested models and validates each one. Polymorphic,
+required and custom checks on a nested model ran nowhere before; they run now.
+A model that validated clean may start reporting errors its children always had.
+
+==== Singular readers can return arrays
+
+An attribute given more values than it was declared for keeps them all, so
+`#validate` has something to report. Until the violation is fixed, the reader
+returns an array rather than a single value.
+
+[source,ruby]
+----
+obj = Person.from_xml("<person><name>A</name><name>B</name></person>")
+obj.name      # => ["A", "B"]
+obj.validate  # => [#<Lutaml::Model::CollectionTrueMissingError ...>]
+----
+
+Code that assumed a singular reader always returns a scalar should call
+`#validate` before trusting the shape.
+
+While the violation stands the document does not round-trip: serializing writes
+the array out as a single stringified value. Fix the cardinality and output
+returns to normal.
+
+==== Enum shorthand predicates answer false while over-counted
+
+The generated `value?` methods read through the same reader, so an attribute
+holding two values answers `false` for all of them.
+
+[source,ruby]
+----
+obj = Doc.from_json('{"kind": ["draft", "final"]}')
+obj.draft?  # => false, the attribute holds two values
+obj.kind = "draft"
+obj.draft?  # => true
+----
+
+==== Assigning a scalar to a collection attribute wraps it
+
+Assignment now produces the same shape as parsing.
+
+[source,ruby]
+----
+doc.tags = "one"
+doc.tags  # => ["one"]
+----
+
+
 === v0.8.0: XML default namespace behavior
 
 Version 0.8.0 introduces a **breaking change** to XML namespace serialization

--- a/docs/_pages/validation.adoc
+++ b/docs/_pages/validation.adoc
@@ -25,13 +25,22 @@ Lutaml::Model supports the following validation types:
 
 === Collection validation
 
-The `collection` option validates collection size ranges.
+The `collection` option sets an attribute's cardinality: `collection: true`
+means `0..*`, a range such as `(1..)` or `(0..5)` bounds the count, and omitting
+it (the default) means `0..1`, a single value.
 
 [source,ruby]
 ----
 attribute :items, :string, collection: (1..)  # At least one item
 attribute :tags, :string, collection: (0..5)  # Up to 5 tags
+attribute :name, :string                      # Default 0..1 (single value)
 ----
+
+An attribute given more occurrences than its cardinality allows raises
+`Lutaml::Model::CollectionTrueMissingError` (a non-collection attribute given
+multiple values) or `Lutaml::Model::CollectionCountOutOfRangeError` (a declared
+range exceeded). Declare `collection: true` for attributes that hold many
+values.
 
 === Value enumeration validation
 

--- a/docs/_pages/validation.adoc
+++ b/docs/_pages/validation.adoc
@@ -36,11 +36,33 @@ attribute :tags, :string, collection: (0..5)  # Up to 5 tags
 attribute :name, :string                      # Default 0..1 (single value)
 ----
 
-An attribute given more occurrences than its cardinality allows raises
-`Lutaml::Model::CollectionTrueMissingError` (a non-collection attribute given
-multiple values) or `Lutaml::Model::CollectionCountOutOfRangeError` (a declared
-range exceeded). Declare `collection: true` for attributes that hold many
-values.
+A non-collection attribute given multiple values keeps them. Parsing does not
+raise; the values land in the attribute as an array and `#validate` reports
+`Lutaml::Model::CollectionTrueMissingError`, which `#validate!` raises wrapped
+in a `Lutaml::Model::ValidationError`.
+
+[source,ruby]
+----
+obj = Person.from_xml("<person><name>A</name><name>B</name></person>")
+obj.name      # => ["A", "B"]
+obj.validate  # => [#<Lutaml::Model::CollectionTrueMissingError ...>]
+obj.validate! # raises Lutaml::Model::ValidationError
+----
+
+Declare `collection: true` for attributes that hold many values.
+
+Two cases still report at parse time rather than on `#validate`:
+
+* A declared range that is exceeded raises
+  `Lutaml::Model::CollectionCountOutOfRangeError` for key/value formats.
+* A model mapped onto a plain Ruby class with `model` has no `#validate`, so
+  there is no later point to report to.
+
+A custom deserializer (`with: { from: }`) receives whatever arrived — a single
+node for one occurrence, an array for several, the same shape a custom
+`to:` method already receives for a collection. If that method collapses the
+array to a single value, the over-count is not reported: the method has decided
+what the attribute holds.
 
 === Value enumeration validation
 

--- a/docs/_pages/validation.adoc
+++ b/docs/_pages/validation.adoc
@@ -51,6 +51,22 @@ obj.validate! # raises Lutaml::Model::ValidationError
 
 Declare `collection: true` for attributes that hold many values.
 
+The rule is about shape, not count. A singular attribute is declared to hold a
+value, not a list, so a one-element array is still a violation:
+
+[source,ruby]
+----
+Person.from_json('{"name": ["A"]}').validate
+# => [#<Lutaml::Model::CollectionTrueMissingError ...>]
+----
+
+XML has no such distinction — a single `<name>` element is a value, so only a
+repeated element trips the check.
+
+An invalid document does not round-trip. While an attribute holds more values
+than it was declared for, serializing it back out will not reproduce the input.
+Fix the violation and it round-trips normally.
+
 Two cases still report at parse time rather than on `#validate`:
 
 * A declared range that is exceeded raises

--- a/lib/lutaml/key_value/transform.rb
+++ b/lib/lutaml/key_value/transform.rb
@@ -262,7 +262,13 @@ format)
                              instance)
         end
 
-        attr.valid_collection!(value, context)
+        # Range errors stay eager here. The over-count error only fires when the
+        # attribute is not a collection, so this guard defers exactly that case
+        # to `.validate` while leaving declared ranges checked at parse. A mapped
+        # PORO has no `.validate` to defer into, so it keeps the eager check.
+        if attr.collection? || !instance.is_a?(Lutaml::Model::Serialize)
+          attr.valid_collection!(value, context)
+        end
         rule.deserialize(instance, value, attributes, self)
       end
 

--- a/lib/lutaml/model/attribute.rb
+++ b/lib/lutaml/model/attribute.rb
@@ -281,9 +281,31 @@ module Lutaml
       end
 
       def cast_value(value, register)
-        return cast_element(value, register) unless collection_instance?(value)
+        if list_like?(value)
+          build_collection(cast_items(value, register), register: register)
+        elsif coerce_to_collection?(value)
+          build_collection(cast_items([value], register), register: register)
+        else
+          cast_element(value, register)
+        end
+      end
 
-        build_collection(value.map { |v| cast_element(v, register) })
+      # Plain Arrays count as list input. On singular attributes
+      # collection_instance? matches Arrays too (their collection class is
+      # Array), preserving the Array so strict cardinality can flag it.
+      def list_like?(value)
+        collection_instance?(value) || (collection? && value.is_a?(::Array))
+      end
+
+      # Prepare the seed items for a collection. Custom Collection classes
+      # cast their own items (idempotently) in #initialize, so hand them a
+      # plain array of the existing elements — rebuilding a fresh collection
+      # avoids sharing a mutable default across instances. Plain collections
+      # cast each element here.
+      def cast_items(value, register)
+        return value.to_a if custom_collection?
+
+        value.map { |v| cast_element(v, register) }
       end
 
       # Apply a value map to transform a value.
@@ -433,6 +455,12 @@ instance_object = nil)
         return true unless enum?
         return true if Utils.uninitialized?(value)
 
+        # Collection attributes hold multiple values; validate each element
+        # against the allowed set rather than the coerced collection itself.
+        if value.is_a?(::Array) || collection_instance?(value)
+          return value.all? { |v| valid_value!(v) }
+        end
+
         unless valid_value?(value)
           raise Lutaml::Model::InvalidValueError.new(name, value, enum_values)
         end
@@ -446,16 +474,17 @@ instance_object = nil)
         options[:values].include?(value)
       end
 
-      # Pattern binds string values only. For a plain :string attribute that is
-      # the resolved type; for a union, the pattern applies to a value that took
-      # the :string branch (a non-string member is exempt). Collections check
-      # each element, so a mix of members validates only its string entries.
-      def valid_pattern!(value, resolved_type)
+      # Pattern binds actual string values only. For a plain :string attribute
+      # every element is a string; for a union the pattern applies to whichever
+      # elements took the :string branch (non-string members are exempt). A nil
+      # or omitted element is skipped rather than crashing Regexp#match?, and
+      # Array(value) flattens both plain Arrays and custom Collections so the
+      # pattern applies per element instead of to the collection as a whole.
+      def valid_pattern!(value, _resolved_type)
         return true unless pattern
 
         Array(value).each do |item|
-          next unless resolved_type == Lutaml::Model::Type::String ||
-            item.is_a?(::String)
+          next unless item.is_a?(::String)
           next if pattern.match?(item)
 
           raise Lutaml::Model::PatternNotMatchedError.new(name, pattern, item)
@@ -561,13 +590,17 @@ instance_object = nil)
         # Allow any value for unbounded collections
         return true if collection == true
 
-        unless (Utils.uninitialized?(value) && resolved_collection.min.zero?) || collection_instance?(value)
+        unless ((value.nil? || Utils.uninitialized?(value)) && resolved_collection.min.zero?) || collection_instance?(value)
           raise Lutaml::Model::CollectionCountOutOfRangeError.new(
             name,
             value,
             collection,
           )
         end
+
+        # An absent value that satisfied a zero minimum above is not a
+        # collection instance, so there is nothing left to size-check.
+        return true unless collection_instance?(value)
 
         return true unless resolved_collection.is_a?(Range)
 
@@ -586,6 +619,11 @@ instance_object = nil)
             collection,
           )
         end
+
+        # Truthy on success: validate_value! chains this with && before
+        # pattern/polymorphic/custom checks, so falling through as nil would
+        # silently skip them for a valid bounded-range collection.
+        true
       end
 
       def serialize(value, format, register, options = {})
@@ -637,7 +675,7 @@ instance_object = nil)
                                       converted: true)
           return build_collection(value.map do |v|
             cast(v, format, register, merged_opts)
-          end)
+          end, register: register)
         end
 
         return value if already_serialized?(resolved_type, value)

--- a/lib/lutaml/model/attribute.rb
+++ b/lib/lutaml/model/attribute.rb
@@ -511,7 +511,7 @@ instance_object = nil)
         resolved_type = type(register)
 
         valid_value!(value) &&
-          valid_collection!(value, self) &&
+          valid_collection!(value, instance_object&.class) &&
           valid_pattern!(value, resolved_type) &&
           validate_polymorphic!(value, resolved_type) &&
           execute_validations!(value)

--- a/lib/lutaml/model/attribute.rb
+++ b/lib/lutaml/model/attribute.rb
@@ -451,7 +451,11 @@ instance_object = nil)
       end
 
       def valid_value!(value)
-        return true if value.nil? && singular?
+        # nil is never tested against the value set, whether it arrives as the
+        # whole value or as one element of a collection (this method recurses
+        # per element). valid_pattern! skips nil the same way, and an unset
+        # attribute is validate_required!'s business, not the enum's.
+        return true if value.nil?
         return true unless enum?
         return true if Utils.uninitialized?(value)
 
@@ -477,9 +481,9 @@ instance_object = nil)
       # Pattern binds actual string values only. For a plain :string attribute
       # every element is a string; for a union the pattern applies to whichever
       # elements took the :string branch (non-string members are exempt). A nil
-      # or omitted element is skipped rather than crashing Regexp#match?, and
-      # Array(value) flattens both plain Arrays and custom Collections so the
-      # pattern applies per element instead of to the collection as a whole.
+      # element is skipped along with every other non-string, and Array(value)
+      # flattens both plain Arrays and custom Collections so the pattern applies
+      # per element instead of to the collection as a whole.
       def valid_pattern!(value, _resolved_type)
         return true unless pattern
 
@@ -510,8 +514,11 @@ instance_object = nil)
         value = cast_value(default_value(register, instance_object), register) if value.nil?
         resolved_type = type(register)
 
-        valid_value!(value) &&
-          valid_collection!(value, instance_object&.class) &&
+        # Shape before contents. An over-count is a cardinality violation, not
+        # an enum or pattern one, and checking it first keeps those predicates
+        # from reporting on a value whose shape is already wrong.
+        valid_collection!(value, instance_object&.class) &&
+          valid_value!(value) &&
           valid_pattern!(value, resolved_type) &&
           validate_polymorphic!(value, resolved_type) &&
           execute_validations!(value)
@@ -590,7 +597,11 @@ instance_object = nil)
         # Allow any value for unbounded collections
         return true if collection == true
 
-        unless ((value.nil? || Utils.uninitialized?(value)) && resolved_collection.min.zero?) || collection_instance?(value)
+        unless collection_instance?(value)
+          # An absent value satisfies a zero minimum and has nothing to size.
+          return true if (value.nil? || Utils.uninitialized?(value)) &&
+            resolved_collection.min.zero?
+
           raise Lutaml::Model::CollectionCountOutOfRangeError.new(
             name,
             value,
@@ -598,21 +609,15 @@ instance_object = nil)
           )
         end
 
-        # An absent value that satisfied a zero minimum above is not a
-        # collection instance, so there is nothing left to size-check.
-        return true unless collection_instance?(value)
+        # cover? rather than between?, so an exclusive range such as (0...5)
+        # rejects a count of 5.
+        in_range = if resolved_collection.end.infinite?
+                     value.size >= resolved_collection.begin
+                   else
+                     resolved_collection.cover?(value.size)
+                   end
 
-        return true unless resolved_collection.is_a?(Range)
-
-        if resolved_collection.is_a?(Range) && resolved_collection.end.infinite?
-          if value.size < resolved_collection.begin
-            raise Lutaml::Model::CollectionCountOutOfRangeError.new(
-              name,
-              value,
-              collection,
-            )
-          end
-        elsif resolved_collection.is_a?(Range) && !resolved_collection.cover?(value.size)
+        unless in_range
           raise Lutaml::Model::CollectionCountOutOfRangeError.new(
             name,
             value,
@@ -620,8 +625,8 @@ instance_object = nil)
           )
         end
 
-        # Truthy on success: validate_value! chains this with && before
-        # pattern/polymorphic/custom checks, so falling through as nil would
+        # Truthy on success: validate_value! chains this with && before the
+        # value/pattern/polymorphic/custom checks, so falling through as nil would
         # silently skip them for a valid bounded-range collection.
         true
       end

--- a/lib/lutaml/model/collection.rb
+++ b/lib/lutaml/model/collection.rb
@@ -595,7 +595,7 @@ lutaml_register: Lutaml::Model::Config.default_register)
         end
       end
 
-      # Override validate to support both instance and collection-level validations
+      # Adds collection-level validations on top of the instance-level ones
       #
       # Collection-level validations run in order and can share state through a
       # context object. Validations can stop the chain early by calling ctx.stop!
@@ -622,7 +622,10 @@ lutaml_register: Lutaml::Model::Config.default_register)
       #     end
       #   end
       #
-      def validate(register: Lutaml::Model::Config.default_register)
+      # Hooks into the guarded pipeline rather than overriding #validate, so
+      # the collection rules run inside the cycle guard and a self-referencing
+      # collection runs them once rather than twice.
+      def collect_validation_errors(register)
         errors = []
 
         # Run standard instance-level validations first (inherited from Serializable)

--- a/lib/lutaml/model/collection_handler.rb
+++ b/lib/lutaml/model/collection_handler.rb
@@ -48,10 +48,29 @@ module Lutaml
 
       # Build a new collection with the given values
       #
+      # Custom Collection classes resolve their item type through the register,
+      # so thread it through when one is supplied. Plain Array collections and
+      # register-less callers keep the prior construction path untouched.
+      #
       # @param args [Array] Values to include in the collection
+      # @param register [Symbol, nil] Register for custom-collection type resolution
       # @return [Object] A new collection instance
-      def build_collection(*args)
-        collection_class.new(args.flatten)
+      def build_collection(*args, register: nil)
+        items = args.flatten
+        return collection_class.new(items) unless custom_collection? && register
+
+        collection_class.new(items, lutaml_register: register)
+      end
+
+      # Whether a bare single value assigned to this attribute must be
+      # coerced into a one-element collection, so assignment produces the
+      # same shape as parsing. nil and the uninitialized sentinel pass
+      # through untouched to preserve absent-value semantics.
+      #
+      # @param value [Object] The value being assigned
+      # @return [Boolean] true if the value should be wrapped
+      def coerce_to_collection?(value)
+        collection? && !value.nil? && !Utils.uninitialized?(value)
       end
 
       # Check if this attribute uses a custom collection class

--- a/lib/lutaml/model/collection_handler.rb
+++ b/lib/lutaml/model/collection_handler.rb
@@ -7,6 +7,9 @@ module Lutaml
     # Provides methods for checking if an attribute is a collection,
     # getting the collection class, building collections, and related operations.
     module CollectionHandler
+      # Parameter kinds that carry a named keyword in Method#parameters.
+      KEYWORD_PARAM_KINDS = %i[key keyreq].freeze
+
       # Get the collection options
       #
       # @return [Object, nil] The collection option value
@@ -57,9 +60,30 @@ module Lutaml
       # @return [Object] A new collection instance
       def build_collection(*args, register: nil)
         items = args.flatten
-        return collection_class.new(items) unless custom_collection? && register
+        unless register && initialize_accepts_register?
+          return collection_class.new(items)
+        end
 
         collection_class.new(items, lutaml_register: register)
+      end
+
+      # Whether the collection class can be handed a register at construction.
+      #
+      # A custom Collection subclass may override #initialize with the
+      # positional signature that predates the register, and passing the
+      # keyword to one of those raises ArgumentError. Such a subclass resolves
+      # its item types against the default register instead — there is no way
+      # to reach a constructor that does not accept one.
+      #
+      # @return [Boolean] true if #initialize declares the register keyword
+      def initialize_accepts_register?
+        return @initialize_accepts_register if defined?(@initialize_accepts_register)
+
+        @initialize_accepts_register = custom_collection? &&
+          collection_class.instance_method(:initialize).parameters.any? do |kind, param|
+            kind == :keyrest ||
+              (KEYWORD_PARAM_KINDS.include?(kind) && param == :lutaml_register)
+          end
       end
 
       # Whether a bare single value assigned to this attribute must be

--- a/lib/lutaml/model/serialize/enum_handling.rb
+++ b/lib/lutaml/model/serialize/enum_handling.rb
@@ -81,7 +81,11 @@ module Lutaml
             i = instance_variable_get(:"@#{enum_name}") || []
 
             if !collection && i.is_a?(Array)
-              i.first
+              # A singular enum stores its one value as a one-element array.
+              # Several values is a cardinality violation, so hand the array
+              # on instead of collapsing it — #validate reads through here and
+              # would otherwise never see the over-count.
+              i.size > 1 ? i : i.first
             else
               i.uniq
             end

--- a/lib/lutaml/model/validation.rb
+++ b/lib/lutaml/model/validation.rb
@@ -10,12 +10,22 @@ module Lutaml
           value = public_send(:"#{name}")
 
           begin
-            if value.is_a?(Lutaml::Model::Serialize)
-              sub_errors = value.validate
+            # Recurse into nested models — a single child or every element of
+            # an array — so their own validation errors surface here. A
+            # Collection is itself a model, so it is validated as one: that
+            # runs its collection-level rules as well as its elements.
+            # #validate takes no arguments here: it is a public override point
+            # that downstream models legitimately define with zero arity.
+            (value.is_a?(::Array) ? value : [value]).each do |item|
+              next unless item.is_a?(Lutaml::Model::Serialize)
+
+              sub_errors = item.validate
               errors.concat(sub_errors) if sub_errors.is_a?(Array)
-            else
-              attr.validate_value!(value, register, instance_object: self)
             end
+
+            # Always run attribute-level validation (cardinality, required,
+            # enum, pattern, polymorphic, custom) regardless of value type.
+            attr.validate_value!(value, register, instance_object: self)
           rescue Lutaml::Model::CollectionCountOutOfRangeError => e
             errors << e unless attr.choice
           rescue Lutaml::Model::InvalidValueError,

--- a/lib/lutaml/model/validation.rb
+++ b/lib/lutaml/model/validation.rb
@@ -3,7 +3,38 @@
 module Lutaml
   module Model
     module Validation
+      # Models being validated on this thread's current stack.
+      VALIDATING_KEY = :lutaml_model_validating
+
+      # Whether a model is already being validated further up this stack.
+      def self.visiting?(model)
+        stack = Thread.current[VALIDATING_KEY]
+        !stack.nil? && stack.key?(model)
+      end
+
+      # The single guarded entry point. A model can appear inside its own
+      # subtree, and re-entering it would recurse forever, so a re-entry
+      # returns early — the outer call is already collecting its errors.
+      #
+      # Override #collect_validation_errors, not this method, to add
+      # validation that must run inside the cycle guard. Overriding #validate
+      # directly puts the override outside the guard.
       def validate(register: Lutaml::Model::Config.default_register)
+        visiting = (Thread.current[VALIDATING_KEY] ||= {}.compare_by_identity)
+        return [] if visiting.key?(self)
+
+        begin
+          # Marked inside the begin, so an exception delivered between the
+          # check and the mark cannot strand an entry on the stack.
+          visiting[self] = true
+          collect_validation_errors(register)
+        ensure
+          visiting.delete(self)
+          Thread.current[VALIDATING_KEY] = nil if visiting.empty?
+        end
+      end
+
+      def collect_validation_errors(register)
         errors = []
 
         self.class.attributes(register).each do |name, attr|
@@ -18,6 +49,10 @@ module Lutaml
             # that downstream models legitimately define with zero arity.
             (value.is_a?(::Array) ? value : [value]).each do |item|
               next unless item.is_a?(Lutaml::Model::Serialize)
+              # Skip a model already on the stack rather than calling into it.
+              # A downstream #validate override sits above the guard, so
+              # re-entering it would run the override's own body a second time.
+              next if Validation.visiting?(item)
 
               sub_errors = item.validate
               errors.concat(sub_errors) if sub_errors.is_a?(Array)

--- a/lib/lutaml/xml/model_transform.rb
+++ b/lib/lutaml/xml/model_transform.rb
@@ -330,6 +330,13 @@ effective_register = nil, instance_is_serialize = nil)
           value = normalize_xml_value(value, rule, attr, new_opts,
                                       effective_register)
           value = rule.transform_value(attr, value, :from, :xml)
+          # Issue #185: a non-collection attribute given more than one element
+          # is a cardinality violation. The `!collection?` guard runs only
+          # valid_collection!'s over-count check (ranges stay on `.validate!`);
+          # map_content keeps its own timing.
+          if attr && !attr.collection? && !rule.content_mapping?
+            attr.valid_collection!(value, context)
+          end
           rule.deserialize(instance, value, attributes, context)
 
           instance.value_set_for(rule_to)
@@ -683,6 +690,12 @@ _effective_register)
         rule_has_custom_method = rule.has_custom_method_for_deserialization?
         if rule_has_custom_method || attr_type == ::Lutaml::Model::Type::Hash
           return_child = attr_type == ::Lutaml::Model::Type::Hash || !attr.collection? if attr
+          # Issue #185 parity: a singular attribute given multiple children is a
+          # cardinality violation. Keep the over-count array so the caller's
+          # valid_collection! detects it, instead of silently collapsing to the
+          # first child (which hid the violation before it could be validated).
+          return children if attr && !attr.collection? && children.size > 1
+
           return return_child ? children.first : children
         end
 
@@ -831,6 +844,10 @@ _effective_register)
         # these are considered empty collection
         return [] if attr&.collection? && [[nil], [""]].include?(values)
         return values if attr&.collection?
+
+        # Issue #185: keep the over-count (don't collapse via .first) so the
+        # non-collection cardinality violation is detected during parse.
+        return values if values.is_a?(Array) && values.size > 1
 
         values.is_a?(Array) ? values.first : values
       end

--- a/lib/lutaml/xml/model_transform.rb
+++ b/lib/lutaml/xml/model_transform.rb
@@ -330,11 +330,11 @@ effective_register = nil, instance_is_serialize = nil)
           value = normalize_xml_value(value, rule, attr, new_opts,
                                       effective_register)
           value = rule.transform_value(attr, value, :from, :xml)
-          # Issue #185: a non-collection attribute given more than one element
-          # is a cardinality violation. The `!collection?` guard runs only
-          # valid_collection!'s over-count check (ranges stay on `.validate!`);
-          # map_content keeps its own timing.
-          if attr && !attr.collection? && !rule.content_mapping?
+          # An over-count is normally left for `.validate` to report. A mapped
+          # PORO has no `.validate`, so deferring there would discard the
+          # violation entirely — check it while there is still someone to tell.
+          if !instance_is_serialize && attr && !attr.collection? &&
+              !rule.content_mapping?
             attr.valid_collection!(value, context)
           end
           rule.deserialize(instance, value, attributes, context)
@@ -690,10 +690,10 @@ _effective_register)
         rule_has_custom_method = rule.has_custom_method_for_deserialization?
         if rule_has_custom_method || attr_type == ::Lutaml::Model::Type::Hash
           return_child = attr_type == ::Lutaml::Model::Type::Hash || !attr.collection? if attr
-          # Issue #185 parity: a singular attribute given multiple children is a
-          # cardinality violation. Keep the over-count array so the caller's
-          # valid_collection! detects it, instead of silently collapsing to the
-          # first child (which hid the violation before it could be validated).
+          # A singular attribute given multiple children keeps the whole array,
+          # so the over-count reaches the slot and `.validate` can report it.
+          # Custom `from:` methods therefore receive it in the same shape a
+          # custom `to:` already gets for a collection.
           return children if attr && !attr.collection? && children.size > 1
 
           return return_child ? children.first : children
@@ -845,8 +845,8 @@ _effective_register)
         return [] if attr&.collection? && [[nil], [""]].include?(values)
         return values if attr&.collection?
 
-        # Issue #185: keep the over-count (don't collapse via .first) so the
-        # non-collection cardinality violation is detected during parse.
+        # Keep the over-count (don't collapse via .first) so it reaches the
+        # attribute slot and `.validate` can report the cardinality violation.
         return values if values.is_a?(Array) && values.size > 1
 
         values.is_a?(Array) ? values.first : values

--- a/lib/lutaml/xml/model_transform.rb
+++ b/lib/lutaml/xml/model_transform.rb
@@ -690,10 +690,8 @@ _effective_register)
         rule_has_custom_method = rule.has_custom_method_for_deserialization?
         if rule_has_custom_method || attr_type == ::Lutaml::Model::Type::Hash
           return_child = attr_type == ::Lutaml::Model::Type::Hash || !attr.collection? if attr
-          # A singular attribute given multiple children keeps the whole array,
-          # so the over-count reaches the slot and `.validate` can report it.
-          # Custom `from:` methods therefore receive it in the same shape a
-          # custom `to:` already gets for a collection.
+          # A custom `from:` receives the over-count in the same shape a custom
+          # `to:` already gets for a collection.
           return children if attr && !attr.collection? && children.size > 1
 
           return return_child ? children.first : children

--- a/lib/lutaml/xml/serialization/instance_methods.rb
+++ b/lib/lutaml/xml/serialization/instance_methods.rb
@@ -266,8 +266,8 @@ module Lutaml
         # Append XSD schema errors (validate_xml_with macro) to the
         # standard validation errors. No-op unless schemas are configured.
         #
-        # @see Lutaml::Model::Validation#validate
-        def validate(register: Lutaml::Model::Config.default_register)
+        # @see Lutaml::Model::Validation#collect_validation_errors
+        def collect_validation_errors(register)
           errors = super
           return errors if self.class.xml_schema_paths.empty?
 

--- a/spec/lutaml/model/attribute_spec.rb
+++ b/spec/lutaml/model/attribute_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Lutaml::Model::Attribute do
     expect { obj.image = Pathname.new("avatar.png") }
       .to change { obj.image }
       .from(nil)
-      .to("avatar.png")
+      .to(["avatar.png"])
   end
 
   it "raises error if both type and method_name are not given" do

--- a/spec/lutaml/model/cardinality_strict_spec.rb
+++ b/spec/lutaml/model/cardinality_strict_spec.rb
@@ -1,0 +1,197 @@
+require "spec_helper"
+require_relative "../../../lib/lutaml/model"
+
+module CardinalityStrictSpec
+  # Singular attribute only, mapped for every format.
+  class Simple < Lutaml::Model::Serializable
+    attribute :name, :string
+
+    xml do
+      root "simple"
+      map_element "name", to: :name
+    end
+
+    # key_value covers JSON, YAML and TOML
+    key_value do
+      map "name", to: :name
+    end
+  end
+
+  # Bounded collection, mapped for every format.
+  class Ranged < Lutaml::Model::Serializable
+    attribute :nick, :string, collection: 0..2
+
+    xml do
+      root "ranged"
+      map_element "nick", to: :nick
+    end
+
+    key_value do
+      map "nick", to: :nick
+    end
+  end
+
+  # Singular attribute deserialized by a custom method. The custom method must
+  # not mask an over-count: multiple children into a singular attribute stay a
+  # cardinality violation, exactly as for the plain (non-custom) mapping above.
+  class CustomSingular < Lutaml::Model::Serializable
+    attribute :label, :string
+
+    xml do
+      root "custom_singular"
+      map_element "label", to: :label,
+                           with: { from: :label_from, to: :label_to }
+    end
+
+    def label_from(model, node)
+      model.label = node.text.upcase
+    end
+
+    def label_to(model, parent, doc); end
+  end
+end
+
+# #185 asks for cardinality enforcement across XML AND key/value formats.
+# Key/value formats already raise at parse (an over-count arrives as an array);
+# this change brings XML in line. These examples prove the behaviour for every
+# format.
+RSpec.describe "Issue #185 strict cardinality" do
+  describe "non-collection attribute (default 0..1) given more than one value" do
+    it "raises at parse for XML (multiple elements)" do
+      expect do
+        CardinalityStrictSpec::Simple.from_xml(
+          "<simple><name>A</name><name>B</name></simple>",
+        )
+      end.to raise_error(Lutaml::Model::CollectionTrueMissingError, /`name`/)
+    end
+
+    {
+      json: ['{"name":["A","B"]}', '{"name":"A"}'],
+      yaml: ["name:\n- A\n- B\n", "name: A\n"],
+      toml: ['name = ["A", "B"]', 'name = "A"'],
+    }.each do |format, (over_count, single)|
+      it "raises at parse for #{format.upcase} (array on a singular attribute)" do
+        expect do
+          CardinalityStrictSpec::Simple.public_send(:"from_#{format}",
+                                                    over_count)
+        end.to raise_error(Lutaml::Model::CollectionTrueMissingError, /`name`/)
+      end
+
+      it "accepts a single #{format.upcase} value" do
+        obj = CardinalityStrictSpec::Simple.public_send(:"from_#{format}",
+                                                        single)
+        expect(obj.name).to eq("A")
+      end
+    end
+
+    it "accepts a single XML occurrence as a scalar" do
+      obj = CardinalityStrictSpec::Simple.from_xml("<simple><name>A</name></simple>")
+      expect(obj.name).to eq("A")
+    end
+
+    it "accepts zero XML occurrences" do
+      obj = CardinalityStrictSpec::Simple.from_xml("<simple/>")
+      expect(obj.name).to be_nil
+    end
+
+    context "when the singular attribute uses a custom deserializer" do
+      it "still raises at parse for multiple XML elements" do
+        expect do
+          CardinalityStrictSpec::CustomSingular.from_xml(
+            "<custom_singular><label>a</label><label>b</label>" \
+            "</custom_singular>",
+          )
+        end.to raise_error(Lutaml::Model::CollectionTrueMissingError, /`label`/)
+      end
+
+      it "runs the custom method for a single XML element" do
+        obj = CardinalityStrictSpec::CustomSingular.from_xml(
+          "<custom_singular><label>hi</label></custom_singular>",
+        )
+        expect(obj.label).to eq("HI")
+      end
+    end
+  end
+
+  describe "declared collection range (collection: 0..2)" do
+    it "flags an XML over-max on validate (XML validates ranges lazily)" do
+      obj = nil
+      expect do
+        obj = CardinalityStrictSpec::Ranged.from_xml(
+          "<ranged><nick>a</nick><nick>b</nick><nick>c</nick></ranged>",
+        )
+      end.not_to raise_error
+      expect(obj.validate).to include(
+        an_instance_of(Lutaml::Model::CollectionCountOutOfRangeError),
+      )
+    end
+
+    it "raises a key/value over-max at parse" do
+      expect do
+        CardinalityStrictSpec::Ranged.from_json('{"nick":["a","b","c"]}')
+      end.to raise_error(Lutaml::Model::CollectionCountOutOfRangeError)
+    end
+
+    it "accepts values within range for XML and key/value" do
+      xml_obj = CardinalityStrictSpec::Ranged.from_xml(
+        "<ranged><nick>a</nick><nick>b</nick></ranged>",
+      )
+      json_obj = CardinalityStrictSpec::Ranged.from_json('{"nick":["a","b"]}')
+      expect(xml_obj.validate).to be_empty
+      expect(json_obj.validate).to be_empty
+    end
+  end
+
+  describe "absent optional collection (regression: min-side false positive)" do
+    # collection: 0..2 with zero occurrences is valid; it must not raise at
+    # key/value parse just because an absent value arrives as nil.
+    it "does not raise for an absent optional collection in JSON" do
+      obj = nil
+      expect { obj = CardinalityStrictSpec::Ranged.from_json("{}") }
+        .not_to raise_error
+      expect(obj.validate).to be_empty
+    end
+
+    it "does not raise for an absent optional collection in YAML" do
+      expect { CardinalityStrictSpec::Ranged.from_yaml("--- {}\n") }
+        .not_to raise_error
+    end
+
+    it "still raises when the range requires a minimum (1..)" do
+      klass = Class.new(Lutaml::Model::Serializable) do
+        def self.name = "CardinalityStrictSpec::AtLeastOne"
+        attribute :nick, :string, collection: (1..)
+        key_value { map "nick", to: :nick }
+      end
+      expect { klass.from_json("{}") }
+        .to raise_error(Lutaml::Model::CollectionCountOutOfRangeError)
+    end
+  end
+
+  describe "map_content is left unchanged" do
+    let(:mixed) do
+      Class.new(Lutaml::Model::Serializable) do
+        def self.name = "CardinalityStrictSpec::Mixed"
+        attribute :bold, :string, collection: true
+        attribute :content, :string
+        xml do
+          root "r"
+          map_element "bold", to: :bold
+          map_content to: :content
+        end
+      end
+    end
+
+    it "does not raise at parse; flags a singular content target on validate" do
+      obj = nil
+      expect do
+        obj = mixed.from_xml(
+          "<r>one <bold>b</bold> two <bold>c</bold> three</r>",
+        )
+      end.not_to raise_error
+      expect(obj.validate).to include(
+        an_instance_of(Lutaml::Model::CollectionTrueMissingError),
+      )
+    end
+  end
+end

--- a/spec/lutaml/model/cardinality_strict_spec.rb
+++ b/spec/lutaml/model/cardinality_strict_spec.rb
@@ -31,9 +31,10 @@ module CardinalityStrictSpec
     end
   end
 
-  # Singular attribute deserialized by a custom method. The custom method must
-  # not mask an over-count: multiple children into a singular attribute stay a
-  # cardinality violation, exactly as for the plain (non-custom) mapping above.
+  # Singular attribute deserialized by a custom method. The method receives one
+  # node for a single occurrence and the whole array when several arrive — the
+  # same shape a custom `to:` method already gets for a collection. It records
+  # what it saw so the specs can assert the handover.
   class CustomSingular < Lutaml::Model::Serializable
     attribute :label, :string
 
@@ -43,26 +44,123 @@ module CardinalityStrictSpec
                            with: { from: :label_from, to: :label_to }
     end
 
+    def self.received
+      @received ||= []
+    end
+
     def label_from(model, node)
-      model.label = node.text.upcase
+      self.class.received << node
+      texts = Array(node).map { |n| n.text.upcase }
+      model.label = texts.size > 1 ? texts : texts.first
     end
 
     def label_to(model, parent, doc); end
   end
+
+  # A transform on the same rule as a custom deserializer. The transformer runs
+  # first and sees whatever arrived, including the over-count array.
+  class RecordingTransform < Lutaml::Model::ValueTransformer
+    def self.seen
+      @seen ||= []
+    end
+
+    def from_xml(value)
+      self.class.seen << value
+      value
+    end
+
+    def to_xml
+      value
+    end
+  end
+
+  class CustomWithTransform < Lutaml::Model::Serializable
+    attribute :label, :string
+
+    xml do
+      root "custom_with_transform"
+      map_element "label", to: :label,
+                           with: { from: :label_from, to: :label_to },
+                           transform: RecordingTransform
+    end
+
+    def label_from(model, node)
+      model.label = Array(node).map { |n| n.text.upcase }
+    end
+
+    def label_to(model, parent, doc); end
+  end
+
+  # Singular :hash attribute. Shares the same parse branch as custom methods,
+  # without a custom method of its own.
+  class HashSingular < Lutaml::Model::Serializable
+    attribute :meta, :hash
+
+    xml do
+      root "hash_singular"
+      map_element "meta", to: :meta
+    end
+  end
+
+  # A custom method that collapses the array to one value. The over-count is
+  # then not reported: the method decided what the attribute holds.
+  class CollapsingCustom < Lutaml::Model::Serializable
+    attribute :label, :string
+
+    xml do
+      root "collapsing_custom"
+      map_element "label", to: :label,
+                           with: { from: :label_from, to: :label_to }
+    end
+
+    def label_from(model, node)
+      model.label = Array(node).first.text.upcase
+    end
+
+    def label_to(model, parent, doc); end
+  end
+
+  # A plain Ruby class mapped with `model`. Instances have no #validate, so a
+  # cardinality violation has nowhere to be reported later.
+  class PlainTarget
+    attr_accessor :name
+  end
+
+  class PlainMapper < Lutaml::Model::Serializable
+    model PlainTarget
+
+    attribute :name, :string
+
+    xml do
+      root "plain"
+      map_element "name", to: :name
+    end
+
+    key_value do
+      map "name", to: :name
+    end
+  end
 end
 
 # #185 asks for cardinality enforcement across XML AND key/value formats.
-# Key/value formats already raise at parse (an over-count arrives as an array);
-# this change brings XML in line. These examples prove the behaviour for every
-# format.
+# Parsing preserves whatever multiplicity arrived; `.validate` judges it. An
+# over-count on a singular attribute is reported there, not raised at parse.
+# Declared ranges keep their existing parse-time timing.
 RSpec.describe "Issue #185 strict cardinality" do
   describe "non-collection attribute (default 0..1) given more than one value" do
-    it "raises at parse for XML (multiple elements)" do
+    it "does not raise at parse for XML; reports on validate" do
+      obj = nil
       expect do
-        CardinalityStrictSpec::Simple.from_xml(
+        obj = CardinalityStrictSpec::Simple.from_xml(
           "<simple><name>A</name><name>B</name></simple>",
         )
-      end.to raise_error(Lutaml::Model::CollectionTrueMissingError, /`name`/)
+      end.not_to raise_error
+
+      expect(obj.name).to eq(%w[A B])
+      expect(obj.validate).to include(
+        an_instance_of(Lutaml::Model::CollectionTrueMissingError),
+      )
+      expect { obj.validate! }.to raise_error(Lutaml::Model::ValidationError)
     end
 
     {
@@ -70,17 +168,24 @@ RSpec.describe "Issue #185 strict cardinality" do
       yaml: ["name:\n- A\n- B\n", "name: A\n"],
       toml: ['name = ["A", "B"]', 'name = "A"'],
     }.each do |format, (over_count, single)|
-      it "raises at parse for #{format.upcase} (array on a singular attribute)" do
+      it "does not raise at parse for #{format.upcase}; reports on validate" do
+        obj = nil
         expect do
-          CardinalityStrictSpec::Simple.public_send(:"from_#{format}",
-                                                    over_count)
-        end.to raise_error(Lutaml::Model::CollectionTrueMissingError, /`name`/)
+          obj = CardinalityStrictSpec::Simple.public_send(:"from_#{format}",
+                                                          over_count)
+        end.not_to raise_error
+
+        expect(obj.name).to eq(%w[A B])
+        expect(obj.validate).to include(
+          an_instance_of(Lutaml::Model::CollectionTrueMissingError),
+        )
       end
 
       it "accepts a single #{format.upcase} value" do
         obj = CardinalityStrictSpec::Simple.public_send(:"from_#{format}",
                                                         single)
         expect(obj.name).to eq("A")
+        expect(obj.validate).to be_empty
       end
     end
 
@@ -95,20 +200,118 @@ RSpec.describe "Issue #185 strict cardinality" do
     end
 
     context "when the singular attribute uses a custom deserializer" do
-      it "still raises at parse for multiple XML elements" do
+      before { CardinalityStrictSpec::CustomSingular.received.clear }
+
+      it "hands the whole array to the custom method for multiple elements" do
+        obj = nil
         expect do
-          CardinalityStrictSpec::CustomSingular.from_xml(
+          obj = CardinalityStrictSpec::CustomSingular.from_xml(
             "<custom_singular><label>a</label><label>b</label>" \
             "</custom_singular>",
           )
-        end.to raise_error(Lutaml::Model::CollectionTrueMissingError, /`label`/)
+        end.not_to raise_error
+
+        # Invoked once with the whole array, not once per child.
+        received = CardinalityStrictSpec::CustomSingular.received
+        expect(received.size).to eq(1)
+        expect(received.first).to be_a(Array)
+
+        expect(obj.label).to eq(%w[A B])
+        expect(obj.validate).to include(
+          an_instance_of(Lutaml::Model::CollectionTrueMissingError),
+        )
       end
 
       it "runs the custom method for a single XML element" do
         obj = CardinalityStrictSpec::CustomSingular.from_xml(
           "<custom_singular><label>hi</label></custom_singular>",
         )
+
+        received = CardinalityStrictSpec::CustomSingular.received
+        expect(received.size).to eq(1)
+        expect(received.first).not_to be_a(Array)
+
         expect(obj.label).to eq("HI")
+        expect(obj.validate).to be_empty
+      end
+    end
+
+    context "when a transform shares the rule with a custom deserializer" do
+      before { CardinalityStrictSpec::RecordingTransform.seen.clear }
+
+      it "runs the transform before the custom method, on the whole array" do
+        obj = CardinalityStrictSpec::CustomWithTransform.from_xml(
+          "<custom_with_transform><label>a</label><label>b</label>" \
+          "</custom_with_transform>",
+        )
+
+        seen = CardinalityStrictSpec::RecordingTransform.seen
+        expect(seen.size).to eq(1)
+        expect(seen.first).to be_a(Array)
+
+        expect(obj.label).to eq(%w[A B])
+        expect(obj.validate).to include(
+          an_instance_of(Lutaml::Model::CollectionTrueMissingError),
+        )
+      end
+    end
+
+    context "when the custom method collapses the array" do
+      it "reports nothing, because the method decided what is stored" do
+        obj = CardinalityStrictSpec::CollapsingCustom.from_xml(
+          "<collapsing_custom><label>a</label><label>b</label>" \
+          "</collapsing_custom>",
+        )
+
+        expect(obj.label).to eq("A")
+        expect(obj.validate).to be_empty
+      end
+    end
+
+    context "when the model is a plain Ruby class" do
+      # A PORO has no #validate, so deferring would discard the violation.
+      # These stay eager for that reason, not by oversight.
+      it "raises at parse for XML" do
+        expect do
+          CardinalityStrictSpec::PlainMapper.from_xml(
+            "<plain><name>A</name><name>B</name></plain>",
+          )
+        end.to raise_error(Lutaml::Model::CollectionTrueMissingError, /`name`/)
+      end
+
+      it "raises at parse for key/value" do
+        expect do
+          CardinalityStrictSpec::PlainMapper.from_json('{"name":["A","B"]}')
+        end.to raise_error(Lutaml::Model::CollectionTrueMissingError, /`name`/)
+      end
+
+      it "still accepts a single value" do
+        obj = CardinalityStrictSpec::PlainMapper.from_xml(
+          "<plain><name>A</name></plain>",
+        )
+        expect(obj).to be_a(CardinalityStrictSpec::PlainTarget)
+        expect(obj.name).to eq("A")
+      end
+    end
+
+    context "when the singular attribute is a :hash" do
+      it "keeps a single occurrence a Hash" do
+        obj = CardinalityStrictSpec::HashSingular.from_xml(
+          "<hash_singular><meta><k>v</k></meta></hash_singular>",
+        )
+        expect(obj.meta).to eq({ "k" => "v" })
+        expect(obj.validate).to be_empty
+      end
+
+      it "stores an over-count as an array and reports it on validate" do
+        obj = CardinalityStrictSpec::HashSingular.from_xml(
+          "<hash_singular><meta><k>v1</k></meta><meta><k>v2</k></meta>" \
+          "</hash_singular>",
+        )
+        expect(obj.meta).to eq([{ "k" => "v1" }, { "k" => "v2" }])
+        expect(obj.validate).to include(
+          an_instance_of(Lutaml::Model::CollectionTrueMissingError),
+        )
       end
     end
   end

--- a/spec/lutaml/model/cardinality_strict_spec.rb
+++ b/spec/lutaml/model/cardinality_strict_spec.rb
@@ -120,6 +120,55 @@ module CardinalityStrictSpec
     def label_to(model, parent, doc); end
   end
 
+  # Singular attribute with an enum. The generated reader used to collapse the
+  # stored array via .first, which hid an over-count from #validate entirely.
+  class EnumSingular < Lutaml::Model::Serializable
+    attribute :kind, :string, values: %w[a b]
+
+    key_value do
+      map "kind", to: :kind
+    end
+  end
+
+  # Enum on a bounded collection: the case where both the range and the value
+  # set can fail at once.
+  class EnumRanged < Lutaml::Model::Serializable
+    attribute :kind, :string, values: %w[a b], collection: 0..2
+
+    xml do
+      root "enum_ranged"
+      map_element "kind", to: :kind
+    end
+  end
+
+  # Enum and pattern on collections, to pin that both skip nil elements.
+  class NilElements < Lutaml::Model::Serializable
+    attribute :kind, :string, values: %w[a b], collection: true
+    attribute :code, :string, pattern: /\A[a-z]+\z/, collection: true
+
+    key_value do
+      map "kind", to: :kind
+      map "code", to: :code
+    end
+  end
+
+  # A value-level validation that measures length. Stands in for the facets
+  # PR #719 adds: it must never run against an over-count array, or a
+  # `min_length` check would silently measure the element count instead.
+  class LengthChecked < Lutaml::Model::Serializable
+    attribute :code, :string, validations: proc {
+      validate :code_length
+
+      def code_length(value)
+        errors.add(:code, "measured #{value.length}")
+      end
+    }
+
+    key_value do
+      map "code", to: :code
+    end
+  end
+
   # A plain Ruby class mapped with `model`. Instances have no #validate, so a
   # cardinality violation has nowhere to be reported later.
   class PlainTarget
@@ -395,6 +444,167 @@ RSpec.describe "Issue #185 strict cardinality" do
       expect(obj.validate).to include(
         an_instance_of(Lutaml::Model::CollectionTrueMissingError),
       )
+    end
+  end
+
+  describe "enum on a singular attribute" do
+    it "reports an over-count whose elements are outside the value set" do
+      obj = CardinalityStrictSpec::EnumSingular.from_json(
+        '{"kind":["a","z"]}',
+      )
+
+      expect(obj.kind).to eq(%w[a z])
+      expect(obj.validate).to contain_exactly(
+        an_instance_of(Lutaml::Model::CollectionTrueMissingError),
+      )
+    end
+
+    it "reports an over-count whose elements are all in the value set" do
+      obj = CardinalityStrictSpec::EnumSingular.from_json(
+        '{"kind":["a","b"]}',
+      )
+
+      expect(obj.kind).to eq(%w[a b])
+      expect(obj.validate).to contain_exactly(
+        an_instance_of(Lutaml::Model::CollectionTrueMissingError),
+      )
+    end
+
+    it "leaves a single value reading as a scalar" do
+      obj = CardinalityStrictSpec::EnumSingular.from_json('{"kind":"a"}')
+
+      expect(obj.kind).to eq("a")
+      expect(obj.validate).to be_empty
+    end
+
+    it "still rejects a single value outside the set" do
+      obj = CardinalityStrictSpec::EnumSingular.from_json('{"kind":"z"}')
+
+      expect(obj.validate).to contain_exactly(
+        an_instance_of(Lutaml::Model::InvalidValueError),
+      )
+    end
+
+    # The generated `a?` shorthand reads through the same reader. An attribute
+    # holding two values has no honest "yes" to give.
+    it "answers the value shorthand false while over-counted" do
+      obj = CardinalityStrictSpec::EnumSingular.from_json(
+        '{"kind":["a","z"]}',
+      )
+
+      expect(obj.a?).to be(false)
+
+      obj.kind = "a"
+      expect(obj.a?).to be(true)
+    end
+
+    # Known limitation, pinned so it stays visible. An enum setter always
+    # stores its value as an array, so a one-element array and a bare scalar
+    # are indistinguishable by the time #validate reads the slot. The
+    # shape-based rule therefore catches over-counts on an enum but not a
+    # one-element array, which a non-enum attribute does flag. Closing this
+    # needs the enum setter to preserve the assigned shape.
+    it "does not flag a one-element array, unlike a non-enum attribute" do
+      enumed = CardinalityStrictSpec::EnumSingular.from_json('{"kind":["a"]}')
+      plain = CardinalityStrictSpec::Simple.from_json('{"name":["A"]}')
+
+      expect(enumed.kind).to eq("a")
+      expect(enumed.validate).to be_empty
+
+      expect(plain.validate).to contain_exactly(
+        an_instance_of(Lutaml::Model::CollectionTrueMissingError),
+      )
+    end
+
+    # An invalid document does not round-trip. The array reaches the writer as
+    # the attribute's value and gets stringified, which is what any singular
+    # attribute holding an over-count already does — this is not specific to
+    # enums. Pinned so the shape is a visible decision. Fixing the violation
+    # restores clean output.
+    it "does not round-trip an over-count" do
+      obj = CardinalityStrictSpec::EnumSingular.from_json(
+        '{"kind":["a","b"]}',
+      )
+
+      expect(obj.to_json).to eq('{"kind":"[\"a\", \"b\"]"}')
+
+      obj.kind = "a"
+      expect(obj.to_json).to eq('{"kind":"a"}')
+    end
+  end
+
+  describe "enum on a bounded collection" do
+    # Shape before contents: the count is the more fundamental violation, so a
+    # value failing both its range and its value set reports the range.
+    it "reports the range when both the range and the value set fail" do
+      obj = CardinalityStrictSpec::EnumRanged.from_xml(
+        "<enum_ranged><kind>a</kind><kind>z</kind><kind>q</kind></enum_ranged>",
+      )
+
+      expect(obj.validate).to contain_exactly(
+        an_instance_of(Lutaml::Model::CollectionCountOutOfRangeError),
+      )
+    end
+
+    it "reports the value set when only the value set fails" do
+      obj = CardinalityStrictSpec::EnumRanged.from_xml(
+        "<enum_ranged><kind>a</kind><kind>z</kind></enum_ranged>",
+      )
+
+      expect(obj.validate).to contain_exactly(
+        an_instance_of(Lutaml::Model::InvalidValueError),
+      )
+    end
+  end
+
+  describe "nil elements in a collection" do
+    it "skips them for both enum and pattern checks" do
+      obj = CardinalityStrictSpec::NilElements.from_json(
+        '{"kind":["a",null],"code":["ab",null]}',
+      )
+
+      expect(obj.validate).to be_empty
+    end
+
+    it "still reports a non-nil element outside the value set" do
+      obj = CardinalityStrictSpec::NilElements.from_json(
+        '{"kind":["a",null,"z"]}',
+      )
+
+      expect(obj.validate).to contain_exactly(
+        an_instance_of(Lutaml::Model::InvalidValueError),
+      )
+    end
+  end
+
+  describe "a one-element array on a singular attribute" do
+    # The rule is about shape, not count: the attribute is declared to hold a
+    # value, and an array of one is still an array.
+    it "is a violation even though only one value arrived" do
+      obj = CardinalityStrictSpec::Simple.from_json('{"name":["A"]}')
+
+      expect(obj.name).to eq(["A"])
+      expect(obj.validate).to contain_exactly(
+        an_instance_of(Lutaml::Model::CollectionTrueMissingError),
+      )
+    end
+  end
+
+  describe "value-level validations against an over-count (PR #719 guard)" do
+    it "does not run them, so nothing measures the element count" do
+      obj = CardinalityStrictSpec::LengthChecked.from_json(
+        '{"code":["abcd","efgh"]}',
+      )
+
+      expect(obj.validate).to contain_exactly(
+        an_instance_of(Lutaml::Model::CollectionTrueMissingError),
+      )
+    end
+
+    it "runs them normally for a single value" do
+      obj = CardinalityStrictSpec::LengthChecked.from_json('{"code":"abcd"}')
+
+      expect(obj.validate.map(&:message).join).to include("measured 4")
     end
   end
 end

--- a/spec/lutaml/model/cdata_spec.rb
+++ b/spec/lutaml/model/cdata_spec.rb
@@ -17,7 +17,7 @@ module CdataSpec
 
   class Alpha < Lutaml::Model::Serializable
     attribute :element1, :string
-    attribute :element2, :string
+    attribute :element2, :string, collection: true
     attribute :element3, :string
     attribute :beta, Beta
 

--- a/spec/lutaml/model/collection_register_spec.rb
+++ b/spec/lutaml/model/collection_register_spec.rb
@@ -1,0 +1,119 @@
+require "spec_helper"
+require_relative "../../../lib/lutaml/model"
+
+module CollectionRegisterSpec
+  # Inherits Collection#initialize, so it declares the register keyword.
+  class Standard < Lutaml::Model::Collection
+    instances :items, :string
+  end
+
+  # Overrides #initialize with the positional signature that predates the
+  # register. Passing the keyword to this raises ArgumentError.
+  class Positional < Lutaml::Model::Collection
+    instances :items, :string
+
+    def initialize(items = [])
+      super
+    end
+  end
+
+  # Accepts and forwards arbitrary keywords, so the register still arrives.
+  class Forwarding < Lutaml::Model::Collection
+    instances :items, :string
+
+    def initialize(items = [], **)
+      super
+    end
+  end
+
+  class UsesStandard < Lutaml::Model::Serializable
+    attribute :items, :string, collection: Standard
+    key_value { map "items", to: :items }
+  end
+
+  class UsesPositional < Lutaml::Model::Serializable
+    attribute :items, :string, collection: Positional
+    key_value { map "items", to: :items }
+  end
+
+  class UsesForwarding < Lutaml::Model::Serializable
+    attribute :items, :string, collection: Forwarding
+    key_value { map "items", to: :items }
+  end
+
+  class UsesPlainArray < Lutaml::Model::Serializable
+    attribute :items, :string, collection: true
+    key_value { map "items", to: :items }
+  end
+end
+
+RSpec.describe "collection construction and the register" do
+  let(:register) { Lutaml::Model::Register.new(:collection_register_spec) }
+
+  before { Lutaml::Model::GlobalRegister.register(register) }
+
+  describe "a custom collection whose constructor takes the register" do
+    it "receives the register used for the parse" do
+      obj = CollectionRegisterSpec::UsesStandard.from_json(
+        '{"items":["x","y"]}',
+        register: :collection_register_spec,
+      )
+
+      expect(obj.items.lutaml_register).to eq(:collection_register_spec)
+    end
+
+    it "receives it through a forwarding constructor too" do
+      obj = CollectionRegisterSpec::UsesForwarding.from_json(
+        '{"items":["x","y"]}',
+        register: :collection_register_spec,
+      )
+
+      expect(obj.items.lutaml_register).to eq(:collection_register_spec)
+    end
+  end
+
+  describe "a custom collection with a positional-only constructor" do
+    it "parses without raising ArgumentError" do
+      obj = nil
+
+      expect do
+        obj = CollectionRegisterSpec::UsesPositional.from_json(
+          '{"items":["x","y"]}',
+        )
+      end.not_to raise_error
+
+      expect(obj.items.to_a).to eq(%w[x y])
+    end
+
+    it "accepts assignment without raising ArgumentError" do
+      obj = CollectionRegisterSpec::UsesPositional.new
+
+      expect { obj.items = %w[x y] }.not_to raise_error
+      expect(obj.items.to_a).to eq(%w[x y])
+    end
+
+    # There is no way to hand a register to a constructor that does not take
+    # one, so such a collection resolves against the default register.
+    it "falls back to the default register under a non-default parse" do
+      obj = CollectionRegisterSpec::UsesPositional.from_json(
+        '{"items":["x"]}',
+        register: :collection_register_spec,
+      )
+
+      expect(obj.items.lutaml_register)
+        .to eq(Lutaml::Model::Config.default_register)
+    end
+  end
+
+  describe "a plain collection: true attribute" do
+    it "still builds a bare Array when a register is in play" do
+      obj = CollectionRegisterSpec::UsesPlainArray.from_json(
+        '{"items":["x","y"]}',
+        register: :collection_register_spec,
+      )
+
+      expect(obj.items).to be_an(Array)
+      expect(obj.items).to eq(%w[x y])
+    end
+  end
+end

--- a/spec/lutaml/model/collection_single_value_coercion_spec.rb
+++ b/spec/lutaml/model/collection_single_value_coercion_spec.rb
@@ -1,0 +1,222 @@
+require "spec_helper"
+require_relative "../../../lib/lutaml/model"
+
+module CollectionSingleValueCoercion
+  class Item < Lutaml::Model::Serializable
+    attribute :name, :string
+
+    xml do
+      element "item"
+      map_element "name", to: :name
+    end
+  end
+
+  class Basket < Lutaml::Model::Serializable
+    attribute :items, Item, collection: true
+    attribute :labels, :string, collection: true
+    attribute :sizes, :string, collection: 1..2
+
+    xml do
+      element "basket"
+      map_element "item", to: :items
+      map_element "label", to: :labels
+      map_element "size", to: :sizes
+    end
+  end
+
+  class NameParts < Lutaml::Model::Collection
+    instances :parts, :string
+  end
+
+  class MetadataEntries < Lutaml::Model::Collection
+    instances :entries, :hash
+  end
+
+  class Person < Lutaml::Model::Serializable
+    attribute :name_parts, :string, collection: NameParts
+    attribute :metadata_entries, :hash, collection: MetadataEntries
+
+    xml do
+      element "person"
+      map_element "part", to: :name_parts
+    end
+  end
+
+  class Coded < Lutaml::Model::Serializable
+    attribute :codes, :string, collection: true, pattern: /\A[a-z]+\z/
+
+    xml do
+      element "coded"
+      map_element "code", to: :codes
+    end
+  end
+
+  # Pattern applied to an attribute backed by a custom Collection class. The
+  # value is a Collection instance (not a plain Array), so pattern validation
+  # must flatten it per element rather than treat it as a single non-string.
+  class CodedCustom < Lutaml::Model::Serializable
+    attribute :codes, :string, collection: NameParts, pattern: /\A[a-z]+\z/
+
+    xml do
+      element "coded_custom"
+      map_element "code", to: :codes
+    end
+  end
+end
+
+RSpec.describe "single value coercion on collection attributes" do
+  describe "setter assignment" do
+    it "wraps a single model instance into a one-element array" do
+      basket = CollectionSingleValueCoercion::Basket.new
+      basket.items = CollectionSingleValueCoercion::Item.new(name: "one")
+
+      expect(basket.items).to be_a(Array)
+      expect(basket.items.map(&:name)).to eq(["one"])
+    end
+
+    it "wraps a single primitive into a one-element array" do
+      basket = CollectionSingleValueCoercion::Basket.new
+      basket.labels = "fragile"
+
+      expect(basket.labels).to eq(["fragile"])
+    end
+
+    it "leaves nil untouched" do
+      basket = CollectionSingleValueCoercion::Basket.new
+      basket.labels = nil
+
+      expect(basket.labels).to be_nil
+    end
+
+    it "leaves array assignment unchanged" do
+      basket = CollectionSingleValueCoercion::Basket.new
+      basket.labels = %w[a b]
+
+      expect(basket.labels).to eq(%w[a b])
+    end
+  end
+
+  describe "constructor assignment" do
+    it "wraps a single value passed to the constructor" do
+      basket = CollectionSingleValueCoercion::Basket.new(labels: "solo")
+
+      expect(basket.labels).to eq(["solo"])
+    end
+
+    it "produces the same shape as parsing one element" do
+      parsed = CollectionSingleValueCoercion::Basket.from_xml(
+        "<basket><label>solo</label></basket>",
+      )
+      built = CollectionSingleValueCoercion::Basket.new(labels: "solo")
+
+      expect(built.labels).to eq(parsed.labels)
+    end
+  end
+
+  describe "bounded collections" do
+    it "wraps a single value and satisfies the range validation" do
+      basket = CollectionSingleValueCoercion::Basket.new(sizes: "small")
+
+      expect(basket.sizes).to eq(["small"])
+      expect { basket.validate! }.not_to raise_error
+    end
+  end
+
+  describe "custom collection classes" do
+    it "wraps a single value into the custom collection" do
+      person = CollectionSingleValueCoercion::Person.new
+      person.name_parts = "Ada"
+
+      expect(person.name_parts)
+        .to be_a(CollectionSingleValueCoercion::NameParts)
+      expect(person.name_parts.to_a.size).to eq(1)
+    end
+
+    it "routes a plain Array through the collection branch element-wise" do
+      person = CollectionSingleValueCoercion::Person.new
+      person.name_parts = %w[Ada Lovelace]
+
+      expect(person.name_parts)
+        .to be_a(CollectionSingleValueCoercion::NameParts)
+      expect(person.name_parts.to_a.size).to eq(2)
+    end
+
+    it "does not double-cast arrays for hash-valued custom collections" do
+      person = CollectionSingleValueCoercion::Person.new
+      person.metadata_entries = [{ "text" => "x" }]
+
+      expect(person.metadata_entries)
+        .to be_a(CollectionSingleValueCoercion::MetadataEntries)
+      expect(person.metadata_entries.to_a).to eq(["x"])
+    end
+
+    it "does not double-cast single values for hash-valued custom collections" do
+      person = CollectionSingleValueCoercion::Person.new
+      person.metadata_entries = { "text" => "x" }
+
+      expect(person.metadata_entries)
+        .to be_a(CollectionSingleValueCoercion::MetadataEntries)
+      expect(person.metadata_entries.to_a).to eq(["x"])
+    end
+
+    it "rebuilds a fresh collection instead of sharing the assigned one" do
+      shared = CollectionSingleValueCoercion::NameParts.new(%w[Ada])
+      a = CollectionSingleValueCoercion::Person.new
+      b = CollectionSingleValueCoercion::Person.new
+
+      a.name_parts = shared
+      b.name_parts = shared
+
+      expect(a.name_parts).not_to be(shared)
+      expect(a.name_parts).not_to be(b.name_parts)
+      expect(a.name_parts.to_a).to eq(%w[Ada])
+    end
+  end
+
+  describe "pattern validation on collection attributes" do
+    it "validates a coerced single value per element" do
+      coded = CollectionSingleValueCoercion::Coded.new(codes: "abc")
+
+      expect(coded.codes).to eq(["abc"])
+      expect { coded.validate! }.not_to raise_error
+    end
+
+    it "validates each element of an assigned array" do
+      coded = CollectionSingleValueCoercion::Coded.new(codes: %w[abc def])
+
+      expect { coded.validate! }.not_to raise_error
+    end
+
+    it "rejects an element that violates the pattern" do
+      coded = CollectionSingleValueCoercion::Coded.new(codes: %w[abc DEF])
+
+      expect { coded.validate! }
+        .to raise_error(Lutaml::Model::ValidationError, /DEF/)
+    end
+
+    it "validates each element of a custom Collection per element" do
+      coded = CollectionSingleValueCoercion::CodedCustom.new(codes: %w[abc def])
+
+      expect { coded.validate! }.not_to raise_error
+    end
+
+    it "rejects a bad element inside a custom Collection" do
+      coded = CollectionSingleValueCoercion::CodedCustom.new(codes: %w[abc DEF])
+
+      expect { coded.validate! }
+        .to raise_error(Lutaml::Model::ValidationError, /DEF/)
+    end
+  end
+
+  describe "serialization round-trip" do
+    it "serializes a coerced single value as a repeated element would" do
+      basket = CollectionSingleValueCoercion::Basket.new
+      basket.items = CollectionSingleValueCoercion::Item.new(name: "one")
+
+      round_tripped = CollectionSingleValueCoercion::Basket.from_xml(
+        basket.to_xml,
+      )
+      expect(round_tripped.items.map(&:name)).to eq(["one"])
+    end
+  end
+end

--- a/spec/lutaml/model/root_mappings_spec.rb
+++ b/spec/lutaml/model/root_mappings_spec.rb
@@ -280,14 +280,17 @@ RSpec.describe "RootMapping" do
         }
       end
 
-      it "raises error" do
+      it "parses, then reports the missing `collection: true` on validate" do
+        obj = nil
         expect do
-          RootMappingSpec::CeramicCollectionWithoutCollectionTrue.public_send(
-            :"from_#{format}", input
-          )
-        end.to raise_error(
-          Lutaml::Model::CollectionTrueMissingError,
-          "May be `collection: true` is missing for `ceramics` in RootMappingSpec::CeramicCollectionWithoutCollectionTrue",
+          obj = RootMappingSpec::CeramicCollectionWithoutCollectionTrue
+            .public_send(:"from_#{format}", input)
+        end.not_to raise_error
+
+        expect(obj.validate).to include(
+          an_object_having_attributes(
+            message: "May be `collection: true` is missing for `ceramics` in RootMappingSpec::CeramicCollectionWithoutCollectionTrue",
+          ),
         )
       end
     end

--- a/spec/lutaml/model/serializable_validation_spec.rb
+++ b/spec/lutaml/model/serializable_validation_spec.rb
@@ -88,4 +88,183 @@ RSpec.describe Lutaml::Model::Serializable do
       expect { valid_instance.validate! }.not_to raise_error
     end
   end
+
+  # Regression: valid_pattern! must short-circuit non-string values instead of
+  # feeding nil / UninitializedClass to Regexp#match? (which raises TypeError).
+  describe "pattern with absent or nil values" do
+    it "does not raise when an optional patterned string is omitted" do
+      instance = TestSerializable.new(name: "Alice", age: [30])
+
+      errors = nil
+      expect { errors = instance.validate }.not_to raise_error
+      expect(errors).to be_none do |e|
+        e.is_a?(Lutaml::Model::PatternNotMatchedError)
+      end
+    end
+
+    it "skips nil elements in a patterned collection" do
+      klass = Class.new(Lutaml::Model::Serializable) do
+        attribute :codes, :string, collection: true, pattern: /\A[A-Z]+\z/
+        key_value { map "codes", to: :codes }
+      end
+
+      expect(klass.new(codes: ["ABC", nil, "DEF"]).validate).to be_empty
+      expect(klass.new(codes: ["ABC", "bad"]).validate).not_to be_empty
+    end
+
+    # valid_collection! must return truthy on success so validate_value!'s &&
+    # chain still reaches pattern validation for a bounded-range collection.
+    it "still runs pattern validation after a valid bounded-range collection" do
+      klass = Class.new(Lutaml::Model::Serializable) do
+        attribute :codes, :string, collection: 1..2, pattern: /\A[A-Z]+\z/
+        key_value { map "codes", to: :codes }
+      end
+
+      expect(klass.new(codes: ["ABC"]).validate).to be_empty
+      expect(klass.new(codes: ["bad"]).validate)
+        .to include(an_instance_of(Lutaml::Model::PatternNotMatchedError))
+    end
+  end
+
+  # Regression: enum (values:) on a collection must validate each element,
+  # not compare the whole coerced collection against the allowed set.
+  describe "enum on collection attributes" do
+    let(:klass) do
+      Class.new(Lutaml::Model::Serializable) do
+        attribute :tags, :string, collection: true, values: %w[a b c]
+        key_value { map "tags", to: :tags }
+      end
+    end
+
+    it "accepts a single valid value coerced into the collection" do
+      expect(klass.new(tags: ["a"]).validate).to be_empty
+    end
+
+    it "accepts multiple valid values" do
+      expect(klass.new(tags: %w[a b]).validate).to be_empty
+    end
+
+    it "rejects a collection containing a disallowed element" do
+      expect(klass.new(tags: %w[a z]).validate)
+        .to include(an_instance_of(Lutaml::Model::InvalidValueError))
+    end
+  end
+
+  # Regression: a collection of nested models must recurse into every element
+  # so a grandchild's own validation errors surface on the parent.
+  describe "nested model collection validation" do
+    let(:child_class) do
+      Class.new(Lutaml::Model::Serializable) do
+        attribute :status, :string, values: %w[ok fine]
+        key_value { map "status", to: :status }
+      end
+    end
+
+    let(:parent_class) do
+      child = child_class
+      Class.new(Lutaml::Model::Serializable) do
+        attribute :items, child, collection: true
+        key_value { map "items", to: :items }
+      end
+    end
+
+    it "surfaces an invalid grandchild in a model collection" do
+      parent = parent_class.new(
+        items: [child_class.new(status: "ok"), child_class.new(status: "BAD")],
+      )
+
+      expect(parent.validate)
+        .to include(an_instance_of(Lutaml::Model::InvalidValueError))
+    end
+
+    it "returns no errors when every model element is valid" do
+      parent = parent_class.new(
+        items: [child_class.new(status: "ok"), child_class.new(status: "fine")],
+      )
+
+      expect(parent.validate).to be_empty
+    end
+  end
+
+  # Regression: a Collection is itself a model, so a nested one must be
+  # validated as one — iterating its elements alone skips collection-level
+  # rules such as validates_min_count.
+  describe "nested collection-level validation" do
+    let(:item_class) do
+      Class.new(Lutaml::Model::Serializable) do
+        attribute :name, :string
+      end
+    end
+
+    let(:collection_class) do
+      item = item_class
+      Class.new(Lutaml::Model::Collection) do
+        instances :items, item
+        validates_min_count 2
+      end
+    end
+
+    let(:holder_class) do
+      collection = collection_class
+      Class.new(Lutaml::Model::Serializable) do
+        attribute :items, collection
+      end
+    end
+
+    it "surfaces a nested collection's collection-level rule violation" do
+      holder = holder_class.new(
+        items: collection_class.new([item_class.new(name: "a")]),
+      )
+
+      expect(holder.validate)
+        .to include(an_instance_of(Lutaml::Model::ValidationFailedError))
+    end
+
+    it "returns no errors when the nested collection satisfies its rules" do
+      holder = holder_class.new(
+        items: collection_class.new(
+          [item_class.new(name: "a"), item_class.new(name: "b")],
+        ),
+      )
+
+      expect(holder.validate).to be_empty
+    end
+  end
+
+  # Regression: #validate is a public override point, so recursing into a child
+  # must not hand it arguments its own signature does not declare.
+  describe "nested model overriding #validate with zero arity" do
+    let(:child_class) do
+      Class.new(Lutaml::Model::Serializable) do
+        attribute :status, :string
+
+        def validate
+          super << "child checked #{status}"
+        end
+      end
+    end
+
+    let(:parent_class) do
+      child = child_class
+      Class.new(Lutaml::Model::Serializable) do
+        attribute :item, child
+        attribute :items, child, collection: true
+      end
+    end
+
+    it "surfaces errors from a zero-arity override on a single child" do
+      parent = parent_class.new(item: child_class.new(status: "one"))
+
+      expect(parent.validate).to include("child checked one")
+    end
+
+    it "surfaces errors from a zero-arity override on every element" do
+      parent = parent_class.new(
+        items: [child_class.new(status: "a"), child_class.new(status: "b")],
+      )
+
+      expect(parent.validate)
+        .to include("child checked a", "child checked b")
+    end
+  end
 end

--- a/spec/lutaml/model/serializable_validation_spec.rb
+++ b/spec/lutaml/model/serializable_validation_spec.rb
@@ -267,4 +267,118 @@ RSpec.describe Lutaml::Model::Serializable do
         .to include("child checked a", "child checked b")
     end
   end
+
+  describe "models that reference themselves" do
+    let(:node_class) do
+      Class.new(Lutaml::Model::Serializable) do
+        def self.name = "ValidationCycleSpec::Node"
+        attribute :name, :string, values: %w[ok]
+        attribute :parent, self
+        attribute :children, self, collection: true
+      end
+    end
+
+    it "validates a self-reference held in a collection" do
+      node = node_class.new(name: "ok")
+      node.children = [node]
+
+      expect { node.validate }.not_to raise_error
+      expect(node.validate).to be_empty
+    end
+
+    it "validates a self-reference held in a single attribute" do
+      node = node_class.new(name: "ok")
+      node.parent = node
+
+      expect { node.validate }.not_to raise_error
+      expect(node.validate).to be_empty
+    end
+
+    it "reports a cycled model's own errors exactly once" do
+      node = node_class.new(name: "bad")
+      node.children = [node]
+
+      expect(node.validate).to contain_exactly(
+        an_instance_of(Lutaml::Model::InvalidValueError),
+      )
+    end
+
+    it "still validates the same child twice when it is not a cycle" do
+      child = node_class.new(name: "bad")
+      parent = node_class.new(name: "ok", children: [child, child])
+
+      expect(parent.validate.size).to eq(2)
+    end
+
+    it "raises from validate! on a cycled model with a real error" do
+      node = node_class.new(name: "bad")
+      node.children = [node]
+
+      expect { node.validate! }.to raise_error(Lutaml::Model::ValidationError)
+    end
+
+    # The guard tracks visited models in thread-local state, so it has to clean
+    # up on the way out even when validate! raises.
+    it "leaves no thread-local state behind when validate! raises" do
+      node = node_class.new(name: "bad")
+      node.children = [node]
+
+      begin
+        node.validate!
+      rescue Lutaml::Model::ValidationError
+        nil
+      end
+
+      expect(Thread.current[Lutaml::Model::Validation::VALIDATING_KEY])
+        .to be_nil
+    end
+
+    # A downstream #validate override runs above the guard, so the cycle has
+    # to be cut before the override is entered, not inside it.
+    it "runs a downstream validate override once on a cycle" do
+      klass = Class.new(Lutaml::Model::Serializable) do
+        def self.name = "ValidationCycleSpec::Overrider"
+        attribute :children, self, collection: true
+
+        def validate
+          super << "override ran"
+        end
+      end
+      node = klass.new
+      node.children = [node]
+
+      expect(node.validate.count { |e| e == "override ran" }).to eq(1)
+    end
+
+    it "keeps the guard isolated between threads" do
+      node = node_class.new(name: "ok")
+      node.children = [node]
+
+      results = Array.new(4) { Thread.new { node.validate } }.map(&:value)
+
+      expect(results).to all(be_empty)
+    end
+  end
+
+  describe "collections that reference themselves" do
+    let(:collection_class) do
+      Class.new(Lutaml::Model::Collection) do
+        def self.name = "ValidationCycleSpec::Items"
+        instances :items, TestSerializable
+
+        validate_collection do |collection, errors, _ctx|
+          errors.add(:collection, "ran #{collection.count}")
+        end
+      end
+    end
+
+    # The rules used to run once inside the guarded pipeline and again from the
+    # outer call, because #validate was overridden above the guard.
+    it "runs its collection-level rules exactly once" do
+      collection = collection_class.new([])
+
+      ran = collection.validate.select { |e| e.to_s.include?("ran ") }
+      expect(ran.size).to eq(1)
+    end
+  end
 end

--- a/spec/lutaml/turtle/transform_spec.rb
+++ b/spec/lutaml/turtle/transform_spec.rb
@@ -375,7 +375,7 @@ RSpec.describe Lutaml::Turtle::Transform do
       instance = UriRefModel.new(name: "test", related: ["skos:other"])
       turtle = instance.to_turtle
       restored = UriRefModel.from_turtle(turtle)
-      expect(restored.related).to eq("skos:other")
+      expect(restored.related).to eq(["skos:other"])
     end
 
     it "handles full URI values without prefix" do
@@ -390,7 +390,7 @@ RSpec.describe Lutaml::Turtle::Transform do
                                  related: ["http://example.org/foo"])
       turtle = instance.to_turtle
       restored = UriRefModel.from_turtle(turtle)
-      expect(restored.related).to eq("http://example.org/foo")
+      expect(restored.related).to eq(["http://example.org/foo"])
     end
   end
 


### PR DESCRIPTION
Fixes #185.

Attributes now enforce their declared cardinality. No `collection:` means one
value; giving it several is a violation.

### Where the error surfaces (deviation from #185)

#185 says "it should raise an error". This reports at `#validate` instead of at
parse, and `#validate!` raises `ValidationError`. The wording still holds, the
timing differs.

Parsing keeps every value it was given. Nothing is discarded, so the violation
stays visible and `#validate` reports it. Raising at parse would throw the
document away before anyone could inspect it, and it would break every caller
that parses first and checks later. Reporting at validate is non-breaking and
matches how every other rule in this library already works.

Flagging for the issue author to confirm.

### Behavior changes

- Nested models run their own validations now. Checks that never ran will start
  reporting.
- A singular reader can return an array before you call `#validate`.
- Enum `value?` shorthands answer `false` while an attribute is over-counted.
- Assigning a scalar to a `collection:` attribute wraps it in a collection.

All four are in `docs/_pages/breaking-changes.adoc`.

### The xmi benchmark gate was measuring the wrong thing

The gate flagged +7% allocations. There is no regression.

- Real allocations are identical between this branch and main. Five paired runs,
  ratios 0.99988 to 1.00012. Two fixtures are bit-identical.
- The new branches never run during an xmi parse. `coerce_to_collection?` fires
  0 times, the three model_transform guards 0 times.
- `bench_common.rb` measured `ObjectSpace.count_objects[:TOTAL]`, which counts
  heap slots, not allocations. It only moves when Ruby adds a page.
- On identical code, six runs gave 381515, 98245, 98244, 98242, 98245, 98236 —
  a 3.9x spread, under-counting the true 400k by 4x. `large` fails its own 1.05
  gate against itself at 1.0562.
- Switched to `GC.stat[:total_allocated_objects]`. Same six runs: 400003 then
  400001 five times. A 1.000005x spread.

The workflow runs the PR's copy of the harness for both sides, so both readings
change together. Stored baselines feed only the push-to-main job, not this gate.

All five downstream gates share this code. Thresholds tuned loose to absorb the
old noise stay satisfied. If a non-xmi gate goes red after this, it means a
pre-existing regression stopped being hidden — this PR did not cause it.
