### PR TITLE
fix(opal): make Module#prepend idempotent (cleaner alternative to #716)

### DIFF
--- a/lib/lutaml/model/runtime_compatibility.rb
+++ b/lib/lutaml/model/runtime_compatibility.rb
@@ -123,4 +123,22 @@ if Lutaml::Model::RuntimeCompatibility.opal?
       end
     end
   end
+
+  # Opal's Module#prepend raises "Prepending a module multiple times
+  # is not supported" when a module is already in the target's ancestor
+  # chain. MRI's prepend is idempotent in that case (no-op, no error).
+  #
+  # Our top-level lib files (lib/lutaml/model.rb, lib/lutaml/xml.rb)
+  # can be re-evaluated under Opal's eager loader, which would trigger
+  # the raise on the second pass. Align Opal with MRI by making prepend
+  # a no-op when the module is already present.
+  class ::Module
+    unless method_defined?(:__lm_original_prepend__)
+      alias_method :__lm_original_prepend__, :prepend
+
+      def prepend(mod)
+        __lm_original_prepend__(mod) unless self <= mod
+      end
+    end
+  end
 end

--- a/spec/lutaml/model/opal_smoke_spec.rb
+++ b/spec/lutaml/model/opal_smoke_spec.rb
@@ -114,4 +114,18 @@ RSpec.describe "Opal compatibility", if: RUBY_ENGINE == "opal" do
     adapter = Lutaml::Model::AdapterResolver.detect_xml_adapter
     expect(adapter).to eq(:oga)
   end
+
+  # Opal's Module#prepend raises "Prepending a module multiple times
+  # is not supported" on the second call; runtime_compatibility.rb
+  # patches it to match MRI's idempotent behavior. Top-level lib files
+  # (lib/lutaml/model.rb, lib/lutaml/xml.rb) rely on this when Opal's
+  # eager loader re-evaluates them.
+  it "Module#prepend is idempotent under Opal" do
+    mod = Module.new
+    klass = Class.new
+    klass.prepend(mod)
+
+    expect { klass.prepend(mod) }.not_to raise_error
+    expect(klass.ancestors.count(mod)).to eq(1)
+  end
 end

--- a/spec/lutaml/model/runtime_compatibility_spec.rb
+++ b/spec/lutaml/model/runtime_compatibility_spec.rb
@@ -33,4 +33,29 @@ RSpec.describe Lutaml::Model::RuntimeCompatibility do
         .to eq(error_class)
     end
   end
+
+  # lib/lutaml/model.rb and lib/lutaml/xml.rb re-evaluate their top-level
+  # prepend calls when Opal's eager loader processes them more than once.
+  # Opal's Module#prepend raises "Prepending a module multiple times is
+  # not supported" in that case; runtime_compatibility.rb aligns Opal
+  # with MRI's idempotent behavior. MRI has been idempotent since 2.0,
+  # so the spec applies to both runtimes.
+  describe "Module#prepend idempotency" do
+    it "is a no-op when the module is already in the ancestor chain" do
+      mod = Module.new
+      klass = Class.new
+      klass.prepend(mod)
+
+      expect { klass.prepend(mod) }.not_to raise_error
+      expect(klass.ancestors.count(mod)).to eq(1)
+    end
+
+    it "still prepends when the module is not yet present" do
+      mod = Module.new
+      klass = Class.new
+
+      expect { klass.prepend(mod) }.not_to raise_error
+      expect(klass.ancestors).to include(mod)
+    end
+  end
 end


### PR DESCRIPTION
## What

Cleaner alternative to #716 — same intent (fix `Prepending a module multiple times is not supported` under Opal), different implementation.

## Audit of #716

| Concern | #716 | This PR |
|---|---|---|
| Adapter under Opal | reverted to `:rexml` (unintentional — branch was based on pre-#715 main) | unchanged from main (`:oga`) |
| `Lutaml::Model.opal?` accessor | removed (same — pre-#715 base) | unchanged from main |
| Idempotency mechanism | 8 `unless ancestors.include?(…)` guards sprinkled across `lib/lutaml/model.rb` + `lib/lutaml/xml.rb` | one `Module#prepend` patch in `runtime_compatibility.rb`, no call-site changes |
| DRY | violated (8 near-identical guards) | honored (single source of truth) |
| OCP | new top-level prepends need their own guard | new top-level prepends inherit the fix automatically |
| MECE | prepend idempotency concern spread across both files | lives alongside existing Opal/MRI parity stubs (`Mutex`, `Thread`, `WeakRef`) in `runtime_compatibility.rb` |
| Spec coverage | none in the PR | MRI spec + Opal smoke spec |

The `:rexml` and `Lutaml::Model.opal?` reversions in #716 are spurious — that branch was created from `acc7424a` (pre-#715) and the diff reflects the pre-#715 baseline, not deliberate reversions. After rebase they would be dropped anyway.

## What changes

- `lib/lutaml/model/runtime_compatibility.rb` — Opal-only `Module#prepend` patch. Aliases the original, skips when `self <= mod` (module already in ancestor chain). Matches MRI's documented idempotent behavior. MRI path is unchanged.
- `spec/lutaml/model/runtime_compatibility_spec.rb` — two MRI specs covering both branches (no-op when present, prepends when absent).
- `spec/lutaml/model/opal_smoke_spec.rb` — one Opal smoke spec so the Opal CI verifies the fix end-to-end.

## Why one patch beats eight guards

The top-level prepends in `lib/lutaml/model.rb` and `lib/lutaml/xml.rb` re-execute when Opal's eager loader processes those files more than once. Guarding each call works but:
- spreads the Opal-parity concern across every prepend site
- requires every future top-level prepend to remember the guard
- duplicates the same `unless ancestors.include?(...)` pattern 8 times

Patching `Module#prepend` once in the Opal compat layer matches the existing pattern (`Mutex`, `ConditionVariable`, `Thread`, `WeakRef` stubs all live there) and fixes all current and future cases.

## Verification

```
bundle exec rake spec:opal                                              # 18 examples, 0 failures
bundle exec rspec spec/lutaml/model/runtime_compatibility_spec.rb       # 5 examples, 0 failures
bundle exec rubocop lib/lutaml/model/runtime_compatibility.rb           # no offenses
```

## Test plan

- [x] Opal smoke specs pass locally
- [x] MRI specs pass locally
- [x] Rubocop clean
- [ ] CI Opal workflow green
- [ ] CI rake workflow green

## Relationship to #716

Recommend closing #716 in favor of this PR. Same fix, cleaner implementation, with specs.
