### PR TITLE
fix(xml): make attribute deserialization namespace-disjoint

### DIFF
--- a/lib/lutaml/xml/mapping_rule.rb
+++ b/lib/lutaml/xml/mapping_rule.rb
@@ -183,6 +183,34 @@ module Lutaml
         result
       end
 
+      # Match names an attribute rule consumes during parsing, mirroring how
+      # serialization qualifies the same attribute (resolve_namespace):
+      # a rule serialized with a prefix matches only attributes in its
+      # namespace; a rule serialized unprefixed matches only namespace-less
+      # attributes.
+      #
+      # Performance: memoized on the rule with zero-allocation cache hits.
+      # The inputs are constant for a given rule, register and parent model,
+      # so every element of a collection reuses the first resolution.
+      def attribute_match_names(attr, register, parent_ns_class, form_default,
+                                default_namespace)
+        if defined?(@_amn_names) && @_amn_register == register &&
+            @_amn_parent_ns == parent_ns_class &&
+            @_amn_form_default == form_default &&
+            @_amn_default_ns == default_namespace
+          return @_amn_names
+        end
+
+        result = compute_attribute_match_names(attr, register, parent_ns_class,
+                                               form_default, default_namespace)
+        @_amn_register = register
+        @_amn_parent_ns = parent_ns_class
+        @_amn_form_default = form_default
+        @_amn_default_ns = default_namespace
+        @_amn_names = result
+        result
+      end
+
       def namespaced_name(parent_namespace = nil, name = self.name)
         if name.to_s == "lang"
           ::Lutaml::Model::Utils.blank?(prefix) ? name.to_s : "#{prefix}:#{name}"
@@ -273,6 +301,30 @@ module Lutaml
       end
 
       private
+
+      # Extracted body of attribute_match_names for caching
+      def compute_attribute_match_names(attr, register, parent_ns_class,
+                                        form_default, default_namespace)
+        ns_info = resolve_namespace(
+          attr: attr,
+          register: register,
+          parent_ns_class: parent_ns_class,
+          form_default: form_default,
+        )
+        uri = ns_info[:uri]
+        # Schema-level attribute_form_default keeps the historical plain-name
+        # parse: dependents (e.g. ogc-gml) declare :qualified but their
+        # documents and expectations rely on unprefixed attributes parsing.
+        # Explicit namespaces, type namespaces and explicit form: rules
+        # mirror serialization strictly.
+        strict_match = uri && ns_info[:prefix] &&
+          !ns_info[:unqualified_same_ns] && !ns_info[:via_schema_default]
+        if strict_match
+          ["#{uri}:#{name}"].freeze
+        else
+          namespaced_names(default_namespace)
+        end
+      end
 
       # Extracted body of namespaced_names for caching
       def compute_namespaced_names(parent_namespace)

--- a/lib/lutaml/xml/mapping_rule.rb
+++ b/lib/lutaml/xml/mapping_rule.rb
@@ -427,7 +427,9 @@ form_default = :unqualified)
         # When schema specifies attributeFormDefault="qualified", attributes
         # must be qualified (prefixed) with the parent element's namespace
         if form_default == :qualified && parent_ns_class
-          return build_namespace_result_from_class(parent_ns_class)
+          result = build_namespace_result_from_class(parent_ns_class)
+          result[:via_schema_default] = true
+          return result
         end
 
         # 4. No namespace (W3C default for unprefixed attributes)

--- a/lib/lutaml/xml/model_transform.rb
+++ b/lib/lutaml/xml/model_transform.rb
@@ -909,7 +909,14 @@ effective_register = lutaml_register)
             :unqualified,
         )
         uri = ns_info[:uri]
-        if uri && !ns_info[:unqualified_same_ns]
+        # Schema-level attribute_form_default keeps the historical plain-name
+        # parse: dependents (e.g. ogc-gml) declare :qualified but their
+        # documents and expectations rely on unprefixed attributes parsing.
+        # Explicit namespaces, type namespaces and explicit form: rules
+        # mirror serialization strictly.
+        strict_match = uri && ns_info[:prefix] &&
+          !ns_info[:unqualified_same_ns] && !ns_info[:via_schema_default]
+        if strict_match
           ["#{uri}:#{rule.name}"]
         else
           rule.namespaced_names(options[:default_namespace])

--- a/lib/lutaml/xml/model_transform.rb
+++ b/lib/lutaml/xml/model_transform.rb
@@ -890,37 +890,41 @@ effective_register = lutaml_register)
       end
 
       # Match names for an attribute rule, mirroring how serialization
-      # qualifies the same attribute (MappingRule#resolve_namespace): a rule
-      # serialized with a prefix matches only attributes in its namespace;
-      # a rule serialized unprefixed matches only namespace-less attributes.
+      # qualifies the same attribute (MappingRule#attribute_match_names):
+      # a rule serialized with a prefix matches only attributes in its
+      # namespace; a rule serialized unprefixed matches only namespace-less
+      # attributes.
       def resolve_attribute_rule_names(rule, attr, options, effective_register,
                                        instance, instance_is_serialize)
         return rule.namespaced_names(options[:default_namespace]) if attr.nil? ||
           rule.multiple_mappings?
 
-        parent_ns_class = if instance_is_serialize
-                            instance.class.mappings_for(:xml)&.namespace_class
-                          end
-        ns_info = rule.resolve_namespace(
-          attr: attr,
-          register: effective_register,
-          parent_ns_class: parent_ns_class,
-          form_default: parent_ns_class&.attribute_form_default ||
-            :unqualified,
-        )
-        uri = ns_info[:uri]
-        # Schema-level attribute_form_default keeps the historical plain-name
-        # parse: dependents (e.g. ogc-gml) declare :qualified but their
-        # documents and expectations rely on unprefixed attributes parsing.
-        # Explicit namespaces, type namespaces and explicit form: rules
-        # mirror serialization strictly.
-        strict_match = uri && ns_info[:prefix] &&
-          !ns_info[:unqualified_same_ns] && !ns_info[:via_schema_default]
-        if strict_match
-          ["#{uri}:#{rule.name}"]
+        if instance_is_serialize
+          parent_ns_class, form_default = parent_attribute_context(instance)
         else
-          rule.namespaced_names(options[:default_namespace])
+          parent_ns_class = nil
+          form_default = :unqualified
         end
+        rule.attribute_match_names(attr, effective_register, parent_ns_class,
+                                   form_default,
+                                   options[:default_namespace])
+      end
+
+      # [namespace_class, attribute_form_default] for the instance's model,
+      # keyed on the model class. Attribute rules of one element share the
+      # model, so a 1-entry cache avoids a mappings_for lookup per rule.
+      def parent_attribute_context(instance)
+        klass = instance.class
+        if @parent_ns_klass == klass && @parent_ns_value
+          return @parent_ns_value
+        end
+
+        ns_class = klass.mappings_for(:xml)&.namespace_class
+        value = [ns_class,
+                 ns_class&.attribute_form_default || :unqualified]
+        @parent_ns_klass = klass
+        @parent_ns_value = value
+        value
       end
 
       # Resolve rule names with type namespace support

--- a/lib/lutaml/xml/model_transform.rb
+++ b/lib/lutaml/xml/model_transform.rb
@@ -509,8 +509,13 @@ _effective_register)
           local_name = rn[(last_colon_index + 1)..]
 
           matched_attr = doc.root.attributes.values.find do |attr|
-            # Match by the attribute's namespaced_name, unprefixed_name, or by extracting
-            # local name from the attribute's key (handles unresolved prefixes).
+            # A namespace-less, prefix-less attribute cannot belong to the
+            # rule's namespace, so it must not satisfy the fallback
+            # (lutaml-model#744). Attributes with undeclared prefixes keep
+            # their prefix in the raw name and stay eligible below.
+            next false if attr.namespace.nil? &&
+              attr.namespace_prefix.nil? && !attr.name.include?(":")
+
             attr.namespaced_name == local_name ||
               attr.unprefixed_name == local_name ||
               (attr.namespace.nil? && ((colon = attr.name.rindex(":")) ? attr.name[(colon + 1)..] : attr.name) == local_name)
@@ -544,9 +549,14 @@ _effective_register)
         rule_namespace = rule_namespace_set ? rule.namespace : nil
         options[:default_namespace]
 
-        # Enhanced namespace resolution with type support
-        rule_names = resolve_rule_names_with_type(rule, attr, options,
-                                                  effective_register, attr_type)
+        rule_names = if rule.attribute?
+                       resolve_attribute_rule_names(rule, attr, options,
+                                                    effective_register,
+                                                    instance, instance_is_serialize)
+                     else
+                       resolve_rule_names_with_type(rule, attr, options,
+                                                    effective_register, attr_type)
+                     end
 
         return value_for_xml_attribute(doc, rule, rule_names) if rule.attribute?
 
@@ -876,6 +886,33 @@ effective_register = lutaml_register)
           node.inner_xml
         else
           node.children.map(&:to_xml).join
+        end
+      end
+
+      # Match names for an attribute rule, mirroring how serialization
+      # qualifies the same attribute (MappingRule#resolve_namespace): a rule
+      # serialized with a prefix matches only attributes in its namespace;
+      # a rule serialized unprefixed matches only namespace-less attributes.
+      def resolve_attribute_rule_names(rule, attr, options, effective_register,
+                                       instance, instance_is_serialize)
+        return rule.namespaced_names(options[:default_namespace]) if attr.nil? ||
+          rule.multiple_mappings?
+
+        parent_ns_class = if instance_is_serialize
+                            instance.class.mappings_for(:xml)&.namespace_class
+                          end
+        ns_info = rule.resolve_namespace(
+          attr: attr,
+          register: effective_register,
+          parent_ns_class: parent_ns_class,
+          form_default: parent_ns_class&.attribute_form_default ||
+            :unqualified,
+        )
+        uri = ns_info[:uri]
+        if uri && !ns_info[:unqualified_same_ns]
+          ["#{uri}:#{rule.name}"]
+        else
+          rule.namespaced_names(options[:default_namespace])
         end
       end
 

--- a/spec/lutaml/xml/attribute_namespace_disjointness_spec.rb
+++ b/spec/lutaml/xml/attribute_namespace_disjointness_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Two map_attribute rules that share a local name but are distinguished by
+# their type classes' bound namespaces must parse disjointly, mirroring
+# serialization (lutaml-model#744).
+#
+# The coexisting-spelling cases under nokogiri/rexml additionally require the
+# moxml adapter fixes (lutaml/moxml#94, lutaml/moxml#95); oga and ox already
+# preserve same-local-name attributes across namespaces.
+module AttributeNamespaceDisjointnessSpec
+  class XmiNs < Lutaml::Xml::Namespace
+    uri "http://www.example.com/xmi"
+    prefix_default "xmi"
+  end
+
+  class XmiNsType < Lutaml::Model::Type::String
+    xml do
+      namespace XmiNs
+    end
+  end
+
+  class Probe < Lutaml::Model::Serializable
+    attribute :xmi_type, XmiNsType
+    attribute :plain_type, Lutaml::Model::Type::String
+
+    xml do
+      element "probe"
+      map_attribute "type", to: :xmi_type
+      map_attribute "type", to: :plain_type
+    end
+  end
+
+  def self.parse(xml, adapter)
+    Lutaml::Model::Config.with_adapter(xml: adapter) { Probe.from_xml(xml) }
+  end
+end
+
+RSpec.describe "Attribute namespace-disjoint parsing" do
+  let(:namespaced_xmi) do
+    %(<probe xmlns:xmi="http://www.example.com/xmi" xmi:type="uml:Parameter"/>)
+  end
+
+  let(:namespaced_foo) do
+    %(<probe xmlns:foo="http://www.example.com/xmi" foo:type="uml:Parameter"/>)
+  end
+
+  let(:plain) { %(<probe type="EAnone_void"/>) }
+
+  let(:both_spellings) do
+    %(<probe xmlns:xmi="http://www.example.com/xmi" xmi:type="uml:Parameter" type="EAnone_void"/>)
+  end
+
+  let(:both_spellings_plain_first) do
+    %(<probe type="EAnone_void" xmlns:xmi="http://www.example.com/xmi" xmi:type="uml:Parameter"/>)
+  end
+
+  %i[oga ox nokogiri].each do |adapter|
+    context "with the #{adapter} adapter" do
+      it "routes a namespaced rule to the attribute bound to its URI" do
+        probe = AttributeNamespaceDisjointnessSpec.parse(namespaced_xmi, adapter)
+
+        expect(probe.xmi_type).to eq("uml:Parameter")
+        expect(probe.plain_type).to be_nil
+      end
+
+      it "accepts any prefix bound to the namespace URI" do
+        probe = AttributeNamespaceDisjointnessSpec.parse(namespaced_foo, adapter)
+
+        expect(probe.xmi_type).to eq("uml:Parameter")
+        expect(probe.plain_type).to be_nil
+      end
+
+      it "does not let a namespace-less attribute satisfy the namespaced rule" do
+        probe = AttributeNamespaceDisjointnessSpec.parse(plain, adapter)
+
+        expect(probe.xmi_type).to be_nil
+        expect(probe.plain_type).to eq("EAnone_void")
+      end
+    end
+  end
+
+  # Same-local-name attributes coexisting on one element require the moxml
+  # fixes (lutaml/moxml#94 drops one under nokogiri; lutaml/moxml#95 crashes
+  # under rexml), so these cases run on the adapters that preserve both.
+  %i[oga ox].each do |adapter|
+    context "with the #{adapter} adapter" do
+      it "keeps both spellings disjoint regardless of document order" do
+        [both_spellings, both_spellings_plain_first].each do |xml|
+          probe = AttributeNamespaceDisjointnessSpec.parse(xml, adapter)
+
+          expect(probe.xmi_type).to eq("uml:Parameter")
+          expect(probe.plain_type).to eq("EAnone_void")
+        end
+      end
+    end
+  end
+
+  describe "serialization" do
+    it "writes each rule in its own namespace" do
+      probe = AttributeNamespaceDisjointnessSpec::Probe.new(
+        xmi_type: "uml:Parameter",
+        plain_type: "EAnone_void",
+      )
+
+      expect(probe.to_xml.strip).to be_xml_equivalent_to(
+        %(<probe xmlns:xmi="http://www.example.com/xmi" xmi:type="uml:Parameter" type="EAnone_void"/>),
+      )
+    end
+
+    it "round-trips both spellings through parsing" do
+      probe = AttributeNamespaceDisjointnessSpec::Probe.new(
+        xmi_type: "uml:Parameter",
+        plain_type: "EAnone_void",
+      )
+      reparsed = AttributeNamespaceDisjointnessSpec.parse(probe.to_xml, :oga)
+
+      expect(reparsed.xmi_type).to eq("uml:Parameter")
+      expect(reparsed.plain_type).to eq("EAnone_void")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Attribute deserialization is now namespace-disjoint, mirroring serialization: a rule serialized with a prefix matches only attributes in its namespace (any prefix bound to the URI), and a rule serialized unprefixed matches only namespace-less attributes.

Fixes #744.

## Before

Two `map_attribute` rules with the same local name but different type-class namespaces serialized disjointly but collapsed during parsing:

```
only namespaced, prefix xmi xmi_type="uml:Parameter"  plain_type=nil
only namespaced, prefix foo xmi_type="uml:Parameter"  plain_type=nil
only plain                 xmi_type="EAnone_void"    plain_type="EAnone_void"   <-- wrong
```

Two defects on the deserialization path:

1. `find_attribute_by_local_name` (the fallback for undeclared prefixes like `v:ext` without `xmlns:v`) matched by local name with no namespace guard, so a namespace-less attribute satisfied a rule whose type class binds a namespace.
2. Attribute rules derived match names from the type namespace only, ignoring `attribute_form_default`. A rule serialized unprefixed per W3C attributeFormDefault (unqualified, same namespace as element) therefore reparsed its own serialized output only through that same fallback — the round-trip worked by accident through defect 1.

## After

```
only namespaced, prefix xmi xmi_type="uml:Parameter"  plain_type=nil
only namespaced, prefix foo xmi_type="uml:Parameter"  plain_type=nil
only plain                 xmi_type=nil               plain_type="EAnone_void"  <-- correct
both spellings (oga/ox)    xmi_type="uml:Parameter"  plain_type="EAnone_void"   <-- disjoint
```

- Attribute rules route through `MappingRule#attribute_match_names` (memoized `resolve_namespace`, the same priority logic serialization uses) so parsing mirrors what serialization emits, with two scope limits:
  - When serialization cannot emit a prefix (namespace class has no `prefix_default`, e.g. ReqIF's default-xmlns documents), parsing matches the plain name, exactly as serialized.
  - Schema-level `attribute_form_default :qualified` (`via_schema_default`) keeps the historical plain-name parse, because dependents such as ogc-gml declare `:qualified` while their documents and expectations use unprefixed attributes (filed as lutaml/ogc-gml#22). Explicit namespaces, type namespaces and explicit `form:` rules stay strictly disjoint.
- The undeclared-prefix fallback keeps its leniency but never matches a definitively namespace-less attribute.
- Perf: the routing is memoized on the rule (zero-allocation hits) and the parent model's namespace context is cached per class. An attribute-heavy parse allocates ~1.5% **fewer** objects than main; on the niso pnas fixture, 0.4% fewer (701,121 vs 703,629 by `GC.stat(:total_allocated_objects)`).

## Adapter notes

Coexisting same-local-name attributes (`xmi:type` + `type` on one element) additionally require moxml fixes, which are already filed:

- lutaml/moxml#94 — Nokogiri adapter drops one of the two attributes (data is lost before it reaches this gem)
- lutaml/moxml#95 — REXML adapter crashes on the same input

oga and ox already preserve both attributes, and the spec covers the full table on them. The spec file notes these dependencies so the nokogiri coexisting-spelling cases can be extended once the moxml fixes ship.

## Verification

- New spec `spec/lutaml/xml/attribute_namespace_disjointness_spec.rb`: the #744 expected table across adapters, serialization disjointness, and round-trip (written failing first; 3 failures observed before the fix)
- The W3C form round-trip and all four undeclared-prefix leniency specs in `compiled_rule_namespace_spec.rb` stay green — the round-trip now works via the primary lookup instead of the fallback
- Full suite: 5326 examples, 0 failures; rubocop clean
- Dependent gems verified locally (green on main before, red on this PR's first commit, green again after the scope limits + memoization): reqif 30/0, ogc-gml 313/0; plurimath/mml, unitsml, genericode, metaschema etc. green in CI

## CI status: every red check is externally tracked, none from this PR's code

| Failing check | Cause | Tracking |
|---|---|---|
| `benchmark (niso)` | benchmark harness alloc metric bug — real ratio for this branch is 0.9964 (verified with fixed harness) | #749 |
| `benchmark (sts)` | same harness bug + pre-existing absolute-time breach that also fails on main | #749 |
| `glossarist/iev` ×3 | glossarist 2.13 L10N breaking change (`RelatedConcept#content` string→hash); fails on pure main | glossarist/iev#67 |
| `metanorma/metanorma-cli` ×3 | dependent-rake workflow lacks GitHub Packages auth for Bundler | metanorma/ci#411 |
| `plurimath/plurimath` ×3 | Ox 2.14.29 rejects `\x01` on dump; fails on pure main | plurimath/plurimath#479 |
| `test (windows-latest, true)` | matrix include entry missing its `ruby` key since June | #748 |
