### PR TITLE
Install yq for dependent tests

### DIFF
--- a/.github/workflows/dependent-tests.yml
+++ b/.github/workflows/dependent-tests.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   rake:
-    uses: metanorma/ci/.github/workflows/dependent-rake.yml@feature/yq-setup-action
+    uses: metanorma/ci/.github/workflows/dependent-rake.yml@main
     with:
       command: bundle exec rspec
       setup-tools: 'inkscape,ghostscript,exiftool,ffmpeg,imagemagick,yq'

--- a/.github/workflows/dependent-tests.yml
+++ b/.github/workflows/dependent-tests.yml
@@ -19,10 +19,10 @@ on:
 
 jobs:
   rake:
-    uses: metanorma/ci/.github/workflows/dependent-rake.yml@main
+    uses: metanorma/ci/.github/workflows/dependent-rake.yml@feature/yq-setup-action
     with:
       command: bundle exec rspec
-      setup-tools: 'inkscape,ghostscript,exiftool,ffmpeg,imagemagick'
+      setup-tools: 'inkscape,ghostscript,exiftool,ffmpeg,imagemagick,yq'
       after-setup-ruby: |
         if [ -f frontend/package.json ]; then cd frontend && npm install && npm run build; fi
     secrets:


### PR DESCRIPTION
Installs `yq` for the dependent tests.

The `ukiryu/ukiryu` dependent job fails on Windows. Windows runners ship no `yq`, so two smoke specs fail.

Failing on `3.3-windows-latest`:

- `profiles_smoke_spec.rb:484` yq detects version
- `profiles_smoke_spec.rb:499` yq evaluates YAML expression

The log shows `NO EXECUTABLE FOUND for yq`. The macOS and Ubuntu legs pass, since those images ship `yq`.

## What this does

Adds `yq` to `setup-tools`. That is the only change.

Ubuntu and macOS already have `yq`, so the new step is a no-op there. Windows gets a chocolatey install.

## Verified locally

- Without `yq` on PATH, both specs fail.
- With `yq` installed the same way, both specs pass.

## Depends on

Needs metanorma/ci#378 first. That PR adds the `yq` tool.

This branch points at the CI branch for testing. Restore `@main` before merging.
