### PR TITLE
Revert 0.9.0 version bump — will re-release as 0.8.18 (patch)

### DIFF
--- a/lib/lutaml/model/version.rb
+++ b/lib/lutaml/model/version.rb
@@ -2,6 +2,6 @@
 
 module Lutaml
   module Model
-    VERSION = "0.9.0"
+    VERSION = "0.8.17"
   end
 end


### PR DESCRIPTION
0.9.0 was published by mistake. Reverting version.rb back to 0.8.17 so a patch release (0.8.18) can be issued instead.