### PR TITLE
fix: deliver empty values to custom from methods

### DIFF
--- a/lib/lutaml/key_value/transform.rb
+++ b/lib/lutaml/key_value/transform.rb
@@ -249,7 +249,10 @@ format)
         value = apply_value_map(value, rule.value_map(:from, options), attr)
 
         if rule.has_custom_method_for_deserialization?
-          return unless Lutaml::Model::Utils.present?(value)
+          # An empty value ("", [], {}) is a present value per the
+          # missing-values semantics and must reach the custom method;
+          # only nil (non-existent) skips it (lutaml-model#746).
+          return if value.nil?
 
           return rule.deserialize(instance, value, attributes, model_class)
         end

--- a/spec/lutaml/model/custom_from_empty_values_spec.rb
+++ b/spec/lutaml/model/custom_from_empty_values_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string: true
+
+require "spec_helper"
+
+# lutaml-model#746: an empty value ("", [], {}) is a PRESENT value per
+# docs/_guides/missing-values-handling.adoc and must reach custom `from`
+# methods. Only nil (non-existent) and an omitted key (undefined) skip them.
+module CustomFromEmptyValuesSpec
+  class Tagged < Lutaml::Model::Serializable
+    attribute :received, :string
+
+    key_value do
+      map "tags", to: :received, with: { to: :tags_to, from: :tags_from }
+    end
+
+    def tags_to(model, doc)
+      doc["tags"] = model.received
+    end
+
+    def tags_from(model, value)
+      model.received = value.inspect
+    end
+  end
+
+  class Mapped < Lutaml::Model::Serializable
+    attribute :received, :string
+
+    key_value do
+      map "fields", to: :received, with: { to: :fields_to, from: :fields_from }
+    end
+
+    def fields_to(model, doc)
+      doc["fields"] = model.received
+    end
+
+    def fields_from(model, value)
+      model.received = value.inspect
+    end
+  end
+end
+
+RSpec.describe "custom from methods and empty values" do
+  it "receives an empty collection" do
+    expect(CustomFromEmptyValuesSpec::Tagged.from_yaml("tags: []").received)
+      .to eq("[]")
+  end
+
+  it "receives an empty string" do
+    expect(CustomFromEmptyValuesSpec::Tagged.from_yaml('tags: ""').received)
+      .to eq("\"\"")
+  end
+
+  it "receives an empty mapping" do
+    expect(CustomFromEmptyValuesSpec::Mapped.from_yaml("fields: {}").received)
+      .to eq("{}")
+  end
+
+  it "receives empty values from JSON too" do
+    expect(CustomFromEmptyValuesSpec::Tagged.from_json(%({"tags": []})).received)
+      .to eq("[]")
+    expect(CustomFromEmptyValuesSpec::Tagged.from_json(%({"tags": ""})).received)
+      .to eq("\"\"")
+  end
+
+  it "still skips the method for a nil value" do
+    expect(CustomFromEmptyValuesSpec::Tagged.from_yaml("tags:").received)
+      .to be_nil
+  end
+
+  it "still skips the method for an omitted key" do
+    expect(CustomFromEmptyValuesSpec::Tagged.from_yaml("{}").received)
+      .to be_nil
+  end
+end


### PR DESCRIPTION
## Summary

Custom `from:` methods now receive empty values (`""`, `[]`, `{}`); only `nil` and omitted keys skip them. Fixes #746.

## Validation — the issue is correct on all three axes

1. **Documentation**: `docs/_guides/missing-values-handling.adoc` defines "the empty value:: the value is **present** but empty", distinct from non-existent (`nil`) and undefined (key omitted). `advanced-mapping.adoc` documents custom `from` receiving the value with no empty-skip caveat.
2. **History**: pre-0.8 (v0.7.7, `mapping_rule.rb:274`) the gate was exactly `return if !custom_methods[:from] || value.nil?` — empties were delivered. The 0.8 `lutaml/xml` + `lutaml/key_value` refactoring silently strengthened this to `Utils.present?`, which blanks out `""`/`[]`/`{}`.
3. **Consistency**: the XML-side custom-method path (`model_transform.rb`) has no `present?` gate and already delivers empty children — the key_value side was the outlier.

## The fix

One gate, `lib/lutaml/key_value/transform.rb`:

```diff
-return unless Lutaml::Model::Utils.present?(value)
+return if value.nil?
```

This also unblocks the `value_map` path for empty inputs, since the gate runs after `apply_value_map` (noted in the issue).

## Before / after

```ruby
Tagged.from_yaml("tags: [a]").tags  # => "[\"a\"]"   before and after
Tagged.from_yaml("tags: []").tags   # => nil         => "[]"
Tagged.from_yaml(%q(tags: "")).tags # => nil         => "\"\""
Tagged.from_yaml("tags:").tags      # => nil         (unchanged: non-existent)
Tagged.from_yaml("{}").tags         # => nil         (unchanged: undefined)
```

## Verification

- New spec `spec/lutaml/model/custom_from_empty_values_spec.rb` (written failing first: 4 of 6 failed with the exact issue behavior) covering empty collection/string/mapping, JSON as well as YAML, and the two skip cases as regression guards
- Full suite: **5335 examples, 0 failures** — no existing behavior depended on the skip
- rubocop clean
