### PR TITLE
ci: give windows experimental leg a ruby version

### DIFF
--- a/.github/workflows/rake.yml
+++ b/.github/workflows/rake.yml
@@ -25,6 +25,7 @@ jobs:
         experimental: [false]
         include:
           - os: windows-latest
+            ruby: head
             experimental: true
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Problem

The experimental Windows leg of the test matrix has failed on every PR since it was introduced in acd728ae ("ci: replace reusable workflow with custom rake.yml"):

```
##[error]Error: input ruby-version needs to be specified if no .ruby-version or .tool-versions file exists
```

The matrix include entry carries `experimental: true` but no `ruby` key, so `ruby-version: ${{ matrix.ruby }}` expands to empty and `ruby/setup-ruby` aborts ~20s into the job. It is `continue-on-error`, so it shows as a red X that everyone has learned to ignore.

## Fix

Give the leg `ruby: head` — restoring it as a non-blocking canary for Ruby head on Windows, which matches the `experimental: true` semantics it was created with.

```
test (windows-latest, true)	fail	23s   <-- before, every PR
```

The three stable Windows legs (3.3/3.4/4.0, `experimental: false`) are unchanged.
