### PR TITLE
ci: add js-sync and js-pr-check workflows for lutaml-model-js

### DIFF
--- a/.github/workflows/js-pr-check.yml
+++ b/.github/workflows/js-pr-check.yml
@@ -1,0 +1,102 @@
+name: js-pr-check
+
+# On PRs that touch lib/, Gemfile, Rakefile, or .gitmodules, fire a
+# repository_dispatch at lutaml-model-js so it builds a test artifact
+# and runs the JS smoke tests against the PR head. Does NOT publish.
+# Catches JS regressions before the Ruby PR merges.
+#
+# PAT token: LUTAML_CI_PAT_TOKEN must have `repo` scope on
+# lutaml/lutaml-model-js. Note that PRs from forks of lutaml/lutaml-model
+# will not have access to the PAT (GitHub masks secrets on fork PRs);
+# those builds will be skipped — contributors from forks should run
+# `gh workflow run js-pr-check` manually after pushing to a branch on
+# the origin repo.
+
+on:
+  pull_request:
+    paths:
+      - 'lib/**'
+      - 'Gemfile'
+      - 'gemspec'
+      - 'Rakefile'
+      - '.gitmodules'
+      - '.github/workflows/js-pr-check.yml'
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to test (for manual reruns).
+        required: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == 'lutaml/lutaml-model' }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Need the PR head, not the merge commit, so the SHA the JS
+          # build pulls matches what reviewers see.
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+
+      - name: Resolve PR inputs
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload.inputs?.pr_number
+              ? parseInt(context.payload.inputs.pr_number, 10)
+              : context.payload.pull_request?.number;
+            if (!prNumber) {
+              core.setFailed("No PR number available");
+              return;
+            }
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+            core.setOutput("number", String(prNumber));
+            core.setOutput("sha", pr.head.sha);
+            core.setOutput("ref", pr.head.ref);
+            core.setOutput("repo", pr.head.repo.full_name);
+
+      - name: Notify lutaml-model-js
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.LUTAML_CI_PAT_TOKEN }}
+          repository: lutaml/lutaml-model-js
+          event-type: js-pr-check
+          client-payload: |-
+            {
+              "pr_number": ${{ steps.pr.outputs.number }},
+              "sha": "${{ steps.pr.outputs.sha }}",
+              "ref": "${{ steps.pr.outputs.ref }}",
+              "repo": "${{ steps.pr.outputs.repo }}"
+            }
+
+      - name: Annotate PR with build link
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = [
+              "### JS build check",
+              "",
+              "Triggered [`js-pr-check`]",
+              `(https://github.com/lutaml/lutaml-model-js/actions/workflows/pr-check.yml)`,
+              "against this PR's head (`" + context.payload.pull_request.head.sha.substring(0, 7) + "`).",
+              "",
+              "The result will appear as a `lutaml-model-js / pr-check` status check",
+              "on this PR once the workflow run completes.",
+            ].join("\n");
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body,
+            });

--- a/.github/workflows/js-sync.yml
+++ b/.github/workflows/js-sync.yml
@@ -1,0 +1,51 @@
+name: js-sync
+
+# On every push to main, fire a repository_dispatch at lutaml-model-js
+# so it rebuilds and publishes under the npm `next` dist-tag. This
+# closes the dev-build gap: JS consumers can track Ruby main without
+# waiting for a stable gem release.
+#
+# PAT token: LUTAML_CI_PAT_TOKEN must have `repo` scope on
+# lutaml/lutaml-model-js. Same token already used by release.yml.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: Specific SHA to build from (defaults to HEAD on main).
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Resolve SHA
+        id: sha
+        run: |
+          if [ -n "${{ github.event.inputs.sha }}" ]; then
+            echo "sha=${{ github.event.inputs.sha }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "sha=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Notify lutaml-model-js
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.LUTAML_CI_PAT_TOKEN }}
+          repository: lutaml/lutaml-model-js
+          event-type: js-sync-main
+          client-payload: |-
+            {
+              "sha": "${{ steps.sha.outputs.sha }}",
+              "ref": "${{ github.ref }}",
+              "ruby_ref": "main"
+            }


### PR DESCRIPTION
## What

Cross-repo wiring that keeps [@lutaml/lutaml-model](https://github.com/lutaml/lutaml-model-js) (the npm package in `lutaml/lutaml-model-js`) in sync with this repo.

Two new workflows, both using `peter-evans/repository-dispatch@v3` with the existing `LUTAML_CI_PAT_TOKEN`:

### `js-sync.yml` — dev build on every main push

Fires `js-sync-main` on push to `main`. The receiver in `lutaml-model-js` rebuilds from the pushed SHA and publishes under the npm `next` dist-tag (does NOT touch `latest`). Closes the dev-build gap: JS consumers can `npm install @lutaml/lutaml-model@next` to track Ruby main without waiting for a stable gem release.

Also exposes a `workflow_dispatch` input for manually triggering a build from a specific SHA.

### `js-pr-check.yml` — JS regression check on PRs

Fires `js-pr-check` on PRs that touch `lib/`, `Gemfile`, `gemspec`, `Rakefile`, `.gitmodules`, or this workflow. The receiver builds both flavors (self-contained + external-opal) against the PR head SHA, runs the JS smoke tests, and does NOT publish. Catches JS regressions before the Ruby PR merges.

Also leaves a comment on the PR linking to the JS workflow run so reviewers can find the result.

Skipped for fork PRs (GitHub masks PATs on fork PRs for security). Contributors from forks can re-run via `workflow_dispatch` after pushing to an origin branch.

## Why

Currently JS only updates on stable Ruby releases. Two problems:

1. **Dev lag** — JS consumers wanting latest features have to wait for a Ruby release cut.
2. **Silent regressions** — a Ruby PR that breaks the Opal build isn't caught until release time, when it's much harder to bisect.

This closes both gaps. The `next` dist-tag pattern is standard npm practice (React, TypeScript, etc. all use it for tracking main).

## Dependencies

- Receiver must land first: [lutaml/lutaml-model-js#5](https://github.com/lutaml/lutaml-model-js/pull/5). Otherwise the new `repository_dispatch` events would 404 against lutaml-model-js's current workflow set.
- Build correctness depends on lutaml-model `main` being at `4c16cbe9` or later (post PR #721 `Module#prepend` idempotency + PR #722 dual-adapter support). Both are already on `main`.

## PAT scope

`LUTAML_CI_PAT_TOKEN` needs `repo` scope on `lutaml/lutaml-model-js`. Same token is already used by the existing release chain (`metanorma/ci/rubygems-release.yml` fires `do-release` to the same target).

## Test plan

- [ ] After both PRs merge: push a trivial commit to lutaml-model `main` → `js-sync.yml` fires → lutaml-model-js publishes `@next`
- [ ] Open a test PR touching `lib/` → `js-pr-check.yml` fires → lutaml-model-js runs `pr-check.yml` without publishing
- [ ] Verify the PR-comment annotation includes a working link to the JS run
