### PR TITLE
fix(xml): adopt document namespace so lenient parsing is lossless

### DIFF
--- a/lib/lutaml/xml/model_transform.rb
+++ b/lib/lutaml/xml/model_transform.rb
@@ -607,6 +607,14 @@ _effective_register)
                           end
           type_ns_prefix_str = type_ns_class&.prefix_default&.to_s
           type_ns_all_uris = type_ns_class&.all_uris
+          # Adopt the parsed document's namespace: when the whole document
+          # is out-of-namespace (original_namespace_uri set at the root),
+          # treat it as an implicit alias so lenient parsing is lossless
+          # (lutaml-model#754).
+          adopted_uri = instance_is_serialize && instance.original_namespace_uri
+          if adopted_uri && !type_ns_all_uris&.include?(adopted_uri)
+            type_ns_all_uris = (type_ns_all_uris || []) + [adopted_uri]
+          end
         end
 
         # Pre-compute model's namespace class for simple-type alias matching
@@ -616,6 +624,13 @@ _effective_register)
                            instance.class.mappings_for(:xml)&.namespace_class
                          end
         model_ns_all_uris = model_ns_class&.all_uris
+        # Same document-namespace adoption for simple-type rules (#754):
+        # a prefixed child in the document's (foreign) namespace must still
+        # bind by local name, or its content is silently dropped.
+        adopted_uri = instance_is_serialize && instance.original_namespace_uri
+        if model_ns_class && adopted_uri && !model_ns_all_uris&.include?(adopted_uri)
+          model_ns_all_uris = (model_ns_all_uris || []) + [adopted_uri]
+        end
 
         # Performance: Use cached element children from XmlElement
         # This avoids O(children * rules) scans by pre-filtering once per element

--- a/spec/lutaml/xml/out_of_namespace_parsing_spec.rb
+++ b/spec/lutaml/xml/out_of_namespace_parsing_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# lutaml-model#754: parsing a document whose elements live in a namespace
+# different from the model's bound namespace must not silently drop
+# element content. The document's own namespace is adopted as an implicit
+# alias of the model's namespace for the duration of the parse, so
+# lenient (out-of-namespace) parsing is lossless for element content the
+# way in-namespace parsing is.
+module OutOfNamespaceParsingSpec
+  class Gml32 < Lutaml::Xml::Namespace
+    uri "http://www.opengis.net/gml/3.2"
+    prefix_default "gml"
+  end
+
+  class Code < Lutaml::Model::Serializable
+    attribute :value, :string
+
+    xml do
+      root "name"
+      namespace Gml32
+      map_content to: :value
+    end
+  end
+
+  class EntryDefinition < Lutaml::Model::Serializable
+    attribute :description, :string
+    attribute :name, Code, collection: true
+
+    xml do
+      element "Definition"
+      namespace Gml32
+      map_element "description", to: :description
+      map_element "name", to: :name
+    end
+  end
+
+  class DictionaryEntry < Lutaml::Model::Serializable
+    attribute :definition, EntryDefinition
+
+    xml do
+      element "dictionaryEntry"
+      namespace Gml32
+      map_element "Definition", to: :definition
+    end
+  end
+
+  class Dictionary < Lutaml::Model::Serializable
+    attribute :name, Code, collection: true
+    attribute :dictionary_entry, DictionaryEntry, collection: true
+
+    xml do
+      element "Dictionary"
+      namespace Gml32
+      map_element "name", to: :name
+      map_element "dictionaryEntry", to: :dictionary_entry
+    end
+  end
+
+  def self.gml_doc(uri)
+    <<~XML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <gml:Dictionary xmlns:gml="#{uri}">
+        <gml:name>codes</gml:name>
+        <gml:dictionaryEntry>
+          <gml:Definition>
+            <gml:description>first</gml:description>
+            <gml:name>ONE</gml:name>
+          </gml:Definition>
+        </gml:dictionaryEntry>
+      </gml:Dictionary>
+    XML
+  end
+end
+
+RSpec.describe "out-of-namespace document parsing" do
+  let(:in_namespace_xml) { OutOfNamespaceParsingSpec.gml_doc("http://www.opengis.net/gml/3.2") }
+  let(:out_of_namespace_xml) { OutOfNamespaceParsingSpec.gml_doc("http://www.opengis.net/gml") }
+
+  it "parses simple-type element content from a document in the bound namespace" do
+    definition = OutOfNamespaceParsingSpec::Dictionary
+      .from_xml(in_namespace_xml).dictionary_entry.first.definition
+    expect(definition.description).to eq("first")
+  end
+
+  it "keeps simple-type element content when the document namespace differs (#754)" do
+    definition = OutOfNamespaceParsingSpec::Dictionary
+      .from_xml(out_of_namespace_xml).dictionary_entry.first.definition
+    expect(definition.description).to eq("first")
+  end
+
+  it "keeps serializable-typed element content when the document namespace differs" do
+    definition = OutOfNamespaceParsingSpec::Dictionary
+      .from_xml(out_of_namespace_xml).dictionary_entry.first.definition
+    expect(definition.name.map(&:value)).to eq(["ONE"])
+  end
+
+  it "keeps simple-type content at the document root level" do
+    dictionary = OutOfNamespaceParsingSpec::Dictionary.from_xml(out_of_namespace_xml)
+    expect(dictionary.name.map(&:value)).to eq(["codes"])
+  end
+
+  it "does not adopt an unrelated child namespace" do
+    xml = <<~XML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <gml:Dictionary xmlns:gml="http://www.opengis.net/gml"
+                      xmlns:city="http://www.opengis.net/citygml/2.0">
+        <city:name>not mine</city:name>
+      </gml:Dictionary>
+    XML
+    dictionary = OutOfNamespaceParsingSpec::Dictionary.from_xml(xml)
+    expect(dictionary.name).to be_empty
+  end
+
+  it "round-trips out-of-namespace content without losing the description" do
+    dictionary = OutOfNamespaceParsingSpec::Dictionary.from_xml(out_of_namespace_xml)
+    output = dictionary.to_xml(prefix: true)
+    expect(output).to include("first")
+    reparsed = OutOfNamespaceParsingSpec::Dictionary.from_xml(output)
+    expect(reparsed.dictionary_entry.first.definition.description).to eq("first")
+  end
+end


### PR DESCRIPTION
## Summary

Fixes #754: out-of-namespace documents (elements in a namespace different from the model's bound namespace, the lenient path that preserves the source URI) silently dropped simple-typed element content — `gml:description` vanished on round-trip of GML 3.1 documents into GML 3.2-bound models, while sibling `gml:name` (a serializable `Code` type) bound fine.

### Root cause

Asymmetric element matching in `Xml::ModelTransform#value_for_rule`: serializable-typed rules match leniently via alias/prefix fallbacks, but the simple-type fallback only accepts unprefixed children (`!child_ns_prefix`) — so a prefixed child in the document's own namespace matched nothing and was skipped in the pre-match fast path.

### Fix

When `data_to_model` has recorded `original_namespace_uri` (document ns ≠ model ns), `value_for_rule` adds that URI to the namespace URI sets consulted by the alias-aware branches, for both serializable- and simple-typed rules. In-namespace parsing is untouched; unrelated child namespaces (`citygml:name` in a GML doc) remain excluded.

### Verification

- Spec red on main, green with the patch (6 examples incl. no-over-adoption and round-trip guards)
- lutaml-model: 5354 examples / 0 failures
- ogc-gml HEAD (includes the two i-UR `gml:description` fixtures from ogc-gml#24): 313 examples / 0 failures under moxml 0.5.4

Known remainder (tracked in the issue): on re-serialization of an out-of-namespace document a simple-typed child may come back unprefixed — content preserved, prefix spelling differs.
