### PR TITLE
feat(opal): load Opal stdlib StringIO before moxml's bare class + README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -303,6 +303,42 @@ gem install lutaml-model
 
 Lutaml::Model includes a command line interface (CLI) that provides useful tools for working with your data models. The CLI is available through the `lutaml-model` command after installation.
 
+== Opal (JavaScript) support
+
+Lutaml::Model runs under
+https://opalrb.com/[Opal] (Ruby compiled to JavaScript), which
+powers the
+https://www.npmjs.com/package/@lutaml/lutaml-model[`@lutaml/lutaml-model`]
+npm package. Two pure-Ruby XML adapters ship under Opal:
+
+* **Oga** (default) — compiled from the vendored `opal-oga` fork,
+  which provides a pure-Ruby lexer.
+* **REXML** (opt-in) — compiled from the bundled stdlib gem, with
+  moxml's `lib/compat/opal/rexml/*` shadows patching the parts Opal
+  can't follow natively.
+
+Nokogiri and Ox are C extensions and are not available under Opal.
+
+[source,ruby]
+----
+# Default (Oga)
+Lutaml::Model::Config.xml_adapter_type = :oga
+
+# Opt-in to REXML
+Lutaml::Model::Config.xml_adapter_type = :rexml
+----
+
+The Opal smoke specs in `spec/lutaml/xml/opal_xml_spec.rb` run a
+shared XML round-trip contract against BOTH adapters so a regression
+in either is caught at CI time (`bundle exec rake spec:opal`).
+
+The npm package `@lutaml/lutaml-model` is rebuilt automatically by
+the `lutaml-model-js` repo on every push to this repo's `main` branch
+(publishes under the `next` dist-tag) and on every stable gem release
+(publishes under `latest`). See
+https://github.com/lutaml/lutaml-model-js[`lutaml-model-js`] for
+details.
+
 === Compare Command
 
 The `compare` command allows you to compare two data files of different formats using your Lutaml::Model classes. This is particularly useful for:

--- a/lib/compat/opal/js_bundle_entry.rb
+++ b/lib/compat/opal/js_bundle_entry.rb
@@ -17,6 +17,13 @@ if RUBY_ENGINE == "opal"
   #    run before any gem that touches thread-safety primitives.
   require "lutaml/model/runtime_compatibility"
 
+  # 0a. Opal's stdlib StringIO < IO loads here so moxml's
+  #     `class StringIO` (bare, no parent) in rexml_compat.rb re-opens
+  #     the existing class instead of conflicting with `< ::IO`.
+  #     Without this, the bare-class definition runs first and Opal's
+  #     `< IO` definition later raises "superclass mismatch".
+  require "stringio"
+
   # 1. stdlib shims: String/Encoding/StringIO + Array#pack + nodejs/yaml
   require "rexml_compat"
   require "yaml_compat"


### PR DESCRIPTION
## What

Two coupled changes for the @lutaml/lutaml-model JS bundle smoke test.

### 1. Load Opal stdlib StringIO first

moxml's `compat/opal/rexml_compat.rb` defines a bare `class StringIO` (no superclass). Opal's stdlib `stringio.rb` uses `class StringIO < IO`. When both load, the second raises `superclass mismatch for class StringIO`.

Fix is load order: require Opal's stdlib `stringio` FIRST in `lib/compat/opal/js_bundle_entry.rb`. moxml's bare `class StringIO` then just re-opens the existing class (no conflict). REXML serialization (used by `to_xml`) needs `StringIO#write` which only Opal's stdlib provides — moxml's bare class only has `<<`.

### 2. README Opal section

Adds an 'Opal (JavaScript) support' section to README.adoc documenting:
- Both adapters ship (Oga default, REXML opt-in)
- Nokogiri/Ox are C extensions, not available
- The npm package `@lutaml/lutaml-model` auto-rebuilds on every push to this repo's main (`next` dist-tag) and on stable gem releases (`latest`)

## Pairs with

[lutaml-model-js PR: real XML round-trip smoke test](https://github.com/lutaml/lutaml-model-js/pull/13) — un-stubs 'stringio' in build.rb (depends on this PR's load-order fix) and adds a real XML round-trip smoke test that exercises both adapters via `LutamlJS::SmokeTest.verify` from `scripts/test.js`.

## Verification

Local: lutaml-model-js build + smoke test both pass with both adapters doing real XML round-trips:
```
self-contained: 455 modules + Oga round-trip + REXML round-trip ✓
external:        455 modules + Oga round-trip + REXML round-trip ✓
```