### PR TITLE
fix(bench): measure allocations with a monotonic counter

### DIFF
--- a/bench/bench_common.rb
+++ b/bench/bench_common.rb
@@ -31,14 +31,17 @@ module BenchCommon
     iterations.times do
       GC.start
       GC.disable
-      mem_before = ObjectSpace.count_objects[:TOTAL]
+      # Must be a monotonic counter: count_objects[:TOTAL] counts occupied
+      # slots, so allocations that reuse slots freed by the GC.start above
+      # are invisible (observed as 0-alloc parses and unstable ratios).
+      alloc_before = GC.stat(:total_allocated_objects)
       t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       yield
       t1 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       GC.enable
-      mem_after = ObjectSpace.count_objects[:TOTAL]
+      alloc_after = GC.stat(:total_allocated_objects)
       times << (t1 - t0)
-      allocations << (mem_after - mem_before)
+      allocations << (alloc_after - alloc_before)
     end
 
     avg_time = times.sum / times.size

--- a/bench/bench_niso.rb
+++ b/bench/bench_niso.rb
@@ -11,8 +11,7 @@
 # NOTE: Must run from the niso-jats bundle:
 #   cd $NISO_DIR && bundle exec ruby /path/to/lutaml-model/bench/bench_niso.rb
 
-lutaml_model_root = ENV["LUTAML_MODEL_DIR"] || "/Users/mulgogi/src/lutaml/lutaml-model"
-require "#{lutaml_model_root}/bench/bench_common"
+require_relative "bench_common"
 include BenchCommon
 
 print_header("NISO JATS Benchmark — Journal Article parsing")


### PR DESCRIPTION
## Problem

The downstream benchmark `alloc_ratio` gates are unstable:

- `benchmark (mml)` reported `alloc_ratio: 1.4232` on a PR that changed **zero library code** (workflow-only diff), while the same code passed the gate an hour earlier on another PR.
- `benchmark (niso)` failed with `alloc_ratio: 1.0676 > 1.05` on lutaml/lutaml-model#747 and reproduced on rerun (1.0621), even though a direct `GC.stat(:total_allocated_objects)` comparison of the same fixture shows the branch allocating **0.4% fewer** objects than main.
- `benchmark (sts)` has been red on main itself.

## Root causes (two, both in `bench/`)

### 1. The allocation metric undercounts invisibly

`BenchCommon#measure` computed allocations as the delta of `ObjectSpace.count_objects[:TOTAL]` — a count of **occupied slots** — with GC disabled during the measured block. But `GC.start` runs right before the window: it frees a pool of slots, and with GC disabled the measured parse allocates into those freed slots. `count_objects[:TOTAL]` does not change, so those allocations are invisible.

Observable symptoms: a 4KB JATS parse reported **0 allocations**; bmj fixture ratios swung 0.31x–20x between runs of near-identical code; identical code compared at 1.4232. The 1.05 gate threshold sits squarely inside this artifact band.

### 2. `bench_niso.rb` loaded the baseline harness from main

`bench_niso.rb` required `bench_common` from `ENV["LUTAML_MODEL_DIR"]`. The CI baseline step sets that to the **main** checkout while running the **PR's** bench script, so baseline and current were measured by two different harnesses. With this PR's metric change alone, every future PR would compare main's old metric against the PR's new one (~4x ratios, all gates red). `require_relative` (as every other bench script already uses) fixes it.

## Fix

- `bench_common.rb`: measure with `GC.stat(:total_allocated_objects)` — cumulative and exact.
- `bench_niso.rb`: `require_relative "bench_common"`.

## Verification

With the fixed harness, comparing **identical code** (main worktree vs main checkout):

```
allocs: 164344 → 164344  (ratio: 1.0000)
allocs: 16994 → 16994    (ratio: 1.0000)
allocs: 703629 → 703629  (ratio: 1.0000)
```

Comparing **main vs the fix/744 branch** (previously failing niso at 1.0676):

```
bmj-49KB      allocs ratio: 0.9945
metrology-4KB allocs ratio: 0.9959
pnas-152KB    allocs ratio: 0.9964   [PASS]
ALL GATES PASSED
```

Absolute allocation counts grow ~4x (they now count every allocation, not just slot growth) — all gates are ratio-based (`alloc_ratio`, `time_ratio`, absolute *time* limits), so no threshold changes are needed.
