### PR TITLE
perf: memoize per-register attribute merge

### DIFF
--- a/lib/lutaml/model/serialize/attribute_definition.rb
+++ b/lib/lutaml/model/serialize/attribute_definition.rb
@@ -188,6 +188,7 @@ module Lutaml
 
           attr = Attribute.new(name, type, options)
           @attributes[name] = attr
+          @merged_attributes_cache = nil
           define_attribute_methods(attr)
 
           attr

--- a/lib/lutaml/model/serialize/initialization.rb
+++ b/lib/lutaml/model/serialize/initialization.rb
@@ -115,13 +115,18 @@ module Lutaml
         # Get all attributes for this model
         #
         # Merges class-level attributes with register-specific attributes.
+        # Memoized per register: this is on the per-element deserialization
+        # hot path, and the merged hash is stable until an attribute, import
+        # or register record mutates (those clear @merged_attributes_cache).
         #
         # @param register [Symbol, nil] The register context
         # @return [Hash] The attributes hash
         def attributes(register = nil)
           ensure_imports!(register) if finalized?
           if @register_records&.any?
-            @attributes.merge(@register_records[extract_register_id(register)][:attributes])
+            register_id = extract_register_id(register)
+            (@merged_attributes_cache ||= {})[register_id] ||=
+              @attributes.merge(@register_records[register_id][:attributes])
           else
             @attributes
           end
@@ -182,6 +187,9 @@ module Lutaml
           if defined?(Lutaml::Model::GlobalContext)
             GlobalContext.resolver.clear_cache(register_id)
           end
+
+          # Clear memoized attribute merge (see .attributes)
+          @merged_attributes_cache = nil
 
           # Clear per-Attribute type caches (stale entries from GC'd TypeContext objects)
           class_attributes.each_value(&:clear_type_cache)

--- a/lib/lutaml/model/serialize/model_import.rb
+++ b/lib/lutaml/model/serialize/model_import.rb
@@ -121,6 +121,7 @@ module Lutaml
           @register_records[register_id][:choice_attributes].concat(
             deep_duplicate_choice_attributes(model, register_id),
           )
+          @merged_attributes_cache = nil
         end
         private :register_only_import_model_attributes
 


### PR DESCRIPTION
## Summary

Removes the single largest allocation source on the XML deserialization hot path: `Serialize.attributes(register)` rebuilt its merged hash on **every call**.

## The finding

Profiling metanorma/sts-ruby's 1MB ISO 13849 parse (stackprof, wall + object modes):

- `Hash#merge` — **13.9% of all allocations (1.2M)**, 98.5% called from `Initialization#attributes`
- GC was **28.6% of wall time** (marking 15.7% + sweeping 12.9%), dominated by the discarded merged hashes
- The method is called per element during deserialization, and for any model with register records each call copied the full class + register attribute hash

## The fix

Memoize the merged hash per register id in `Initialization#attributes`, invalidated at the three mutation points:

| Mutation | Invalidation |
|---|---|
| `attribute` DSL | clears after `@attributes[name] = attr` |
| model attribute imports | clears after the register-records `merge!` |
| anything calling `clear_cache` | centralized hook now clears it too |

`restrict` mutates `Attribute` options in place; the memo holds references to the same `Attribute` objects, so option changes remain visible without invalidation. The existing `dynamic_attribute_spec.rb` (dynamically adding attributes after register records are populated) guards the staleness case.

## Measured

Deterministic allocation counts (`GC.stat`), iso-13849-1MB via `bench/bench_sts.rb`:

```
allocs: 8,648,572 -> 7,466,382  (ratio: 0.8633)   -13.7%
wall (quiet window, min of iterations): 11.7s -> 8.2s
GC share of wall profile: 28.6% -> 4.0%
```

No fixture regresses on allocations (1.0000 / 0.9936 / 0.8633 across the sts suite). A `convert_rule_name_to_attribute_name` micro-optimization was measured, showed zero benefit, and was reverted.

Note: wall-clock numbers from a loaded laptop are unreliable (documented in the PR discussion of #749's metric fix); the benchmark CI job compares base vs current on the same runner and will arbitrate the time gates.

## Verification

- Full suite: **5335 examples, 0 failures**; rubocop clean
- The sts gate's 5s absolute limit runs ~2.4x faster on CI runners than this laptop, so the measured 8.2s minimum here should land well under the gate there
