### PR TITLE
feat: eager-resolve namespace autoloads on string-type cast

### DIFF
--- a/lib/lutaml/model/attribute.rb
+++ b/lib/lutaml/model/attribute.rb
@@ -88,10 +88,65 @@ module Lutaml
       end
 
       def self.cast_from_string!(type)
+        ensure_namespace_eager_loaded(type)
         Type.const_get(type)
       rescue NameError
         raise ArgumentError, "Unknown Lutaml::Model::Type: #{type}"
       end
+
+      # When a string-typed attribute references a class inside a namespace
+      # that uses autoload + lazy per-file registration (e.g. `Mml::V3::Math`,
+      # where sibling types register themselves as a side-effect of their
+      # file being loaded), resolving just the leaf constant via `const_get`
+      # leaves the sibling types unregistered. Deserialization of the root
+      # then fails because the registry has no entry for child element types.
+      #
+      # To fix this, walk each parent namespace segment of the string-typed
+      # reference and force every direct child constant to resolve. Each
+      # resolution triggers its autoload, which fires any per-file
+      # registration side-effects.
+      #
+      # Each namespace is touched at most once per process (memoized in
+      # `@eager_loaded_namespaces`) to keep repeated attribute declarations
+      # cheap.
+      def self.ensure_namespace_eager_loaded(type)
+        return unless type.is_a?(String) && type.include?("::")
+
+        segments = type.split("::")
+        return if segments.length < 2
+
+        @eager_loaded_namespaces ||= {}
+        @eager_loaded_namespaces_mutex ||= Mutex.new
+
+        segments[0..-2].each_with_object(+"") do |segment, accumulator|
+          accumulator << "::" unless accumulator.empty?
+          accumulator << segment
+          namespace_name = accumulator.freeze
+
+          @eager_loaded_namespaces_mutex.synchronize do
+            next if @eager_loaded_namespaces[namespace_name]
+
+            begin
+              namespace = Object.const_get(namespace_name)
+            rescue NameError
+              next
+            end
+            next unless namespace.is_a?(Module)
+
+            # Force every direct child constant to resolve, triggering any
+            # pending autoloads. Skip constants that fail to load (they may
+            # be defined dynamically or have unsatisfied dependencies).
+            namespace.constants(false).each do |child_name|
+              namespace.const_get(child_name)
+            rescue StandardError
+              nil
+            end
+
+            @eager_loaded_namespaces[namespace_name] = true
+          end
+        end
+      end
+      private_class_method :ensure_namespace_eager_loaded
 
       def initialize(name, type, options = {})
         skip_validation = options.fetch(:skip_validation, false)

--- a/spec/lutaml/model/namespace_autoload_spec.rb
+++ b/spec/lutaml/model/namespace_autoload_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "tmpdir"
+require "securerandom"
+
+# When a Serializable declares an attribute with a string type that points
+# into a namespace using autoload + lazy per-file registration, resolving
+# just the leaf constant via const_get leaves sibling types unregistered.
+# Deserialization of the root then fails because child element types are
+# missing from the registry.
+#
+# The fix in `Lutaml::Model::Attribute.cast_from_string!` walks each parent
+# namespace segment of the string type and force-resolves its constants so
+# autoloads fire and per-file registration side-effects complete.
+
+RSpec.describe "string-type resolution with namespace autoload" do
+  # Build a throwaway namespace with autoloads pointing at files that
+  # self-register on load. This mirrors the pattern used by gems like
+  # `mml` (where each `lib/mml/v3/<tag>.rb` ends with
+  # `Configuration.register_model(...)`).
+  def build_namespace(name)
+    Object.const_set(name, Module.new)
+
+    ns = Object.const_get(name)
+    ns.const_set(:REGISTRY, {})
+    ns.const_set(:LOADED_FILES, [])
+    ns.singleton_class.define_method(:loaded_files) { ns::LOADED_FILES }
+    ns.singleton_class.define_method(:registry) { ns::REGISTRY }
+
+    tmpdir = Dir.mktmpdir("lutaml-autoload-#{name.downcase}")
+
+    root_file = File.join(tmpdir, "root.rb")
+    sibling_file = File.join(tmpdir, "sibling.rb")
+
+    File.write(root_file, <<~RUBY)
+      #{name}::LOADED_FILES << "root"
+      #{name}::REGISTRY[:root] = Class.new
+      #{name}.const_set(:Root, #{name}::REGISTRY[:root])
+    RUBY
+
+    File.write(sibling_file, <<~RUBY)
+      #{name}::LOADED_FILES << "sibling"
+      #{name}::REGISTRY[:sibling] = Class.new
+      #{name}.const_set(:Sibling, #{name}::REGISTRY[:sibling])
+    RUBY
+
+    ns.autoload(:Root, root_file)
+    ns.autoload(:Sibling, sibling_file)
+    ns
+  end
+
+  # Each spec builds a uniquely-named namespace (via SecureRandom), so
+  # cross-test cleanup is unnecessary. Constants leak for the duration of
+  # the process but never collide.
+
+  let(:namespace_name) { :"LutamlAutoloadTest#{SecureRandom.hex(4)}" }
+  let(:namespace_module) { Object.const_get(namespace_name) }
+
+  it "eager-resolves sibling autoloads when a namespaced string type is cast" do
+    build_namespace(namespace_name)
+    expect(namespace_module.loaded_files).to be_empty
+
+    Lutaml::Model::Attribute.cast_from_string!("#{namespace_module}::Root")
+
+    expect(namespace_module.loaded_files).to include("root", "sibling")
+    expect(namespace_module.registry.key?(:root)).to be(true)
+    expect(namespace_module.registry.key?(:sibling)).to be(true)
+  end
+
+  it "is idempotent across multiple cast_from_string! calls within the same namespace" do
+    build_namespace(namespace_name)
+
+    Lutaml::Model::Attribute.cast_from_string!("#{namespace_module}::Root")
+    first_count = namespace_module.loaded_files.length
+
+    Lutaml::Model::Attribute.cast_from_string!("#{namespace_module}::Sibling")
+    expect(namespace_module.loaded_files.length).to eq(first_count)
+  end
+
+  it "raises ArgumentError for unknown types" do
+    expect do
+      Lutaml::Model::Attribute.cast_from_string!("LutamlAutoloadDoesNotExist::X")
+    end.to raise_error(ArgumentError, /Unknown Lutaml::Model::Type/)
+  end
+end


### PR DESCRIPTION
## Summary

- `Attribute.cast_from_string!` now walks each parent namespace segment of a string-typed attribute reference and force-resolves every direct child constant, triggering autoloads and any per-file registration side-effects.
- Memoizes per-namespace so repeated declarations stay cheap.
- Adds `spec/lutaml/model/namespace_autoload_spec.rb` demonstrating the failure mode with a synthetic namespace that mirrors the `mml` gem pattern.

## Problem

When a Serializable in a downstream gem declares:

```ruby
class Document < Lutaml::Model::Serializable
  attribute :math, "Mml::V3::Math"
end
```

`cast_from_string!` resolved only the leaf constant (`Mml::V3::Math`) via `Type.const_get`. The leaf's autoload fires, loading `mml/v3/math.rb`, which registers `:math`. But sibling types in the same namespace (`:mfrac`, `:msub`, ...) remained unloaded — their autoloads were declared on the version module but never triggered. Deserialization of `<math><mfrac>...</mfrac></math>` then failed because the type registry had no entry for `:mfrac`.

Gems that follow this lazy-registration pattern (autoload + per-file `Configuration.register_model` side-effects) cannot be cleanly referenced via string-typed attributes without this fix. The `mml` gem currently papers over it with `Mml::Vn.ensure_registered!` calls at the bottom of each version file — a stopgap this PR makes unnecessary.

## Approach

In `Attribute.cast_from_string!`, before resolving the leaf:

1. Split the string on `::`.
2. For each parent namespace segment, `Object.const_get` to ensure it loads.
3. Once the parent module is loaded, iterate `namespace.constants(false)` and `const_get` each one — this fires every pending autoload on that namespace.
4. Memoize each namespace name in a thread-safe `@eager_loaded_namespaces` Hash guarded by a `Mutex` so the second+ attribute declaration in the same namespace is a no-op.

Skips constants that fail to load (some gems define constants dynamically with unsatisfied dependencies at file load time).

## Test plan

- [x] New spec `namespace_autoload_spec.rb` — three cases:
  - String-type cast resolves sibling autoloads and registers all sibling types.
  - Idempotency: second cast within the same namespace does not reload files.
  - Unknown type still raises ArgumentError.
- [x] `bundle exec rspec spec/lutaml/model/attribute_spec.rb spec/lutaml/model/type_resolver_spec.rb spec/lutaml/model/type_registry_spec.rb spec/lutaml/model/type_context_spec.rb spec/lutaml/model/namespace_autoload_spec.rb` — 304 examples, 0 failures.
- [x] `bundle exec rubocop lib/lutaml/model/attribute.rb spec/lutaml/model/namespace_autoload_spec.rb` — clean.

## Out of scope

- Removing the `Mml::Vn.ensure_registered!` stopgap in the mml gem. That happens after this PR is merged and released.
