### PR TITLE
cleanup: replace all 'root' DSL calls with 'element' in specs

### DIFF
--- a/spec/lutaml/model/ordered_content_spec.rb
+++ b/spec/lutaml/model/ordered_content_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe "OrderedContent" do
           attribute :b, :string
 
           xml do
-            root "item"
+            element "item"
             ordered
             map_element "a", to: :a
             map_element "b", to: :b

--- a/spec/lutaml/model/union_attribute_spec.rb
+++ b/spec/lutaml/model/union_attribute_spec.rb
@@ -46,7 +46,7 @@ module UnionAttributeSpec
               [TemperatureWithUnit, Temperature, :string]
 
     xml do
-      root "ceramic"
+      element "ceramic"
       map_element "FiringTemperature", to: :firing_temperature
     end
 
@@ -178,7 +178,7 @@ module UnionAttributeSpec
     attribute :amount, [Amount, :string]
 
     xml do
-      root "measurement"
+      element "measurement"
       map_element "amount", to: :amount
     end
   end
@@ -208,7 +208,7 @@ module UnionAttributeSpec
               collection: true
 
     xml do
-      root "log"
+      element "log"
       map_element "entry", to: :entries
     end
   end

--- a/spec/lutaml/model/union_spec.rb
+++ b/spec/lutaml/model/union_spec.rb
@@ -218,7 +218,7 @@ RSpec.describe Lutaml::Model::Type::Union do
         attribute :v,
                   [Lutaml::Model::Type::Integer, Lutaml::Model::Type::String]
         xml do
-          root "union_schema_sample"
+          element "union_schema_sample"
           map_element "v", to: :v
         end
         key_value { map "v", to: :v }

--- a/spec/lutaml/xml/validate_xml_with_constructs_spec.rb
+++ b/spec/lutaml/xml/validate_xml_with_constructs_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "validate_xml_with XSD constructs" do
         attribute :dimensions, XsdDimensions
 
         xml do
-          root "product"
+          element "product"
           map_attribute "id", to: :id
           map_attribute "status", to: :status
           map_element "sku", to: :sku
@@ -133,7 +133,7 @@ RSpec.describe "validate_xml_with XSD constructs" do
                    attribute :age, :string
 
                    xml do
-                     root "person"
+                     element "person"
                      map_element "name", to: :name
                      map_element "age", to: :age
                    end
@@ -169,7 +169,7 @@ RSpec.describe "validate_xml_with XSD constructs" do
                    attribute :city, :string
 
                    xml do
-                     root "address"
+                     element "address"
                      map_element "city", to: :city
                    end
 
@@ -199,7 +199,7 @@ RSpec.describe "validate_xml_with XSD constructs" do
                    attribute :email, :string
 
                    xml do
-                     root "contact"
+                     element "contact"
                      map_element "email", to: :email
                    end
 

--- a/spec/lutaml/xml/validate_xml_with_spec.rb
+++ b/spec/lutaml/xml/validate_xml_with_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "validate_xml_with" do
                  attribute :age, :string
 
                  xml do
-                   root "person"
+                   element "person"
                    map_element "name", to: :name
                    map_element "age", to: :age
                  end
@@ -125,7 +125,7 @@ RSpec.describe "validate_xml_with" do
                    attribute :age, :string
 
                    xml do
-                     root "person"
+                     element "person"
                      map_element "name", to: :name
                      map_element "age", to: :age
                    end
@@ -151,7 +151,7 @@ RSpec.describe "validate_xml_with" do
         attribute :name, :string
 
         xml do
-          root "person"
+          element "person"
           map_element "name", to: :name
         end
       end)
@@ -169,7 +169,7 @@ RSpec.describe "validate_xml_with" do
                    attribute :name, :string
 
                    xml do
-                     root "person"
+                     element "person"
                      map_element "name", to: :name
                    end
 


### PR DESCRIPTION
Audit found 13 `root` DSL calls remaining in spec files. All replaced with `element`. The `root` method definition stays in lib as a backward-compat alias for external consumers.