### PR TITLE
fix: replace anonymous argument forwarding so Ruby 3.0+ parses and runs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ plugins:
 - rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 3.2
+  TargetRubyVersion: 3.0
   NewCops: enable
   Exclude:
     - 'vendor/**/*'

--- a/bench/bench_common.rb
+++ b/bench/bench_common.rb
@@ -22,9 +22,9 @@ module BenchCommon
   module_function
 
   # Measure parse time and allocations for a block
-  def measure(name, iterations: ITERATIONS, &)
+  def measure(name, iterations: ITERATIONS, &block)
     # Warmup
-    WARMUP_ITERATIONS.times(&)
+    WARMUP_ITERATIONS.times(&block)
 
     times = []
     allocations = []

--- a/benchmark/serialization_benchmark.rb
+++ b/benchmark/serialization_benchmark.rb
@@ -394,7 +394,7 @@ class BenchmarkRunner
     @results[name]
   end
 
-  def run_memory_benchmark(&)
+  def run_memory_benchmark(&block)
     # Force GC before measurement
     GC.start
     GC.compact if GC.respond_to?(:compact)
@@ -403,7 +403,7 @@ class BenchmarkRunner
     profile = RubyProf::Profile.new(measure_mode: RubyProf::ALLOCATIONS)
 
     profile.start
-    10.times(&)
+    10.times(&block)
     result = profile.stop
 
     # Print allocation report
@@ -418,12 +418,12 @@ class BenchmarkRunner
     puts "  Memory profiling skipped: #{e.message}"
   end
 
-  def run_cpu_profile(name, &)
+  def run_cpu_profile(name, &block)
     # ruby-prof 2.0 API: create a profile with wall time measurement
     profile = RubyProf::Profile.new(measure_mode: RubyProf::WALL_TIME)
 
     profile.start
-    ITERATIONS.times(&)
+    ITERATIONS.times(&block)
     result = profile.stop
 
     # Print flat report to console

--- a/lib/lutaml/model/collection.rb
+++ b/lib/lutaml/model/collection.rb
@@ -481,8 +481,8 @@ lutaml_register: Lutaml::Model::Config.default_register)
         self.class.new(items - other.items)
       end
 
-      def each(&)
-        collection.each(&)
+      def each(&block)
+        collection.each(&block)
       end
 
       def size

--- a/lib/lutaml/model/compiled_rule.rb
+++ b/lib/lutaml/model/compiled_rule.rb
@@ -192,7 +192,7 @@ module Lutaml
       # @param args [Array] Arguments (ignored for options)
       # @param block [Proc] Block (ignored for options)
       # @return [Object] The option value or nil
-      def method_missing(method_name, *args, &)
+      def method_missing(method_name, *args, &block)
         # Check if this is an option key
         if options.key?(method_name)
           return options[method_name]

--- a/lib/lutaml/model/config.rb
+++ b/lib/lutaml/model/config.rb
@@ -42,8 +42,8 @@ module Lutaml
       #   Config.with_adapter(xml: :nokogiri, toml: :tomlib) do
       #     MyModel.from_xml(data)
       #   end
-      def with_adapter(**overrides, &)
-        AdapterScope.with(overrides, &)
+      def with_adapter(**overrides, &block)
+        AdapterScope.with(overrides, &block)
       end
 
       # Delegate configure to Configuration

--- a/lib/lutaml/model/consolidation_map.rb
+++ b/lib/lutaml/model/consolidation_map.rb
@@ -39,8 +39,8 @@ module Lutaml
         end
 
         # Pattern A: declare discriminator routing
-        def dispatch_by(discriminator, &)
-          routes = DispatchBuilder.new.evaluate(&)
+        def dispatch_by(discriminator, &block)
+          routes = DispatchBuilder.new.evaluate(&block)
           @rules << DispatchBlock.new(discriminator, routes)
         end
 

--- a/lib/lutaml/model/consolidation_rule/dispatch_block.rb
+++ b/lib/lutaml/model/consolidation_rule/dispatch_block.rb
@@ -20,9 +20,9 @@ module Lutaml
 
     # Helper builder for the dispatch_by block
     class DispatchBuilder
-      def evaluate(&)
+      def evaluate(&block)
         @routes = {}
-        instance_eval(&)
+        instance_eval(&block)
         @routes
       end
 

--- a/lib/lutaml/model/errors.rb
+++ b/lib/lutaml/model/errors.rb
@@ -18,8 +18,8 @@ module Lutaml
         @errors.empty?
       end
 
-      def each(&)
-        @errors.each(&)
+      def each(&block)
+        @errors.each(&block)
       end
 
       def full_messages

--- a/lib/lutaml/model/mapping/model_mapping.rb
+++ b/lib/lutaml/model/mapping/model_mapping.rb
@@ -43,7 +43,7 @@ module Lutaml
         to: nil,
         transform: nil,
         reverse_transform: nil,
-        &
+        &block
       )
         map(
           from: from,
@@ -51,7 +51,7 @@ module Lutaml
           transform: transform,
           reverse_transform: reverse_transform,
           collection: true,
-          &
+          &block
         )
       end
 

--- a/lib/lutaml/model/runtime_compatibility.rb
+++ b/lib/lutaml/model/runtime_compatibility.rb
@@ -114,8 +114,8 @@ if Lutaml::Model::RuntimeCompatibility.opal?
 
       # Minimal method_missing so the WeakRef quacks like its target
       # for the Store's index lookups.
-      def method_missing(name, *, &)
-        @__target__.public_send(name, *, &)
+      def method_missing(name, ...)
+        @__target__.public_send(name, ...)
       end
 
       def respond_to_missing?(name, include_private = false)

--- a/lib/lutaml/model/schema/decorators/definition_collection.rb
+++ b/lib/lutaml/model/schema/decorators/definition_collection.rb
@@ -21,12 +21,12 @@ module Lutaml
             resolve_polymorphic_base_types!
           end
 
-          def each(&)
-            @definitions.each(&)
+          def each(&block)
+            @definitions.each(&block)
           end
 
-          def transform_values(&)
-            @definitions.transform_values(&)
+          def transform_values(&block)
+            @definitions.transform_values(&block)
           end
 
           def [](name)

--- a/lib/lutaml/model/schema/renderers/base.rb
+++ b/lib/lutaml/model/schema/renderers/base.rb
@@ -10,8 +10,8 @@ module Lutaml
         # (Union, RestrictedType, Namespace). Model has its own constructor
         # because it computes an opt-out (module-wrappable) namespace.
         class Base
-          def self.render(spec, **)
-            new(spec, **).render
+          def self.render(spec, **options)
+            new(spec, **options).render
           end
 
           def initialize(spec, indent: 2, module_namespace: nil,

--- a/lib/lutaml/model/schema/renderers/model.rb
+++ b/lib/lutaml/model/schema/renderers/model.rb
@@ -10,8 +10,8 @@ module Lutaml
         # subclass as Ruby source. Member-declaration and xml-mapping
         # rendering is delegated to MemberDecls and Mappings.
         class Model
-          def self.render(spec, **)
-            new(spec, **).render
+          def self.render(spec, **options)
+            new(spec, **options).render
           end
 
           def initialize(spec, indent: 2, module_namespace: nil,

--- a/lib/lutaml/model/schema/xml_compiler/supported_data_types.rb
+++ b/lib/lutaml/model/schema/xml_compiler/supported_data_types.rb
@@ -59,8 +59,8 @@ module Lutaml
             TABLE[name]
           end
 
-          def each(&)
-            TABLE.each(&)
+          def each(&block)
+            TABLE.each(&block)
           end
 
           # `TypeRef.value` and `simple_content.base_class` ask the same

--- a/lib/lutaml/model/sequence.rb
+++ b/lib/lutaml/model/sequence.rb
@@ -27,12 +27,12 @@ module Lutaml
         @model.attribute(name, type, options)
       end
 
-      def sequence(&)
-        instance_eval(&)
+      def sequence(&block)
+        instance_eval(&block)
       end
 
-      def map_element(name, **)
-        @attributes << @model.map_element(name, **)
+      def map_element(name, **options)
+        @attributes << @model.map_element(name, **options)
       end
 
       def import_model_mappings(model, register = nil)

--- a/lib/lutaml/model/serialize.rb
+++ b/lib/lutaml/model/serialize.rb
@@ -175,15 +175,15 @@ module Lutaml
         @using_default[attribute_name]
       end
 
-      def method_missing(method_name, *, &)
+      def method_missing(method_name, *args, &block)
         if method_name.to_s.end_with?("=") && attribute_exist?(method_name)
           define_singleton_method(method_name) do |value|
             instance_variable_set(:"@#{method_name.to_s.chomp('=')}", value)
           end
-          send(method_name, *)
+          send(method_name, *args)
         elsif ::Lutaml::Model::Attribute.default_evaluation? &&
             self.class.respond_to?(method_name)
-          self.class.public_send(method_name, *, &)
+          self.class.public_send(method_name, *args, &block)
         else
           super
         end

--- a/lib/lutaml/model/serialize/format_conversion.rb
+++ b/lib/lutaml/model/serialize/format_conversion.rb
@@ -13,7 +13,7 @@ module Lutaml
         # @param format [Symbol] The format (:xml, :json, etc.)
         # @param args [Array] Additional arguments (e.g., mapping class for XML)
         # @param block [Proc] The DSL block to evaluate
-        def process_mapping(format, *_args, &)
+        def process_mapping(format, *_args, &block)
           klass = ::Lutaml::Model::Config.mappings_class_for(format)
           existing = mappings[format]
           mappings[format] = if existing.nil? || !existing.is_a?(klass)
@@ -21,7 +21,7 @@ module Lutaml
                              else
                                existing
                              end
-          mappings[format].instance_eval(&)
+          mappings[format].instance_eval(&block)
 
           if mappings[format].is_a?(Lutaml::Xml::Mapping)
             mappings[format].finalize(self)

--- a/lib/lutaml/model/type/uninitialized_class_guard.rb
+++ b/lib/lutaml/model/type/uninitialized_class_guard.rb
@@ -17,7 +17,7 @@ module Lutaml
         #
         # The prepend ensures this method runs BEFORE the subclass's
         # cast implementation, even if the subclass doesn't call super.
-        def cast(value, *args, **kwargs, &)
+        def cast(value, *args, **kwargs, &block)
           # Return UninitializedClass unchanged - don't transform it
           return value if Utils.uninitialized?(value)
 

--- a/lib/lutaml/model/type_registry.rb
+++ b/lib/lutaml/model/type_registry.rb
@@ -127,8 +127,8 @@ module Lutaml
       #
       # @example
       #   registry.each { |name, klass| puts "#{name}: #{klass}" }
-      def each(&)
-        @types.each(&)
+      def each(&block)
+        @types.each(&block)
       end
 
       # Create a copy of this registry

--- a/lib/lutaml/model/uninitialized_class.rb
+++ b/lib/lutaml/model/uninitialized_class.rb
@@ -48,7 +48,7 @@ module Lutaml
         "".encoding
       end
 
-      def method_missing(method, *_args, &)
+      def method_missing(method, *_args)
         return false if method.end_with?("?")
 
         nil

--- a/lib/lutaml/model/utils.rb
+++ b/lib/lutaml/model/utils.rb
@@ -201,10 +201,10 @@ module Lutaml
           end
         end
 
-        def add_singleton_method_if_not_defined(instance, method_name, &)
+        def add_singleton_method_if_not_defined(instance, method_name, &block)
           return if instance.singleton_class.method_defined?(method_name, false)
 
-          instance.define_singleton_method(method_name, &)
+          instance.define_singleton_method(method_name, &block)
         end
 
         # Determines the appropriate register for a child model during deserialization.

--- a/lib/lutaml/rdf/mapping.rb
+++ b/lib/lutaml/rdf/mapping.rb
@@ -19,8 +19,8 @@ module Lutaml
         @namespace_set = Lutaml::Rdf::NamespaceSet.new(*namespace_classes)
       end
 
-      def subject(&)
-        @rdf_subject = Proc.new(&) if block_given?
+      def subject(&block)
+        @rdf_subject = Proc.new(&block) if block
       end
 
       def type(value)

--- a/lib/lutaml/rdf/namespace_set.rb
+++ b/lib/lutaml/rdf/namespace_set.rb
@@ -38,8 +38,8 @@ module Lutaml
         nil
       end
 
-      def each(&)
-        @by_prefix.each_value(&)
+      def each(&block)
+        @by_prefix.each_value(&block)
       end
 
       def size

--- a/lib/lutaml/rdf/transform.rb
+++ b/lib/lutaml/rdf/transform.rb
@@ -17,9 +17,9 @@ module Lutaml
         mapping.rdf_type.map { |t| resolve_single_type_uri(mapping, t) }
       end
 
-      def each_member(instance, member_rule, &)
+      def each_member(instance, member_rule, &block)
         collection = Array(instance.public_send(member_rule.attr_name))
-        collection.each(&)
+        collection.each(&block)
       end
 
       def member_mapping_for(member, format)

--- a/lib/lutaml/xml/adapter/base_adapter.rb
+++ b/lib/lutaml/xml/adapter/base_adapter.rb
@@ -215,8 +215,8 @@ module Lutaml
 
         private
 
-        def attribute_values(element, &)
-          element.attributes.each_value(&)
+        def attribute_values(element, &block)
+          element.attributes.each_value(&block)
         end
 
         def schema_location_attribute?(attr)

--- a/lib/lutaml/xml/builder/base.rb
+++ b/lib/lutaml/xml/builder/base.rb
@@ -180,9 +180,9 @@ module Lutaml
           result
         end
 
-        def method_missing(method_name, *args, &)
+        def method_missing(method_name, *args, &block)
           attrs = args.first.is_a?(Hash) ? args.first : {}
-          create_and_add_element(method_name.to_s, attributes: attrs, &)
+          create_and_add_element(method_name.to_s, attributes: attrs, &block)
         end
 
         def respond_to_missing?(_method_name, _include_private = false)

--- a/lib/lutaml/xml/mapping.rb
+++ b/lib/lutaml/xml/mapping.rb
@@ -818,10 +818,10 @@ module Lutaml
       # @param group_class [Class] the GroupClass to instantiate (optional, resolved from Organization)
       # @yield Builder block with gather/dispatch_by or map_element/map_content
       # @return [ConsolidationMap]
-      def consolidate_map(by:, to:, group_class: nil, &)
+      def consolidate_map(by:, to:, group_class: nil, &block)
         builder = ::Lutaml::Model::ConsolidationMap::Builder.new(by, to,
                                                                  group_class)
-        builder.instance_eval(&)
+        builder.instance_eval(&block)
         @consolidation_maps << builder.build
       end
 

--- a/lib/lutaml/xml/namespace_collector.rb
+++ b/lib/lutaml/xml/namespace_collector.rb
@@ -37,18 +37,18 @@ module Lutaml
       # @param mapping [Xml::Mapping] the XML mapping for this element
       # @param options [Hash] additional options including mapper_class for recursive calls
       # @return [NamespaceNeeds] namespace needs structure
-      def collect(element, mapping, visited: nil, **)
+      def collect(element, mapping, visited: nil, **options)
         # If this is a top-level call (no visited yet), ensure cleanup
         if visited.nil?
           Thread.current[:namespace_collector_call_stack] = []
           begin
-            collect_internal(element, mapping, visited: nil, **)
+            collect_internal(element, mapping, visited: nil, **options)
           ensure
             Thread.current[:namespace_collector_call_stack] = nil
           end
         else
           # Nested call - don't clean up yet
-          collect_internal(element, mapping, visited: visited, **)
+          collect_internal(element, mapping, visited: visited, **options)
         end
       end
 

--- a/lib/lutaml/xml/parsed_namespace_set.rb
+++ b/lib/lutaml/xml/parsed_namespace_set.rb
@@ -135,8 +135,8 @@ module Lutaml
 
       # @yield [declaration] Yields each unique declaration
       # @return [self]
-      def each(&)
-        @by_prefix.values.flatten.uniq.each(&)
+      def each(&block)
+        @by_prefix.values.flatten.uniq.each(&block)
         self
       end
 

--- a/lib/lutaml/xml/schema/builder.rb
+++ b/lib/lutaml/xml/schema/builder.rb
@@ -20,7 +20,7 @@ module Lutaml
         # Supported schema builders (separate from XML parsing adapters)
         SUPPORTED_BUILDERS = %i[nokogiri oga].freeze
 
-        def initialize(adapter_type: nil, options: {}, &)
+        def initialize(adapter_type: nil, options: {}, &block)
           # Use specified adapter, or configured XML adapter, or default to Nokogiri
           requested_adapter = adapter_type || Lutaml::Model::Config.xml_adapter_type || :nokogiri
 
@@ -32,7 +32,7 @@ module Lutaml
                             :nokogiri
                           end
           @options = options
-          @builder = create_builder(&)
+          @builder = create_builder(&block)
         end
 
         # Generate the XSD schema XML string
@@ -45,12 +45,12 @@ module Lutaml
 
         private
 
-        def create_builder(&)
+        def create_builder(&block)
           case @adapter_type
           when :nokogiri
-            Nokogiri.new(@options, &)
+            Nokogiri.new(@options, &block)
           when :oga
-            Oga.new(@options, &)
+            Oga.new(@options, &block)
           end
         end
       end

--- a/lib/lutaml/xml/schema/xsd/schema_location_mapping.rb
+++ b/lib/lutaml/xml/schema/xsd/schema_location_mapping.rb
@@ -28,7 +28,7 @@ module Lutaml
           # @param to [String] The target path
           # @param pattern [Boolean, nil] Explicit pattern flag (optional)
           def initialize(attributes = nil, from: nil, to: nil, pattern: nil,
-      **)
+      **options)
             # Handle hash argument from Lutaml::Model deserialization
             if attributes.is_a?(Hash)
               from = attributes[:from] || attributes["from"]
@@ -45,7 +45,7 @@ module Lutaml
             # Use explicit pattern flag if provided, otherwise use detected value
             final_pattern = pattern.nil? ? detected_pattern : pattern
 
-            super(from: from_str, to: to, pattern: final_pattern, **)
+            super(from: from_str, to: to, pattern: final_pattern, **options)
           end
 
           # Convert hash-based mapping to SchemaLocationMapping instance

--- a/lib/lutaml/xml/serialization/format_conversion.rb
+++ b/lib/lutaml/xml/serialization/format_conversion.rb
@@ -89,7 +89,7 @@ module Lutaml
         end
 
         # Override choice to set format: :xml so Choice knows which format it belongs to.
-        def choice(min: 1, max: 1, format: :xml, &)
+        def choice(min: 1, max: 1, format: :xml, &block)
           super
         end
 
@@ -101,9 +101,9 @@ module Lutaml
         # @param format [Symbol] The format
         # @param args [Array] Additional arguments (mapping class for XML)
         # @param block [Proc] The DSL block
-        def process_mapping(format, *args, &)
+        def process_mapping(format, *args, &block)
           if format == :xml && args.any? && args.first.is_a?(Class) && args.first < Lutaml::Xml::Mapping
-            process_xml_mapping_class_inheritance(args.first, &)
+            process_xml_mapping_class_inheritance(args.first, &block)
           else
             super
           end

--- a/lib/lutaml/yamls/adapter/mapping.rb
+++ b/lib/lutaml/yamls/adapter/mapping.rb
@@ -10,9 +10,9 @@ module Lutaml
           super(:yaml)
         end
 
-        def sequence(&)
+        def sequence(&block)
           @yamls_sequence = YamlsSequence.new
-          @yamls_sequence.instance_eval(&)
+          @yamls_sequence.instance_eval(&block)
         end
 
         def dup_instance

--- a/lib/tasks/benchmark_runner.rb
+++ b/lib/tasks/benchmark_runner.rb
@@ -118,10 +118,10 @@ direction: nil)
     end
   end
 
-  def time_runs(&)
+  def time_runs(&block)
     job = Benchmark::IPS::Job.new
     job.config(time: @run_time, warmup: 5)
-    job.report("#{@label} #{@adapter} #{@direction}_#{@format}", &)
+    job.report("#{@label} #{@adapter} #{@direction}_#{@format}", &block)
     job.run
 
     entry = job.full_report.entries.first

--- a/spec/lutaml/model/custom_bibtex_adapter_spec.rb
+++ b/spec/lutaml/model/custom_bibtex_adapter_spec.rb
@@ -298,9 +298,9 @@ module CustomBibtexAdapterSpec
       add_mapping(name, to, field_type: :field, render_nil: render_nil)
     end
 
-    def add_mapping(name, to, **)
+    def add_mapping(name, to, **options)
       # validate!(name, to, {})
-      @mappings << BibtexMappingRule.new(name, to: to, **)
+      @mappings << BibtexMappingRule.new(name, to: to, **options)
     end
 
     def mapping_for_field(field)

--- a/spec/lutaml/model/custom_vobject_adapter_spec.rb
+++ b/spec/lutaml/model/custom_vobject_adapter_spec.rb
@@ -201,8 +201,8 @@ module CustomVobjectAdapterSpec
       @objects
     end
 
-    def map(&)
-      @objects.map(&)
+    def map(&block)
+      @objects.map(&block)
     end
 
     private
@@ -260,16 +260,16 @@ module CustomVobjectAdapterSpec
       @element_type = element_type
     end
 
-    def map_value(to:, **)
-      add_mapping(:value, to, type: :simple, **)
+    def map_value(to:, **options)
+      add_mapping(:value, to, type: :simple, **options)
     end
 
-    def map_property(name, to:, type: :simple, **)
-      add_mapping(name.downcase, to, type: type, **)
+    def map_property(name, to:, type: :simple, **options)
+      add_mapping(name.downcase, to, type: type, **options)
     end
 
-    def map_component(name, to:, **)
-      add_mapping(name.downcase, to, type: :component, **)
+    def map_component(name, to:, **options)
+      add_mapping(name.downcase, to, type: :component, **options)
     end
 
     def map_field_set(count:, item_type:, item_options: {})


### PR DESCRIPTION
## Summary

Makes the library actually run on the Rubies the gemspec declares (`required_ruby_version >= 3.0.0`): all anonymous argument forwarding replaced with named forms, in `lib/` and dev files. Fixes the Ruby 3.1 require-time breakage from #745 in code, as required — no requirement changes.

Follows #756 (revert of the `>= 3.2` floor). The gemspec stays exactly `>= 3.0.0`.

## What was incompatible

- bare `&` in def position — `def m(&)` — needs Ruby 3.1+
- bare `*`, `**`, `&` in call position — `f(a, *)` — needs Ruby 3.2+

Present in ~37 files. All replaced with `&block` / `**options` / `*args`. One semantic trap handled: `choice` keeps **bare `super`** (writing `super(&block)` disables implicit argument forwarding and silently drops `min:`/`max:` — the suite caught a first attempt that did this).

`.rubocop.yml` `TargetRubyVersion` moves 3.2 → 3.0 to match the gemspec; the codebase was already linted against a 3.2 target that contradicted the declared floor.

## Verification

- Parse survey (`RubyVM::AbstractSyntaxTree.parse`): **0 failures on Ruby 3.0.7 and 3.1.6** across `lib/`, `spec/`, `bench/`, `benchmark/`, `lib/tasks/`
- Runtime on both floor Rubies (bundled, rexml adapter): `require "lutaml/model"` + `from_xml` + `to_xml` roundtrip succeed
- Full suite: 5335 examples, 0 failures; rubocop clean at target 3.0

## Note

Gem packaging question flagged for the maintainer (not changed here): `spec.files` excludes only `^(test|features|vendor)/` — `spec/` and `bench/` are currently shipped in the published gem though they are development-only; harmless for `require` but worth deciding.
