### PR TITLE
fix: OrderedApplier honors raw: :element on mixed_content mappings

### DIFF
--- a/docs/_guides/xml-mapping.adoc
+++ b/docs/_guides/xml-mapping.adoc
@@ -1172,6 +1172,27 @@ class MultiFragment < Lutaml::Model::Serializable
   end
 end
 ----
+
+`raw: :element` also works on `mixed_content` and `ordered` parents. The
+captured string is emitted verbatim regardless of which applier dispatches the
+rule. This matters for round-trip serialization: when a model is parsed from
+XML, `element_order` is populated and the `OrderedApplier` path takes over --
+without the `raw: :element` short-circuit, each captured fragment (which already
+contains its own wrapper tag) would be wrapped again, producing
+`<fragment><fragment>...</fragment></fragment>`.
+
+[source,ruby]
+----
+class WordParagraph < Lutaml::Model::Serializable
+  attribute :runs, :string, collection: true
+
+  xml do
+    element "p"
+    mixed_content
+    map_element "oMath", to: :runs, raw: :element
+  end
+end
+----
 ====
 
 ===== `raw: :content` on `map_element` -- inner content capture

--- a/lib/lutaml/xml/transformation/ordered_applier.rb
+++ b/lib/lutaml/xml/transformation/ordered_applier.rb
@@ -81,6 +81,12 @@ model_class, register_id)
         # @param options [Hash] Options
         # @yield Block to create element for value
         def apply_element_rule_single(parent:, rule:, value:, options:)
+          # raw: :element — value is a complete XML element string, inject directly
+          if rule.raw == :element
+            add_raw_element_fragments(parent, value)
+            return
+          end
+
           # Extract parent's namespace info for element_form_default inheritance
           parent_ns_class = parent.namespace_class
           # Only pass element_form_default VALUE if it was explicitly set

--- a/spec/lutaml/model/raw_element_spec.rb
+++ b/spec/lutaml/model/raw_element_spec.rb
@@ -87,6 +87,50 @@ module RawElementSpec
     end
   end
 
+  # mixed_content parent with a collection raw: :element mapping.
+  # Round-trip dispatches through OrderedApplier#apply_element_rule_single
+  # (see issue #727 — previously double-wrapped each fragment).
+  class MixedContentRawCollectionContainer < Lutaml::Model::Serializable
+    attribute :name, :string
+    attribute :fragments, :string, collection: true
+
+    xml do
+      element "container"
+      mixed_content
+      map_element "name", to: :name
+      map_element "fragment", to: :fragments, raw: :element
+    end
+  end
+
+  # mixed_content parent with a single (non-collection) raw: :element mapping.
+  # Dispatches through OrderedApplier -> :apply_rule -> RuleApplier#apply_rule,
+  # which already had the short-circuit. Kept as a regression guard.
+  class MixedContentRawSingleContainer < Lutaml::Model::Serializable
+    attribute :name, :string
+    attribute :embedded, :string
+
+    xml do
+      element "container"
+      mixed_content
+      map_element "name", to: :name
+      map_element "foreign", to: :embedded, raw: :element
+    end
+  end
+
+  # ordered (no mixed_content) parent with a collection raw: :element mapping.
+  # Same dispatch path as mixed_content; same bug class.
+  class OrderedRawCollectionContainer < Lutaml::Model::Serializable
+    attribute :name, :string
+    attribute :fragments, :string, collection: true
+
+    xml do
+      element "container"
+      ordered
+      map_element "name", to: :name
+      map_element "fragment", to: :fragments, raw: :element
+    end
+  end
+
   RSpec.describe "map_element raw: :element" do
     describe "deserialization" do
       describe "foreign namespace element capture" do
@@ -375,6 +419,87 @@ module RawElementSpec
           expect(doc2.fragments.length).to eq(2)
           expect(doc2.fragments[0]).to include("first")
           expect(doc2.fragments[1]).to include("second")
+        end
+      end
+
+      # Regression for issue #727: OrderedApplier#apply_element_rule_single
+      # was missing the raw: :element short-circuit, so each captured fragment
+      # string (which already contains its own <fragment> wrapper) got wrapped
+      # again, producing <fragment><fragment>...</fragment></fragment>.
+      describe "round-trip with mixed_content + raw: :element collection" do
+        let(:mixed_collection_xml) do
+          <<~XML
+            <container>
+              before
+              <name>multi</name>
+              <fragment id="1">first</fragment>
+              <fragment id="2"><nested>second</nested></fragment>
+              after
+            </container>
+          XML
+        end
+
+        it "does not double-wrap fragments on round-trip" do
+          doc = MixedContentRawCollectionContainer.from_xml(mixed_collection_xml)
+          output = doc.to_xml
+
+          expect(output).not_to include("<fragment><fragment")
+          expect(output).to include('id="1"')
+          expect(output).to include("first")
+          expect(output).to include('id="2"')
+          expect(output).to include("<nested>second</nested>")
+        end
+
+        it "is stable across repeated round-trips" do
+          doc = MixedContentRawCollectionContainer.from_xml(mixed_collection_xml)
+          once = MixedContentRawCollectionContainer.from_xml(doc.to_xml)
+          twice = MixedContentRawCollectionContainer.from_xml(once.to_xml)
+
+          expect(twice.fragments.length).to eq(2)
+          expect(twice.fragments[0]).to include("first")
+          expect(twice.fragments[1]).to include("<nested>second</nested>")
+        end
+      end
+
+      # Regression guard: the non-collection path under mixed_content dispatches
+      # through :apply_rule -> RuleApplier#apply_rule, which already had the
+      # short-circuit. Lock in the working behavior.
+      describe "round-trip with mixed_content + raw: :element single" do
+        let(:mixed_single_xml) do
+          '<container>before<name>x</name><foreign attr="v"><child>c</child></foreign>after</container>'
+        end
+
+        it "emits the foreign element verbatim without wrapping" do
+          doc = MixedContentRawSingleContainer.from_xml(mixed_single_xml)
+          output = doc.to_xml
+
+          expect(output).not_to include("<foreign><foreign")
+          expect(output).to include('attr="v"')
+          expect(output).to include("<child>c</child>")
+        end
+      end
+
+      # Same dispatch path (OrderedApplier) as mixed_content; same bug class.
+      describe "round-trip with ordered + raw: :element collection" do
+        let(:ordered_collection_xml) do
+          <<~XML
+            <container>
+              <name>multi</name>
+              <fragment id="1">first</fragment>
+              <fragment id="2">second</fragment>
+            </container>
+          XML
+        end
+
+        it "does not double-wrap fragments on round-trip" do
+          doc = OrderedRawCollectionContainer.from_xml(ordered_collection_xml)
+          output = doc.to_xml
+
+          expect(output).not_to include("<fragment><fragment")
+          expect(output).to include('id="1"')
+          expect(output).to include("first")
+          expect(output).to include('id="2"')
+          expect(output).to include("second")
         end
       end
 


### PR DESCRIPTION
## Summary

- Adds the missing `raw: :element` short-circuit to `OrderedApplier#apply_element_rule_single`, mirroring the existing branch in `RuleApplier#apply_element_rule`. Without it, round-trip serialization on `mixed_content` / `ordered` parents wrapped each captured fragment string in an extra element, producing `<fragment><fragment>…</fragment></fragment>`.
- Adds round-trip specs covering `mixed_content` + collection (the failing case), `mixed_content` + single (regression guard), and `ordered` + collection (same dispatch path).
- Documents the `mixed_content` / `ordered` interaction in `docs/_guides/xml-mapping.adoc`.

## Trigger

The bug only manifests on round-trip (`from_xml` → `to_xml`) when `element_order` is populated and `mapping.ordered?` is true — that's what routes dispatch through `OrderedApplier`. Fresh-constructed models go through `RuleApplier`, which already had the short-circuit, so they were unaffected. (The original issue #727 reproduction used a fresh model, which is why it didn't actually reproduce the bug.)

Fixes #727.

## Test plan

- [x] Existing `raw: :element` specs on `RuleApplier` paths still pass (40 examples)
- [x] New spec: `raw: :element` on a `mixed_content` collection does not double-wrap
- [x] Round-trip stability verified for `mixed_content` and `ordered` mappings
