### PR TITLE
fix(opal): unblock JS bundle runtime — block-form class_eval + boot entry

### DIFF
--- a/lib/compat/opal/js_bundle_entry.rb
+++ b/lib/compat/opal/js_bundle_entry.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# JS bundle entry point. Pulls in the Opal-only compat shims and boot
+# files BEFORE lutaml/model so that moxml's adapter constants, the
+# String/Encoding/YAML/Array#pack patches, and the eager-loaded
+# Moxml::* / Lutaml::* constants are all in place by the time
+# lib/lutaml/model.rb runs.
+#
+# Used by scripts/build.rb as the bundle ENTRY (instead of
+# "lutaml/model" directly) so the JS bundle mirrors the load order
+# that lutaml-model's Rakefile applies for `rake spec:opal`.
+
+if RUBY_ENGINE == "opal"
+  # 0. runtime_compatibility first: it stubs Mutex/ConditionVariable/
+  #    Thread/WeakRef and patches Module#prepend for Opal. Oga's LRU
+  #    and other gems reference Mutex at file-load time, so this must
+  #    run before any gem that touches thread-safety primitives.
+  require "lutaml/model/runtime_compatibility"
+
+  # 1. stdlib shims: String/Encoding/StringIO + Array#pack + nodejs/yaml
+  require "rexml_compat"
+  require "yaml_compat"
+
+  # 2. forks' Opal-aware conditionals select the pure-Ruby lexer
+  require "oga"
+  require "ll/setup"
+
+  # 3. eager-load boots (Opal ignores autoload)
+  require "moxml_boot"
+  require "lutaml_model_boot"
+end
+
+# 4. the actual entry point
+require "lutaml/model"
+require "lutaml/xml"

--- a/lib/lutaml/model/global_context.rb
+++ b/lib/lutaml/model/global_context.rb
@@ -324,10 +324,13 @@ context_id = nil)
       end
 
       class << self
-        # Performance: Define delegation methods without closures
-        # Using class_eval with string avoids closure allocation per call
+        # Block form: avoids Opal's runtime string parsing requirement
+        # (MRI's class_eval(string) needs `require 'opal-parser'` at
+        # runtime under Opal, which isn't bundled). Closures are
+        # allocated once at file load, not per call, so the perf cost
+        # over the previous string form is negligible.
 
-        class_eval <<-RUBY, __FILE__, __LINE__ + 1
+        class_eval do
           def registry
             instance.registry
           end
@@ -440,7 +443,7 @@ context_id = nil)
           def namespace_register_map
             instance.namespace_register_map
           end
-        RUBY
+        end
       end
     end
   end

--- a/lib/lutaml/xml.rb
+++ b/lib/lutaml/xml.rb
@@ -11,6 +11,15 @@ require_relative "model"
 # XML requires moxml for parsing
 require "moxml"
 
+# Under Opal, moxml's autoloads don't fire (Opal ignores autoload).
+# Pull in the eager-load boot that ships at lib/compat/opal/moxml_boot.rb
+# so Moxml::Adapter::{Oga,Rexml} etc. are actually defined. Without
+# this, `Config.adapter = :oga` later fails with
+# `NameError: uninitialized constant Moxml::Adapter::Oga`.
+if Lutaml::Model.opal?
+  require "moxml_boot"
+end
+
 module Lutaml
   module Xml
     # Error module for XML-specific errors


### PR DESCRIPTION
## What

Three coupled changes that unblock the runtime of the @lutaml/lutaml-model JS bundle (https://github.com/lutaml/lutaml-model-js/pull/10).

## Root causes fixed

1. **`class_eval <<-RUBY` requires opal-parser under Opal** — `lib/lutaml/model/global_context.rb` used the string form for a perf optimization. Opal's `class_eval(string)` needs `opal-parser` at runtime (~500 KB, slow). Switched to block form. Closures are allocated once at file load, not per call, so the perf comment on the string form was overstated.

2. **`Moxml::Adapter::Oga` undefined at runtime** — moxml's `lib/moxml.rb` autoloads the adapter namespaces, but Opal ignores autoload. Without `require "moxml_boot"` the constants never resolve and `Config.adapter = :oga` raises NameError. `lib/lutaml/xml.rb` now eagerly loads moxml_boot under Opal.

3. **No bundle entry that wires up all the Opal-only boots in the right order** — added `lib/compat/opal/js_bundle_entry.rb` as the single entry point the JS bundle compiles. Order: `runtime_compatibility` (Mutex/Thread/WeakRef stubs) → `rexml_compat`/`yaml_compat` → forks' `oga`/`ll/setup` → `moxml_boot`/`lutaml_model_boot` → `lutaml/model` + `lutaml/xml`. Mirrors the load order that the Rakefile applies for `rake spec:opal`.

## Verification

```
bundle exec rake spec:opal                                              # 26 examples, 0 failures
bundle exec rspec spec/lutaml/model/runtime_compatibility_spec.rb       # 5 examples, 0 failures
bundle exec rspec spec/lutaml/xml/adapter/                              # 148 examples, 0 failures
```

JS bundle (paired with [lutaml-model-js#10](https://github.com/lutaml/lutaml-model-js/pull/10)):
- Build: 4945 KiB self-contained, 3968 KiB external (4.9 MB / 4 MB — both XML adapters ship in the bundle)
- Smoke test: 455 lutaml/* modules registered, Opal global exposed, both variants pass

## Test plan

- [x] Ruby-side: spec:opal 26 examples, 0 failures
- [x] Ruby-side: MRI adapter specs 148 examples, 0 failures
- [x] JS bundle smoke test passes locally with both self-contained and external variants
- [ ] CI: opal.yml green
- [ ] CI: rake.yml green
