### PR TITLE
fix: ordered builder honours setter call order (#735)

### DIFF
--- a/lib/lutaml/model/serialize/builder.rb
+++ b/lib/lutaml/model/serialize/builder.rb
@@ -39,8 +39,10 @@ module Lutaml
 
           return self unless block
 
-          # Enable order tracking for mixed_content models
-          @__order_tracking__ = mixed_content?
+          # Enable order tracking for ordered and mixed_content models.
+          # `ordered?` is true for both `ordered` and `mixed_content`
+          # (mixed_content sets @ordered = true in addition to @mixed_content).
+          @__order_tracking__ = ordered?
 
           # Evaluate the block - use instance_eval for no-receiver style
           # The block's first parameter determines the style:
@@ -60,6 +62,17 @@ module Lutaml
         def mixed_content?
           mapping = self.class.mappings_for(:xml, lutaml_register)
           mapping&.mixed_content? || false
+        end
+
+        # Check if this model has ordered or mixed_content enabled.
+        # Both set @ordered = true on the XML mapping; mixed_content
+        # additionally sets @mixed_content = true. Order tracking is
+        # needed for either mode so the builder can emit elements in
+        # setter-call order rather than declaration order.
+        # @return [Boolean]
+        def ordered?
+          mapping = self.class.mappings_for(:xml, lutaml_register)
+          mapping&.ordered? || false
         end
 
         private

--- a/spec/lutaml/model/ordered_content_spec.rb
+++ b/spec/lutaml/model/ordered_content_spec.rb
@@ -145,6 +145,36 @@ RSpec.describe "OrderedContent" do
         expect(serialized).to be_xml_equivalent_to(expected_xml)
       end
     end
+
+    # Regression for issue #735: `ordered` builder must honour setter
+    # call order, not declaration order. The @__order_tracking__ flag
+    # was gated on mixed_content? instead of ordered?.
+    context "ordered builder honours setter call order" do
+      it "emits elements in builder-call order, not declaration order" do
+        klass = Class.new(Lutaml::Model::Serializable) do
+          attribute :a, :string
+          attribute :b, :string
+
+          xml do
+            root "item"
+            ordered
+            map_element "a", to: :a
+            map_element "b", to: :b
+          end
+        end
+
+        item = klass.new do |i|
+          i.b "first"
+          i.a "second"
+        end
+
+        xml = item.to_xml
+        b_pos = xml.index("<b>first</b>")
+        a_pos = xml.index("<a>second</a>")
+        expect(b_pos).to be < a_pos
+        expect(item.element_order.map(&:name)).to eq(%w[b a])
+      end
+    end
   end
 
   describe Lutaml::Xml::Adapter::NokogiriAdapter do


### PR DESCRIPTION
## What

Fixes #735. The `@__order_tracking__` flag in `Builder#initialize` was gated on `mixed_content?` instead of `ordered?`. Pure `ordered` models (no `mixed_content`) never tracked setter call order, so `to_xml` emitted elements in declaration order.

## Root cause

```ruby
# lib/lutaml/model/serialize/builder.rb:43
@__order_tracking__ = mixed_content?  # ← should be ordered?
```

`ordered` sets `@ordered = true` only. `mixed_content` sets both `@ordered` and `@mixed_content`. Since the gate checked `mixed_content?`, pure `ordered` models were excluded from order tracking.

## Fix

Gate on `ordered?` (which subsumes `mixed_content?` because mixed_content also sets `@ordered = true`). Added an `ordered?` instance method on Builder parallel to the existing `mixed_content?`.

```ruby
# before
@__order_tracking__ = mixed_content?

# after
@__order_tracking__ = ordered?
```

## Verification

```
item = OrderedItem.new do |i|
  i.b "first"
  i.a "second"
end

item.to_xml
# before: <item><a>second</a><b>first</b></item>  (declaration order)
# after:  <item><b>first</b><a>second</a></item>  (call order) ✓

item.element_order.map(&:name)
# before: nil
# after:  ["b", "a"]  ✓
```

107 ordered + mixed_content specs pass, rubocop clean.